### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.4.0
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+ENV RAILS_ENV=production
+
+EXPOSE 3000
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+
+RUN apt-get update && apt-get install -y nodejs sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+COPY ./ /usr/src/app
+RUN bundle install
+RUN bundle exec rake db:migrate
+RUN bundle exec rake setup:import_all_noreset

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -229,11 +229,15 @@ namespace :setup do
     end
   end
 
-  desc 'Resets db and imports all data'
-  task import_all: [:environment, 'db:reset', 'setup:import_teachers',
+  desc 'imports all data without resetting db'
+  task import_all_noreset: [:environment, 'setup:import_teachers',
                     'setup:import_terms', 'setup:import_courses',
                     'setup:import_tags', 'setup:import_lectures',
                     'setup:import_chapters', 'setup:import_sections',
                     'setup:import_lessons', 'setup:import_media',
                     'setup:import_assets']
+
+  desc 'Resets db and imports all data'
+  task import_all: [:environment, 'db:reset', 'setup:import_all_noreset']
+
 end


### PR DESCRIPTION
adds Dockerfile and splits the setup:import_all function into
setup:import_all_noreset and setup:importall because db:reset is a
destructive operation. While building the dockerfile a db:reset is
unnecessary and ignoring the usage of destructive operations is ugly.