### PR TITLE
Add One help text concerning Upload of submissions

### DIFF
--- a/app/assets/javascripts/upload.coffee
+++ b/app/assets/javascripts/upload.coffee
@@ -529,6 +529,7 @@ bulkCorrectionUpload = (fileInput) ->
           $('#upload-userManuscript').val("")
           $('input[type="submit"]').prop('disabled',false)
           $('#userManuscript-upload-notice').show()
+          $('#userManuscript-not-upload-notice').hide()
           $('#submission_detach_user_manuscript').val('false')
           $('#userManuscript-uploadButton-call').text(
             $('#userManuscript-uploadButton-call').data 'tr-success'
@@ -663,6 +664,7 @@ bulkCorrectionUpload = (fileInput) ->
       reader.readAsArrayBuffer(file)
 
   $('#upload-userManuscript').change () ->
+    $('#userManuscript-not-upload-notice').show()
     $('input[type="submit"]').prop('disabled',true)
     filez = Array.prototype.slice.call(
         document.getElementById('upload-userManuscript').files

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -172,6 +172,12 @@
           </div>
           <div class="col-12">
             <small class="text-danger submission-initially-hidden"
+                   id="userManuscript-not-upload-notice">
+              <%= t('submission.submission_not_upload_notice_html')%>
+            </small>
+          </div>
+          <div class="col-12">
+            <small class="text-danger submission-initially-hidden"
                    id="userManuscript-upload-notice">
               <%= t('submission.submission_upload_notice_html')%>
             </small>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2423,6 +2423,9 @@ de:
     removal_notice_html: >
       <b>Hinweis:</b> Dateien werden nach Ablauf des Semesters gelöscht.
       Wir übernehmen keine Haftung für mögliche Datenverluste.
+    submission_not_upload_notice_html: >
+      <b>Wichtig</b>: Bitte drücke auf "Hochladen" und dann auf "Speichern", ansonsten werden deine
+       Änderungen verworfen, wenn du die Seite verlässt.
     submission_upload_notice_html: >
       <b>Wichtig</b>: Bitte drücke auf "Speichern", ansonsten werden deine
        Änderungen verworfen, wenn du die Seite verlässt.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2295,6 +2295,9 @@ en:
     submission_upload_notice_html: >
       <b> Important </b>: Please press "Save", otherwise your
         Changes are discarded when you leave the site.
+    submission_not_upload_notice_html: >
+      <b>Important </b>: Please press "Upload" and then "Save", otherwise your
+        Changes are discarded when you leave the site.
     no_manuscript_yet: Currently, no file is stored.
     exists_no_longer: This submission does not exist.
     working: Working


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [x] `rubocop` reports equal or less errors and warnings **in total**
    - [x] `yarn lint` reports equal or less errors and warnings **in total**
    - [x] `coffeelint .` reports equal or less errors and warnings **in total**
    - [x] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)

It was not clear, when a file is replaced/uploaded.

* **What is the new behavior (if this is a feature change)?**

A helper now  guides now users.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


* **Other information**:
