### PR TITLE
allow matlab .m files as file type for assignments

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -13,7 +13,7 @@ class Assignment < ApplicationRecord
   scope :expired, -> { where('deadline < ?', Time.now) }
 
   def self.accepted_file_types
-    ['.pdf', '.tar.gz', '.cc', '.hh', '.zip']
+    ['.pdf', '.tar.gz', '.cc', '.hh', '.m', '.zip']
   end
 
   validates :accepted_file_type,
@@ -100,6 +100,7 @@ class Assignment < ApplicationRecord
                     'application/octet-stream'],
       '.cc' => ['text/*'],
       '.hh' => ['text/*'],
+      '.m' => ['text/*'],
       '.zip' => ['application/zip', 'application/x-zip',
                  'application/x-zip-compressed', 'application/octet-stream',
                  'application/x-compress', 'application/x-compressed',

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -154,9 +154,9 @@ class Submission < ApplicationRecord
                      	 		 accepted_file_type: '.tar.gz')
 			end
     end
-    if (!assignment.accepted_file_type.in?(['.cc', '.hh']) &&
+    if (!assignment.accepted_file_type.in?(['.cc', '.hh', '.m']) &&
       !metadata['mime_type'].in?(assignment.accepted_mime_types)) ||
-      (assignment.accepted_file_type.in?(['.cc', '.hh']) &&
+      (assignment.accepted_file_type.in?(['.cc', '.hh', '.m']) &&
         (!metadata['mime_type'].starts_with?('text/') &&
          metadata['mime_type'] != 'application/octet-stream'))
       errors.push I18n.t('submission.wrong_mime_type',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [ ] `rubocop` reports equal or less errors and warnings **in total**
    - [ ] `yarn lint` reports equal or less errors and warnings **in total**
    - [ ] `coffeelint .` reports equal or less errors and warnings **in total**
    - [ ] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)

matlab files are not accepted as as file type for assignments

* **What is the new behavior (if this is a feature change)?**

matlab files are accepted as as file type for assignments

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
