### PR TITLE
Locales for submissions

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -7,14 +7,17 @@ class AssignmentsController < ApplicationController
 
   def new
     @assignment = Assignment.new
-    lecture = Lecture.find_by_id(params[:lecture_id])
-    @assignment.lecture = lecture
+    @lecture = Lecture.find_by_id(params[:lecture_id])
+    @assignment.lecture = @lecture
+    set_assignment_locale
   end
 
   def create
     @assignment = Assignment.new(assignment_params)
     @assignment.save
     @errors = @assignment.errors
+    @lecture = @assignment.lecture
+    set_assignment_locale
   end
 
   def edit
@@ -28,7 +31,6 @@ class AssignmentsController < ApplicationController
   end
 
   def destroy
-    @lecture = @assignment.lecture
     @assignment.destroy
   end
 
@@ -37,6 +39,7 @@ class AssignmentsController < ApplicationController
 
   def cancel_new
     @lecture = Lecture.find_by_id(params[:lecture])
+    set_assignment_locale
     @none_left = @lecture&.assignments&.none?
   end
 
@@ -44,7 +47,8 @@ class AssignmentsController < ApplicationController
 
   def set_assignment
     @assignment = Assignment.find_by_id(params[:id])
-    return if @assignment
+    @lecture = @assignment&.lecture
+    set_assignment_locale and return if @assignment
     redirect_to :root, alert: I18n.t('controllers.no_assignment')
   end
 
@@ -52,6 +56,11 @@ class AssignmentsController < ApplicationController
     @lecture = Lecture.find_by_id(assignment_params[:lecture_id])
     return if @lecture
     redirect_to :root, alert: I18n.t('controllers.no_lecture')
+  end
+
+  def set_assignment_locale
+    I18n.locale = @lecture&.locale_with_inheritance || current_user.locale ||
+                    I18n.default_locale
   end
 
   def assignment_params

--- a/app/controllers/quiz_certificates_controller.rb
+++ b/app/controllers/quiz_certificates_controller.rb
@@ -2,6 +2,8 @@
 class QuizCertificatesController < ApplicationController
   before_action :set_certificate, only: :claim
   before_action :check_if_claimed, only: :claim
+  before_action :set_locale_by_quiz, only: :claim
+  before_action :set_locale_by_lecture, only: :validate
   authorize_resource
 
   def claim
@@ -27,6 +29,19 @@ class QuizCertificatesController < ApplicationController
   end
 
   def certificate_params
-    params.permit(:code)
+    params.permit(:code, :lecture_id)
+  end
+
+  def set_locale_by_quiz
+    return unless @certificate
+    quiz_locale = @certificate.quiz.locale_with_inheritance
+    I18n.locale = quiz_locale || current_user.locale ||
+                    I18n.default_locale
+  end
+
+  def set_locale_by_lecture
+    @lecture = Lecture.find_by_id(certificate_params[:lecture_id])
+    I18n.locale = @lecture&.locale_with_inheritance || current_user.locale ||
+                    I18n.default_locale
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -24,7 +24,7 @@ class SubmissionsController < ApplicationController
   def new
   	@submission = Submission.new
     @submission.assignment = @assignment
-  	@lecture = @assignment.lecture
+    set_submission_locale
   end
 
   def edit
@@ -60,6 +60,8 @@ class SubmissionsController < ApplicationController
 
   def create
   	@submission = Submission.new(submission_create_params)
+    @lecture = @submission&.assignment&.lecture
+    set_submission_locale
     @too_late = @submission.not_updatable?
   	return if @too_late
     if submission_manuscript_params[:manuscript].present?
@@ -105,6 +107,8 @@ class SubmissionsController < ApplicationController
 
   def join
     @assignment = Assignment.find_by_id(join_params[:assignment_id])
+    @lecture = @assignment.lecture
+    set_submission_locale
     code = join_params[:code]
     @submission = Submission.find_by(token: code, assignment: @assignment)
     check_code_and_join
@@ -227,6 +231,7 @@ class SubmissionsController < ApplicationController
     @submission = Submission.find_by_id(params[:id])
     @assignment = @submission&.assignment
     @lecture = @assignment&.lecture
+    set_submission_locale
     return if @submission
     flash[:alert] = I18n.t('controllers.no_submission')
     render js: "window.location='#{root_path}'"
@@ -248,6 +253,8 @@ class SubmissionsController < ApplicationController
 
   def set_assignment
     @assignment = Assignment.find_by_id(params[:assignment_id])
+    @lecture = @assignment&.lecture
+    set_submission_locale
     return if @assignment
     flash[:alert] = I18n.t('controllers.no_assignment')
     render js: "window.location='#{root_path}'"
@@ -256,12 +263,17 @@ class SubmissionsController < ApplicationController
 
   def set_lecture
     @lecture = Lecture.find_by_id(params[:id])
-    return if @lecture
+    set_submission_locale and return if @lecture
     redirect_to :root, alert: I18n.t('controllers.no_lecture')
   end
 
   def set_too_late
     @too_late = @submission.not_updatable?
+  end
+
+  def set_submission_locale
+    I18n.locale = @lecture&.locale_with_inheritance || current_user.locale ||
+                    I18n.default_locale
   end
 
   def join_params

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -31,12 +31,15 @@ class TutorialsController < ApplicationController
 
   def new
     @tutorial = Tutorial.new
-    lecture = Lecture.find_by_id(params[:lecture_id])
-    @tutorial.lecture = lecture
+    @lecture = Lecture.find_by_id(params[:lecture_id])
+    set_tutorial_locale
+    @tutorial.lecture = @lecture
   end
 
   def create
     @tutorial = Tutorial.new(tutorial_params)
+    @lecture = @tutorial&.lecture
+    set_tutorial_locale
     @tutorial.save
     @errors = @tutorial.errors
   end
@@ -51,7 +54,6 @@ class TutorialsController < ApplicationController
   end
 
   def destroy
-    @lecture = @tutorial.lecture
     @tutorial.destroy
   end
 
@@ -60,6 +62,7 @@ class TutorialsController < ApplicationController
 
   def cancel_new
     @lecture = Lecture.find_by_id(params[:lecture])
+    set_tutorial_locale
     @none_left = @lecture&.tutorials&.none?
   end
 
@@ -89,13 +92,16 @@ class TutorialsController < ApplicationController
   end
 
   def validate_certificate
+    @lecture = Lecture.find_by_id(params[:lecture_id])
+    set_tutorial_locale
   end
 
   private
 
   def set_tutorial
     @tutorial = Tutorial.find_by_id(params[:id])
-    return if @tutorial
+    @lecture = @tutorial&.lecture
+    set_tutorial_locale and return if @tutorial
     redirect_to :root, alert: I18n.t('controllers.no_tutorial')
   end
 
@@ -107,7 +113,7 @@ class TutorialsController < ApplicationController
 
   def set_lecture
     @lecture = Lecture.find_by_id(params[:id])
-    return if @lecture
+    set_tutorial_locale and return if @lecture
     redirect_to :root, alert: I18n.t('controllers.no_lecture')
   end
 
@@ -115,6 +121,11 @@ class TutorialsController < ApplicationController
     @lecture = Lecture.find_by_id(tutorial_params[:lecture_id])
     return if @lecture
     redirect_to :root, alert: I18n.t('controllers.no_lecture')
+  end
+
+  def set_tutorial_locale
+    I18n.locale = @lecture&.locale_with_inheritance || current_user.locale ||
+                    I18n.default_locale
   end
 
   def check_tutor_status

--- a/app/views/quiz_certificates/_form.html.erb
+++ b/app/views/quiz_certificates/_form.html.erb
@@ -15,6 +15,8 @@
       </button>
     </div>
   </div>
+  <%= f.hidden_field :lecture_id,
+                     value: @lecture.id %>
 <% end %>
 <div class="row mt-3">
   <div class="col-12">

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -40,7 +40,7 @@
     <% end %>
     <div class="row">
       <div class="col-12">
-        <%= f.label :manuscript, 'Abgabe' %>
+        <%= f.label :manuscript, t('basics.submission') %>
       </div>
       <div class="col-3" id="userManuscript-uploadButton"
            data-choosefiles="<%= file_button_text(assignment) %>">

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -63,7 +63,9 @@
         </button>
       <% end %>
       <%= link_to t('tutorial.certificate_check'),
-                  validate_certificate_as_tutor_path,
+                  validate_certificate_as_tutor_path(params:
+                                                       { lecture_id:
+                                                           @lecture.id }),
                   class: 'btn btn-primary ml-3',
                   remote: true %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2012,7 +2012,7 @@ en:
       characters.
     certify: Request Certificate
     obtained_certificate: >
-      you obtained the following certificate code for this quiz: %{code}
+      You obtained the following certificate code for this quiz: %{code}
     certificate_info_on_use: >
       If your lecture uses certified MaMpf quizzes in the tutorials
       you will have to give present this code in some form (e.g. your homework
@@ -2288,7 +2288,7 @@ en:
       For this purpose, a small additional program is downloaded and executed <i> in the browser </i>.
         Your file will remain on your device until you have uploaded them.
     assure_third_party: >
-      I assure you that the file does not infringe any rights of third parties.
+      I assure that the file does not infringe any rights of third parties.
     removal_notice_html: >
       <b>Notice:</b> Files will be deleted at the end of the semester.
        We do not assume any liability for possible data loss.
@@ -2393,7 +2393,7 @@ en:
       includes successful upload and removal of files, joining or leaving of
       team members, decisions about the acceptance of late submissions and
       upload of corrections by your tutor.
-    deletion_date: >
+    deletion_date_info: >
       Your submission contains personal data which we will delete two weeks
       after the end of this term due to protection of data privacy. You will be
       notified ahead via email so that you can save them.
@@ -2446,7 +2446,7 @@ en:
       informed about the user and the quiz that this certificate belongs to.
     certificate_valid: >
       The code is valid. It belongs to user %{user} and quiz %{quiz}.
-    certificate_invalid: Der Code ist ungültig.
+    certificate_invalid: This code is invalid.
     bulk_upload:
       report: Report on the bulk upload of the corrections
       number_of_submissions: Number of submissions
@@ -2844,7 +2844,7 @@ en:
     copy_to_clipboard: 'Copy to Clipboard'
     leave: 'Leave'
     upload: 'Upload'
-    upload_success: 'Upload successfull'
+    upload_success: 'Upload successful'
     refresh_token: 'Refresh Code'
     invite: 'Invite'
     send: 'Send'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (#135)

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [ ] `rubocop` reports equal or less errors and warnings **in total**
    - [ ] `yarn lint` reports equal or less errors and warnings **in total**
    - [ ] `coffeelint .` reports equal or less errors and warnings **in total**
    - [ ] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)

The controllers associated to the following models do not set specific locales: `assignment, submission, tutorial, quiz_certificate`
So, although the localizations are present in `.yml` locale files, they are not displayed.

* **What is the new behavior (if this is a feature change)?**

The correct locales are set in the controllers, so they are displayed in the views.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
