### PR TITLE
Registration limit via ENV (#144) (#149)

### DIFF
--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -80,6 +80,8 @@ de:
           Ich stimme der Speicherung und Verarbeitung meiner Daten gemäß der
           %{policy} der Universität Heidelberg zu.
         policy: 'Datenschutzerklärung'
+      user:
+        too_many_registrations: In letzter Zeit sind zu viele Registrierungen versucht worden, bitte versuche es später erneut.
     sessions:
       signed_in: "Du hast Dich erfolgreich angemeldet."
       signed_out: "Du hast Dich erfolgreich abgemeldet."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -88,6 +88,8 @@ en:
           I consent to the storing and processing of my data according to the
           %{policy} of Heidelberg University.
         policy: 'Privacy Policy'
+      user:
+        too_many_registrations: There were too many registrations in the last few minutes. Please try again later.
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       REDIS_URL: redis://redis:6379/1
       SOLR_PATH: /solr/mampf-dev
       SPROCKETS_CACHE: /cache
+      MAMPF_REGISTRATION_TIMEFRAME: 25
+      MAMPF_MAX_REGISTRATION_PER_TIMEFRAME: 40
       # uncomment DB_SQL_PRESEED_URL and UPLOADS_PRESEED_URL to enable db preseeding
       # DB_SQL_PRESEED_URL: "https://heibox.uni-heidelberg.de/d/6fb4a9d2e7f54d8b9931/files/?p=%2F20200907123000_mampf.sql&dl=1"
       # UPLOADS_PRESEED_URL: "https://heibox.uni-heidelberg.de/f/d2f72a4069814debaf69/?dl=1"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 
- Linter
    - [x] `rubocop` reports equal or less errors and warnings **in total**
    - [x] `yarn lint` reports equal or less errors and warnings **in total**
    - [x] `coffeelint .` reports equal or less errors and warnings **in total**
    - [x] `erblint .` reports equal or less errors and warnings **in total**





* **What is the current behavior?** (You can also link to an open issue here)

No limits

* **What is the new behavior (if this is a feature change)?**

Limits the number of signups


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Edit ENV, to set custom time frame and user limits.

* **Other information**:
