### PR TITLE
Stop copying pubic files in production

### DIFF
--- a/docker/production/entrypoint-master.sh
+++ b/docker/production/entrypoint-master.sh
@@ -7,8 +7,6 @@ then
   bundle exec rails db:migrate
   echo 'running: bundle exec rake sunspot:solr:reindex'
   bundle exec rake sunspot:solr:reindex
-  echo 'copying public assets to volume'
-  rsync -av --delete public/ /public/
   echo 'finished initialisation'
   touch completed_initial_run
 fi


### PR DESCRIPTION
Remove rsync call in master entrypoint, since docker automatically copies these files to the correct location now.