### PR TITLE
adds .mlx as another file type for assignments

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -13,7 +13,7 @@ class Assignment < ApplicationRecord
   scope :expired, -> { where('deadline < ?', Time.now) }
 
   def self.accepted_file_types
-    ['.pdf', '.tar.gz', '.cc', '.hh', '.m', '.zip']
+    ['.pdf', '.tar.gz', '.cc', '.hh', '.m', '.mlx', '.zip']
   end
 
   validates :accepted_file_type,
@@ -101,6 +101,10 @@ class Assignment < ApplicationRecord
       '.cc' => ['text/*'],
       '.hh' => ['text/*'],
       '.m' => ['text/*'],
+      '.mlx' => ['application/zip', 'application/x-zip',
+                 'application/x-zip-compressed', 'application/octet-stream',
+                 'application/x-compress', 'application/x-compressed',
+                 'multipart/x-zip'],
       '.zip' => ['application/zip', 'application/x-zip',
                  'application/x-zip-compressed', 'application/octet-stream',
                  'application/x-compress', 'application/x-compressed',
@@ -108,7 +112,7 @@ class Assignment < ApplicationRecord
   end
 
   def self.non_inline_file_types
-    ['.tar.gz', '.zip']
+    ['.tar.gz', '.zip', '.mlx']
   end
 
   def accepted_mime_types


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [ ] `rubocop` reports equal or less errors and warnings **in total**
    - [ ] `yarn lint` reports equal or less errors and warnings **in total**
    - [ ] `coffeelint .` reports equal or less errors and warnings **in total**
    - [ ] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)

.mlx files are not accepted for assignments

* **What is the new behavior (if this is a feature change)?**

.mlx files are accepted for assignments

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
