### PR TITLE
add downward arrow to submission and correction badges

### DIFF
--- a/app/views/submissions/_card_main.html.erb
+++ b/app/views/submissions/_card_main.html.erb
@@ -52,12 +52,12 @@
           </th>
           <td>
             <% if submission.manuscript %>
-              <%= link_to t('basics.submission'),
+              <%= link_to raw(t('basics.submission') + ' &darr;'),
                           show_submission_manuscript_path(submission),
                           target: :_blank,
                           class: 'badge badge-secondary' %>
               <% if submission.correction %>
-                <%= link_to t('basics.correction'),
+                <%= link_to raw(t('basics.correction') + ' &darr;') ,
                           show_correction_path(submission),
                           target: :_blank,
                           class: 'badge badge-secondary' %>


### PR DESCRIPTION
This PR adds a downward arrow to the badge for submissions and correction, so that the bevhaviour of these buttons seems more intuitive.