### PR TITLE
Separate email for exception notifications

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module Mampf
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.exception_handler = {
-      email:      ENV['PROJECT_EMAIL'], # sends exception emails to a listed email (string // "you@email.com")
+      email:      ENV['ERROR_EMAIL'], # sends exception emails to a listed email (string // "you@email.com")
 
       # All keys interpolated as strings, so you can use symbols, strings or integers where necessary
       exceptions: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -429,7 +429,7 @@ Rails.application.routes.draw do
   mount CorrectionUploader.upload_endpoint(:submission_cache) => "/corrections/upload"
   mount ZipUploader.upload_endpoint(:submission_cache) => "/packages/upload"
   mount Thredded::Engine => '/forum'
-  get '*path', to: 'main#error'
+  match '*path', to: 'main#error', via: :all
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       ERDBEERE_API: https://erdbeere.mathi.uni-heidelberg.de/api/v1
       MUESLI_SERVER: https://muesli.mathi.uni-heidelberg.de
       PROJECT_EMAIL: project@localhost
+      ERROR_EMAIL: mampf-error@mathi.uni-heidelberg.de
       INSTANCE_PATH: mampf
       REDIS_URL: redis://redis:6379/1
       SOLR_PATH: /solr/mampf-dev

--- a/docker/production/docker.env
+++ b/docker/production/docker.env
@@ -14,6 +14,7 @@ MEMCACHED_SERVER=cache
 FROM_ADDRESS=mampf@mathi.uni-heidelberg.de
 MAILSERVER=mail.mathi.uni-heidelberg.de
 PROJECT_EMAIL=mampf@mathi.uni-heidelberg.de
+ERROR_EMAIL=mampf-error@mathi.uni-heidelberg.de
 MAILID_DOMAIN=mathi.uni-heidelberg.de
 
 # Due to CORS constraints, some urls are proxied to the media server

--- a/docker/run_tests/docker-compose.yml
+++ b/docker/run_tests/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       FROM_ADDRESS: development@localhost
       URL_HOST: localhost
       PROJECT_EMAIL: project@localhost
+      ERROR_EMAIL: error@localhost
       INSTANCE_PATH: mampf
       REDIS_URL: redis://redis:6379/1
       SOLR_HOST: solr


### PR DESCRIPTION
This PR introduces a separate email adress that exception notification. Also, requests of any kind for nonexistent paths will be redirected to an error page (until now,this was only so for GET requests).