### PR TITLE
Fix submission without users bug

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -71,12 +71,11 @@ class SubmissionsController < ApplicationController
                                                   :manuscript)
       return if @errors.present?
     end
+    @submission.user_submission_joins.build(user: current_user)
     @submission.save
     @assignment = @submission.assignment
     @errors = @submission.errors
     return unless @submission.valid?
-    UserSubmissionJoin.create(user: current_user,
-                              submission: @submission)
     send_invitation_emails
     @submission.update(last_modification_by_users_at: Time.now)
     return unless @submission.manuscript

--- a/app/views/submissions/create.coffee
+++ b/app/views/submissions/create.coffee
@@ -10,6 +10,9 @@ $('#submission-tutorial-error')
 <% if @errors[:manuscript].present? %>
 alert('<%= @errors[:manuscript].join(" ") %>')
 <% end %>
+<% if @errors[:user_submission_joins].present? %>
+alert('<%= @errors[:user_submission_joins].join(" ") %>')
+<% end %>
 <% else %>
 $('.submissionArea[data-id="<%= @assignment.id %>"]').empty()
   .append('<%= j render partial: "submissions/card",

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3298,6 +3298,10 @@ de:
           attributes:
             tutorial:
               blank: Es muss ein gültiges Tutorium angegeben werden.
+            user_submission_joins:
+              invalid: >
+                Es gibt schon eine Abgabe von Dir oder die Teamgröße ist
+                überschritten.
         tag:
           attributes:
             notions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3120,6 +3120,10 @@ en:
           attributes:
             tutorial:
               blank: A valid tutorial has to be supplied.
+            user_submission_joins:
+              invalid: >
+                There is already a submission from you or the team has already
+                reached its maximal size.
         tag:
           attributes:
             notions:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [ ] `rubocop` reports equal or less errors and warnings **in total**
    - [ ] `yarn lint` reports equal or less errors and warnings **in total**
    - [ ] `coffeelint .` reports equal or less errors and warnings **in total**
    - [ ] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)

Adding of users is done after creation of submission, which can lead to submissions without users if multiple create requests were fired.This behaviour is an unintended consequence of [this](https://github.com/MaMpf-HD/mampf/commit/8556fdf4c912118a7dbf9d5657420eb569224e54) commit.

* **What is the new behavior (if this is a feature change)?**

Users are added before the submission is created (and the bug that should be fixed by the commit that caused the current behaviour remains fixed).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
