### PR TITLE
Proper user deletion

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,19 @@
 # RegistrationsController
 class RegistrationsController < Devise::RegistrationsController
+
+  def destroy
+    success = resource.archive_and_destroy(deletion_params[:archive_name])
+    if !success
+      set_flash_message :alert, :not_destroyed
+      respond_with_navigational(resource){ redirect_to after_sign_up_path_for(resource_name) }
+      return
+    end
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message :notice, :destroyed
+    yield resource if block_given?
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+  end
+
   def after_sign_up_path_for(resource)
     edit_profile_path
   end
@@ -9,5 +23,9 @@ class RegistrationsController < Devise::RegistrationsController
   def sign_up_params
     params.require(:user).permit(:email, :password, :password_confirmation,
                                  :locale, :consents)
+  end
+
+  def deletion_params
+    params.permit(:archive_name)
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,6 +2,12 @@
 class RegistrationsController < Devise::RegistrationsController
 
   def destroy
+    password_correct = resource.valid_password?(deletion_params[:password])
+    if !password_correct
+      set_flash_message :alert, :password_incorrect
+      respond_with_navigational(resource){ redirect_to after_sign_up_path_for(resource_name) }
+      return
+    end
     success = resource.archive_and_destroy(deletion_params[:archive_name])
     if !success
       set_flash_message :alert, :not_destroyed
@@ -26,6 +32,6 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def deletion_params
-    params.permit(:archive_name)
+    params.permit(:archive_name, :password)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,6 +67,9 @@ class UsersController < ApplicationController
     render json: result
   end
 
+  def delete_account
+  end
+
   private
 
   def elevate_params

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -3,14 +3,4 @@ module UsersHelper
   def users_for_select(users)
     users.map { |u| [u.info, u.id] }
   end
-
-  def confirm_user_deletion_text(user)
-    return I18n.t('confirmation.generic') unless user.submissions.any?
-    submission_count = user.submissions.proper.size
-    single_submission_count = user.submissions.proper
-                                  .select { |s| s.users.size == 1}.size
-    t('confirmation.delete_account_with_submissions_html',
-      submissions: submission_count,
-      single_submissions: single_submission_count)
-  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -9,7 +9,7 @@ module UsersHelper
     submission_count = user.submissions.proper.size
     single_submission_count = user.submissions.proper
                                   .select { |s| s.users.size == 1}.size
-    t('confirmation.delete_account_with_submissions',
+    t('confirmation.delete_account_with_submissions_html',
       submissions: submission_count,
       single_submissions: single_submission_count)
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -148,7 +148,7 @@ class Ability
       can :update, User do |u|
         user == u
       end
-      can [:teacher, :fill_user_select, :list], User
+      can [:teacher, :fill_user_select, :list, :delete_account], User
       can :manage, [:event, :vertex]
       can [:take, :proceed, :preview], Quiz
       can [:new, :create, :edit, :open, :close, :set_alternatives,
@@ -255,6 +255,8 @@ class Ability
       can [:bulk_download, :bulk_upload], Tutorial do |tutorial|
         tutorial.tutor == user
       end
+
+      can :delete_account, User
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -523,7 +523,7 @@ class User < ApplicationRecord
     destroy
   end
 
-  # private
+  private
 
   def set_defaults
     self.subscription_type = 1 if subscription_type.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   has_many :notifications, foreign_key: 'recipient_id'
 
   # a user has many announcements as announcer
-  has_many :announcements, foreign_key: 'announcer_id'
+  has_many :announcements, foreign_key: 'announcer_id', dependent: :destroy
 
   # a user has many clickers as editor
   has_many :clickers, foreign_key: 'editor_id', dependent: :destroy
@@ -495,7 +495,35 @@ class User < ApplicationRecord
     in?(lecture.editors) || self == lecture.teacher
   end
 
-  private
+  def proper_submissions_count
+    submissions.proper.size
+  end
+
+  def proper_single_submissions_count
+    submissions.proper.select { |s| s.users.size == 1 }.size
+  end
+
+  def proper_team_submissions_count
+    proper_submissions_count - proper_single_submissions_count
+  end
+
+  def media_editor?
+    edited_media.any?
+  end
+
+  def contributor?
+    teacher? || media_editor?
+  end
+
+  def archive_and_destroy(archive_name)
+    if contributor?
+      success = transfer_contributions_to(archive_user(archive_name))
+      return false unless success
+    end
+    destroy
+  end
+
+  # private
 
   def set_defaults
     self.subscription_type = 1 if subscription_type.nil?
@@ -525,5 +553,27 @@ class User < ApplicationRecord
   def destroy_single_submissions
     Submission.where(id: submissions.select { |s| s.users.count == 1 }
                                     .map(&:id)).destroy_all
+  end
+
+  def archive_email
+    splitting = DefaultSetting::PROJECT_EMAIL.split('@')
+    "#{splitting.first}-archive-#{id}@#{splitting.second}"
+  end
+
+  def transfer_contributions_to(user)
+    return false unless user && user.valid? && user != self
+    given_lectures.update_all(teacher_id: user.id)
+    EditableUserJoin.where(user: self, editable_type: 'Medium')
+                    .update_all(user_id: user.id)
+  end
+
+  def archive_user(archive_name)
+    User.create(name: archive_name,
+                email: archive_email,
+                password: SecureRandom.base58(12),
+                consents: true,
+                consented_at: Time.now,
+                confirmed_at: Time.now,
+                archived: true)
   end
 end

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -9,10 +9,14 @@
       </span>
       <% if @lecture.term || !@lecture.disable_teacher_display %>
         <span>
-          <%= link_to @lecture.teacher.name,
-                      teacher_path(@lecture.teacher),
-                      id: 'lecture-teacher',
-                      class: 'text-dark' %>
+          <% if !@lecture.teacher.archived %>
+            <%= link_to @lecture.teacher.name,
+                        teacher_path(@lecture.teacher),
+                        id: 'lecture-teacher',
+                        class: 'text-dark' %>
+          <% else %>
+            <%= @lecture.teacher.name %>
+          <% end %>
         </span>
       <% end %>
       <% privileged = current_user.admin ||

--- a/app/views/profile/_account.html.erb
+++ b/app/views/profile/_account.html.erb
@@ -4,7 +4,7 @@
               class: "btn btn-outline-secondary mb-2" %>
 <% end %>
 <%= link_to t('profile.delete_account'),
-            user_registration_path,
+            delete_account_path,
             class: "btn btn-outline-danger mb-2",
-            data: { confirm: confirm_user_deletion_text(current_user) },
-            method: :delete %>
+            remote: true %>
+

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -101,3 +101,6 @@
     </div>
   </div>
 <% end %>
+<%= render partial: 'shared/generic_modal',
+           locals: { sort: 'deleteAccount',
+                     title: t('profile.delete_account') } %>

--- a/app/views/users/_delete_account.html.erb
+++ b/app/views/users/_delete_account.html.erb
@@ -1,0 +1,60 @@
+<%= form_with url: user_registration_path,
+              method: :delete do |f| %>
+<%= t('profile.confirm_account_deletion') %>
+<% if current_user.contributor? %>
+  <div class="row mt-2">
+    <div class="col-12">
+      <%= t('profile.thanks_for_contributions') %>
+      <ul>
+        <% if current_user.teacher? %>
+          <li>
+            <%= t('profile.given_lectures',
+                  lectures: current_user.given_lectures.size) %>
+          </li>
+        <% end %>
+        <% if current_user.media_editor? %>
+          <li>
+            <%= t('profile.edited_media',
+                  media: current_user.edited_media.size) %>
+          </li>
+        <% end %>
+      </ul>
+      <%= t('profile.contributions_remain') %>
+      <%= f.text_field :archive_name,
+                       class: 'form-control my-2',
+                       value: current_user.name,
+                       required: true %>
+      <%= t('profile.manual_deletion') %>
+    </div>
+  </div>
+<% end %>
+<% if current_user.proper_submissions_count.positive? %>
+  <div class="row mt-2">
+    <div class="col-12">
+      <b>
+        <%= t('basics.attention') %>.
+      </b>
+      <%= t('profile.stored_submissions',
+          submissions: current_user.proper_submissions_count) %>
+      <ul>
+        <li>
+          <%= t('profile.single_submissions',
+                single_submissions:
+                  current_user.proper_single_submissions_count) %>
+        </li>
+        <li>
+          <%= t('profile.team_submissions',
+                team_submissions: current_user.proper_team_submissions_count) %>
+        </li>
+      </ul>
+      <%= t('profile.submission_deletion') %>
+    </div>
+  </div>
+<% end %>
+<div class="row mt-3">
+  <div class="col-12 text-center">
+    <%= f.submit t('profile.delete_account'),
+                 class: "btn btn-danger mb-2" %>
+  </div>
+</div>
+<% end %>

--- a/app/views/users/_delete_account.html.erb
+++ b/app/views/users/_delete_account.html.erb
@@ -1,6 +1,9 @@
 <%= form_with url: user_registration_path,
               method: :delete do |f| %>
 <%= t('profile.confirm_account_deletion') %>
+<%= f.password_field :password,
+                     class: 'form-control my-2',
+                     required: true %>
 <% if current_user.contributor? %>
   <div class="row mt-2">
     <div class="col-12">

--- a/app/views/users/delete_account.coffee
+++ b/app/views/users/delete_account.coffee
@@ -1,0 +1,3 @@
+$('#deleteAccount-modal-content').empty()
+  .append('<%= j render partial: "users/delete_account" %>')
+$('#deleteAccountModal').modal('show')

--- a/app/views/users/teacher.html.erb
+++ b/app/views/users/teacher.html.erb
@@ -29,12 +29,14 @@
                           class: 'text-dark' %>
             </li>
           <% end %>
-          <li>
-            <%= t('basics.email') %>:
-            <%= mail_to @teacher.email,
-                        nil,
-                        class: 'text-dark' %>
-          </li>
+          <% unless @teacher.archived %>
+            <li>
+              <%= t('basics.email') %>:
+              <%= mail_to @teacher.email,
+                          nil,
+                          class: 'text-dark' %>
+            </li>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1865,8 +1865,8 @@ de:
       eines größeren Teams warst, dessen Mitglieder noch einen Account haben,
       bleiben im System bis zum vorgesehenen Löschdatum.
     confirm_account_deletion: >
-      Bitte bestätige die Löschung Deines Accounts, indem Du den roten Button
-      drückst.
+      Bitte bestätige die Löschung Deines Accounts, indem Du Dein Passwort
+      eingibst und den roten Button drückst.
     thanks_for_contributions: >
       Vielen Dank dafür, dass Du auf MaMpf als Editor tätig warst!
       Von Dir gibt es auf MaMpf

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1831,9 +1831,6 @@ de:
     no_current_at_all: >
       Im aktuellen Semester sind noch keine Veranstaltungen veröffentlicht
       worden.
-    new_design: >
-      Neues *experimentelles* Design verwenden (personalisierte Startseite, kein Dropdown-Menü
-      für Veranstaltungswahl)
     other_preferences: >
       Sonstige Einstellungen
     changes_made: >
@@ -1856,6 +1853,31 @@ de:
     email_for_submission_decision: >
       eine Entscheidung über das Akzeptieren oder die Ablehnung einer
       verspäteten Abgabe getroffen wurde
+    delete_account: Account löschen
+    stored_submissions: >
+      Von Dir sind %{submissions} Abgaben zu Hausaufgaben im System gespeichert,
+      bei denen eine Datei hochgeladen wurde. Diese teilen sich auf in:
+    single_submissions: '%{single_submissions} Einzelabgaben'
+    team_submissions: '%{team_submissions} Teamabgaben'
+    submission_deletion: >
+      Die Einzelabgaben und zugehörigen Korrekturen werden alle gelöscht,
+      die Abgaben und zugehörigen Korrekturen, bei denen Du Mitglied
+      eines größeren Teams warst, dessen Mitglieder noch einen Account haben,
+      bleiben im System bis zum vorgesehenen Löschdatum.
+    confirm_account_deletion: >
+      Bitte bestätige die Löschung Deines Accounts, indem Du den roten Button
+      drückst.
+    thanks_for_contributions: >
+      Vielen Dank dafür, dass Du auf MaMpf als Editor tätig warst!
+      Von Dir gibt es auf MaMpf
+    given_lectures: '%{lectures} Vorlesung als DozentIn'
+    edited_media: '%{media} Medien als MedieneditorIn'
+    contributions_remain: >
+      Diese würden wir gerne in MaMpf belassen. Hier kannst Du eingeben,
+      unter welchem Namen diese künftig angezeigt werden sollen:
+    manual_deletion: >
+      Wenn Du nicht möchtest, dass die Materialien in MaMpf verbleiben, kannst
+      Du die entsprechenden Vorlesungen und Medien manuell löschen.
   mampf_news:
     title: 'MaMpf-News'
     check_notifications: 'Alle erledigen'
@@ -2964,13 +2986,6 @@ de:
       Bist Du sicher? Damit wird sich für alle NutzerInnen die Startseite
       ändern, da die aktuellen Vorlesungen über das aktuelle Semester bestimmt
       werden.
-    delete_account_with_submissions: >
-      Bist Du sicher? ACHTUNG: Es sind %{submissions} Abgaben zu Hausaufgaben
-      von Dir im System, davon %{single_submissions} als Einzelabgabe.
-      Die Einzelabgaben und zugehörigen Korrekturen werden alle gelöscht,
-      die Abgaben und zugehörigen Korrekturen, bei denen Du Mitglied
-      eines größeren Teams warst, dessen Mitglieder noch einen Account haben,
-      bleiben im System bis zum vorgesehenen Löschdatum.
   privacy_html: >
     Wir nehmen den Umgang mit Deinen Daten ernst. Im Rahmen der
     Datenschutz-Grundverordnung (DSGVO) benötigen wir Deine Zustimmung zur

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1873,8 +1873,9 @@ de:
     given_lectures: '%{lectures} Vorlesung als DozentIn'
     edited_media: '%{media} Medien als MedieneditorIn'
     contributions_remain: >
-      Diese würden wir gerne in MaMpf belassen. Hier kannst Du eingeben,
-      unter welchem Namen diese künftig angezeigt werden sollen:
+      Die Standardeinstellung sieht vor, dass diese in MaMpf belassen werden.
+      Hier kannst Du eingeben, unter welchem Namen diese künftig angezeigt
+      werden sollen:
     manual_deletion: >
       Wenn Du nicht möchtest, dass die Materialien in MaMpf verbleiben, kannst
       Du die entsprechenden Vorlesungen und Medien manuell löschen.

--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -63,6 +63,7 @@ de:
         confirm_new_password: 'Neues Passwort bestätigen'
     registrations:
       destroyed: "Dein Account wurde gelöscht."
+      not_destroyed: "Es gab ein Problem bei der Löschung Deines Accounts. Bitte wende Dich an die MaMpf-Administratoren."
       signed_up: "Du hast dich erfolgreich registriert. Bitte nimm Dir eine Minute, um Dein Profil zu vervollständigen"
       signed_up_but_inactive: "Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account inaktiv ist."
       signed_up_but_locked: "Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account gesperrt ist."

--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -64,6 +64,7 @@ de:
     registrations:
       destroyed: "Dein Account wurde gelöscht."
       not_destroyed: "Es gab ein Problem bei der Löschung Deines Accounts. Bitte wende Dich an die MaMpf-Administratoren."
+      password_incorrect: "Dein Account wurde nicht gelöscht, da das von Dir angegebene Passwort inkorrekt ist."
       signed_up: "Du hast dich erfolgreich registriert. Bitte nimm Dir eine Minute, um Dein Profil zu vervollständigen"
       signed_up_but_inactive: "Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account inaktiv ist."
       signed_up_but_locked: "Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account gesperrt ist."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -70,6 +70,7 @@ en:
         confirm_new_password: 'Confirm new password'
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      not_destroyed: "There was a problem with the deletion of your account. Please contact the MaMpf administrators."
       signed_up: "Welcome! You have signed up successfully. Please take aminute to complete your profile."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -71,6 +71,7 @@ en:
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       not_destroyed: "There was a problem with the deletion of your account. Please contact the MaMpf administrators."
+      password_incorrect: "Your account was not deleted because the password you gave is incorrect."
       signed_up: "Welcome! You have signed up successfully. Please take aminute to complete your profile."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1754,6 +1754,16 @@ en:
       scheduled deletion date.
     confirm_account_deletion: >
       Please confirm the deletion of your account by pushing the red button.
+    thanks_for_contributions: >
+      Thank you for being a contributor to MaMpf! Your contributions include
+    given_lectures: '%{lectures} event series as teacher'
+    edited_media: '%{media} meia as media editor'
+    contributions_remain: >
+      The defalut setting is that these remain in MaMpf. Here you can enter
+      under which name they will be shown in the future:
+    manual_deletion: >
+      If you do not want these materials to remain in MaMpf you can delete them
+      manually.
   mampf_news:
     title: 'MaMpf News'
     check_notifications: 'Clear all'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1719,9 +1719,6 @@ en:
       You have not yet subscribed any event series outside of the current term.
     no_current_at_all: >
       In the current term, no event series have yet been published.
-    new_design: >
-      Use the new *experimental* design (personalized start page, no dropdown
-      menu for lecture selection)
     other_preferences: >
       Other Preferences
     changes_made: >
@@ -1743,6 +1740,20 @@ en:
     email_for_submission_decision: >
       a decision about the acceptance or rejection of late submission has been
       made
+    delete_account: Delete Account
+    stored_submissions: >
+      There are %{submissions} submissions to assignments from you in the
+      system.
+    single_submissions: >
+      %{single_submissions} single submissions (i.e. submissions in which you
+      had no partners)
+    team_submissions: '%{team_submissions} team submissions'
+    submission_deletion: >
+      The single submissions and their corresponding corrections will be
+      deleted, while the team submissions will remain in the system until the
+      scheduled deletion date.
+    confirm_account_deletion: >
+      Please confirm the deletion of your account by pushing the red button.
   mampf_news:
     title: 'MaMpf News'
     check_notifications: 'Clear all'
@@ -2798,12 +2809,6 @@ en:
       Are you sure? This will in particular mean that the starting page for all
       users will be different as the current lectures are computed from the
       current term.
-    delete_account_with_submissions: >
-      Are you sure? ATTENTION: There are %{submissions} for assignments from
-      you in the systen, %{single_submissions} of which were made by you alone.
-      The last ones and their corresponding corrections will be deleted, while
-      the submissions where you were part of a teams whose members still
-      have an account will remain in the system until the planned deltion date.
   privacy_html: >
     We care about handling your data responsibly. By
     GDPR, we need your consent for storing and processing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1753,7 +1753,8 @@ en:
       deleted, while the team submissions will remain in the system until the
       scheduled deletion date.
     confirm_account_deletion: >
-      Please confirm the deletion of your account by pushing the red button.
+      Please confirm the deletion of your account by entering your password and
+      pushing the red button.
     thanks_for_contributions: >
       Thank you for being a contributor to MaMpf! Your contributions include
     given_lectures: '%{lectures} event series as teacher'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -385,6 +385,8 @@ Rails.application.routes.draw do
                               as: 'fill_user_select'
   get 'users/list', to: 'users#list',
                     as: 'list_users'
+  get 'users/delete_account', to: 'users#delete_account',
+                              as: 'delete_account'
   resources :users, only: [:index, :edit, :update, :destroy]
 
   get 'examples/:id', to: 'erdbeere#show_example',

--- a/db/migrate/20201015154231_add_archived_to_user.rb
+++ b/db/migrate/20201015154231_add_archived_to_user.rb
@@ -1,5 +1,9 @@
 class AddArchivedToUser < ActiveRecord::Migration[6.0]
-  def change
+  def up
     add_column :users, :archived, :boolean
+  end
+
+  def down
+    remove_column :users, :archived, :boolean
   end
 end

--- a/db/migrate/20201015154231_add_archived_to_user.rb
+++ b/db/migrate/20201015154231_add_archived_to_user.rb
@@ -1,0 +1,5 @@
+class AddArchivedToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :archived, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_160756) do
+ActiveRecord::Schema.define(version: 2020_10_15_154231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -788,6 +788,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_160756) do
     t.boolean "email_for_correction_upload"
     t.boolean "email_for_submission_decision"
     t.text "name_in_tutorials"
+    t.boolean "archived"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
This pull request implements the feature that lectures/media can remain in the database when their editor/teacher deletes her/his MaMpf account. The account gets destroyed, but these materials (and only these) will be transfered to a new user who gets an `archived` flag.  