### PR TITLE
add disclaimers to quizzes at course level

### DIFF
--- a/app/views/quizzes/_disclaimer.html.erb
+++ b/app/views/quizzes/_disclaimer.html.erb
@@ -1,0 +1,14 @@
+<div class="row justify-content-center px-2">
+  <div class="col-sm-12 col-md-12 col-lg-10">
+		<div class="card bg-grey-lighten-4 mt-2 border-secondary">
+  		<div class="card-body">
+  			<span class="badge badge-secondary">
+        	<%= t('basics.note') %>.
+      	</span>
+  			<%= t('admin.quiz.course_disclaimer',
+  						course: course.title) %>
+  			<%= t('test.notation') %>
+  		</div>
+  	</div>
+  </div>
+</div>

--- a/app/views/quizzes/take.html.erb
+++ b/app/views/quizzes/take.html.erb
@@ -1,3 +1,7 @@
+<% if @quiz.sort == 'Quiz' && @quiz.teachable.is_a?(Course) %>
+  <%= render partial: 'quizzes/disclaimer',
+             locals: { course: @quiz.teachable } %>
+<% end %>
 <div id="<%= quiz_id %>" class="quiz">
   <%= render partial: 'quizzes/quiz_round',
              locals: { hidden: false } %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1720,6 +1720,10 @@ de:
         typischerweise Quiz-Fragen, die nur im Kontext eines konkreten Quizzes
         Sinn ergeben (beispielsweise, weil in vorangegangenen Fragen spezielle
         Voraussetzungen festgelegt wurden).
+      course_disclaimer: >
+        Dieses Quiz ist semesterübergreifend auf der Ebene des Moduls
+        %{course} angesiedelt, das Material stammt also aus verschiedenen
+        Veranstaltungen und von verschiedenen DozentInnen.
       info:
         graph: >
           Der Quiz-Graph ist der gerichtete Graph, der zu dem
@@ -2120,7 +2124,7 @@ de:
     number_of_questions_label: 'Anzahl der Fragen'
     certificate_info: >
       Du kannst ein Zertifikat dafür bekommen, dass Du dieses Quiz vollständig
-      absolviert hast. Wenn Du den Buton drückst, erhältst Du das Zertifikat in
+      absolviert hast. Wenn Du den Button drückst, erhältst Du das Zertifikat in
       Form eines Codes aus 6 Zeichen.
     certify: Zertifikat anfordern
     obtained_certificate: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1614,6 +1614,9 @@ en:
         Questions that only make sense in the context of a
         certain quiz (e.g., because special assumptions have been made
         in the questions before)
+      course_disclaimer: >
+        This quiz is located at the level of the course %{course}, in particular
+        it covers material from different semesters and from different teachers.
       info:
         graph: >
           The Quiz Graph is the directed graph corresponding to this quiz.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature (requested by users)

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [ ] `rubocop` reports equal or less errors and warnings **in total**
    - [ ] `yarn lint` reports equal or less errors and warnings **in total**
    - [ ] `coffeelint .` reports equal or less errors and warnings **in total**
    - [ ] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**

Quizzees that are associated to a course (not to a lecture) get a disclaimer that informs the students that the notation and material in these quizzes may differ slightly from the material they have had in their lecture.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
