### PR TITLE
add boost field to media

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -404,7 +404,7 @@ class MediaController < ApplicationController
                                    :geogebra, :geogebra_app_name,
                                    :teachable_type, :teachable_id,
                                    :released, :text, :locale,
-                                   :content,
+                                   :content, :boost,
                                    editor_ids: [],
                                    tag_ids: [],
                                    linked_medium_ids: [])

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -502,10 +502,12 @@ class Lecture < ApplicationRecord
   end
 
   # for a given list of media, sorts them as follows:
-  # 1) media associated to the lecture
+  # 1) media associated to the lecture, sorted first by boost and second
+  # by creation date
   # 2) media associated to lessons of the lecture, sorted by lesson numbers
   def lecture_lesson_results(filtered_media)
     lecture_results = filtered_media.where(teachable: self)
+                                    .order(boost: :desc, created_at: :desc)
     lesson_results = filtered_media.where(teachable:
                                             Lesson.where(lecture: self))
     lecture_results + lesson_results.includes(:teachable)

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -204,7 +204,8 @@ class Medium < ApplicationRecord
     # media sitting at course level
     course_media_in_project = media_in_project.includes(:tags)
                                               .where(teachable: lecture.course)
-                                              .natural_sort_by(&:caption)
+                                              .order(boost: :desc,
+                                                     description: :asc)
     # media sitting at lecture level
     # append results at course level to lecture/lesson level results
     lecture.lecture_lesson_results(media_in_project) + course_media_in_project
@@ -214,7 +215,7 @@ class Medium < ApplicationRecord
   def self.media_in_project(project)
     return Medium.none unless project.present?
     sort = project == 'keks' ? 'Quiz' : project.capitalize
-    Medium.where(sort: sort).order(:id)
+    Medium.where(sort: sort)
   end
 
   # returns the array of all media (by title), together with their ids

--- a/app/views/media/_basics.html.erb
+++ b/app/views/media/_basics.html.erb
@@ -151,6 +151,12 @@
         <% end %>
       </div>
     </div>
+    <div class="form-group">
+      <%= t('admin.medium.boost') %>
+      <%= helpdesk(t('admin.medium.info.boost'), false) %>
+      <%= f.text_field :boost,
+                       class: 'form-control' %>
+    </div>
     <%= f.hidden_field :teachable_id, value: medium.teachable_id %>
     <%= f.hidden_field :teachable_type, value: medium.teachable_type %>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -880,6 +880,7 @@ de:
         Mediums auf der MaMpf-Plattform keine Rechte Dritter verletzt werden.
       lock_comments: Kommentare für dieses Medium deaktivieren
       comments_locked: Kommentare deaktiviert
+      boost: Boost
       info:
         locked: >
           Dieses Medium wurde gesperrt. Du kannst es unter
@@ -1160,6 +1161,13 @@ de:
           die mit dem THymE-Editor bearbeitet wurden).
         details_warning: >
           Es wurden Details geändert, die noch nicht übernommen wurden.
+        boost: >
+          Über den Boost kannst Du die Reihenfolge überschreiben, in der
+          standardmäßig Medien angeordnet werden, die zu Modulen bzw.
+          Veranstaltungen gehören (der Boost wirkt sich nicht auf Medien aus,
+          die zu einer Sitzung assoziiert sind). Der Standardwert ist 0,
+          Medien mit höherem Boost werden weiter vorn angezeigt, Medien mit
+          niedrigerem Boost weiter hinten.
     tag:
       index: 'Tagübersicht'
       related_tags: 'Verknüpfte Tags'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -833,6 +833,7 @@ en:
         no rights of third parties are infringed.
       lock_comments: 'Disable comments for this medium'
       comments_locked: 'Comments disabled'
+      boost: 'Boost'
       info:
         locked: >
           This medium has been locked. It can be unlocked via
@@ -1090,6 +1091,12 @@ en:
           editor.
         details_warning: >
           Details have been changed that have not yet been imported.
+        boost: >
+          Via the boost you can override the way in ehich media are ordered
+          by default (for media that belong to a course or an event series,
+          it does not affect media associated to a session). The default value
+          is 0, Media with a higher boost will be displayed in the first places,
+          media with lower boost at the end.
     tag:
       index: 'Tag Index'
       related_tags: 'Related Tags'

--- a/db/migrate/20201114125010_add_boost_to_medium.rb
+++ b/db/migrate/20201114125010_add_boost_to_medium.rb
@@ -1,0 +1,9 @@
+class AddBoostToMedium < ActiveRecord::Migration[6.0]
+  def up
+    add_column :media, :boost, :float, default: 0
+  end
+
+  def down
+		remove_column :media, :boost, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_30_104932) do
+ActiveRecord::Schema.define(version: 2020_11_14_125010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -354,6 +354,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_104932) do
     t.text "geogebra_app_name"
     t.integer "position"
     t.boolean "text_input", default: false
+    t.float "boost", default: 0.0
     t.index ["quizzable_type", "quizzable_id"], name: "index_media_on_quizzable_type_and_quizzable_id"
     t.index ["teachable_type", "teachable_id"], name: "index_media_on_teachable_type_and_teachable_id"
   end


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [ ] `rubocop` reports equal or less errors and warnings **in total**
    - [ ] `yarn lint` reports equal or less errors and warnings **in total**
    - [ ] `coffeelint .` reports equal or less errors and warnings **in total**
    - [ ] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

There is a new field "boost" for media, which is a `float`. The default value is `0`. Media associated to courses or lectures will be sorted by boost first, giving the user the opportunity to override the default order.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
A db:migrate should be run.