### PR TITLE
Extract metadata later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -170,7 +170,7 @@ Layout/SpaceInsideParens:
 # Check quotes usage according to lint rule below.
 Style/StringLiterals:
   Enabled: true
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 
 # Detect hard tabs, no hard tabs.
 Layout/IndentationStyle:

--- a/app/assets/javascripts/upload.coffee
+++ b/app/assets/javascripts/upload.coffee
@@ -88,14 +88,10 @@ videoUpload = (fileInput) ->
 
       videoFile = document.getElementById('video-file')
       videoSize = document.getElementById('video-size')
-      videoResolution = document.getElementById('video-resolution')
-      videoDuration = document.getElementById('video-duration')
 
       # put metadata into place
       videoFile.innerHTML = data.metadata.filename
       videoSize.innerHTML = formatBytes(data.metadata.size)
-      videoResolution.innerHTML = data.metadata.resolution
-      videoDuration.innerHTML = fancyTimeFormat(Math.round(data.metadata.duration))
       $(metaData).show()
       $(videoPreviewArea).show()
       $('#medium_detach_video').val('false')

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -46,6 +46,7 @@ class MediaController < ApplicationController
   def update
     I18n.locale = @medium.locale_with_inheritance
     old_manuscript_data = @medium.manuscript_data
+    old_video_data = @medium.video_data
     old_geogebra_data = @medium.geogebra_data
     @medium.update(medium_params)
     @errors = @medium.errors
@@ -69,6 +70,14 @@ class MediaController < ApplicationController
     if @medium.geogebra.present? && changed_geogebra
       @medium.geogebra_derivatives!
       @medium.save
+    end
+    changed_video = @medium.video_data != old_video_data
+    if @medium.video.present? && changed_video
+      # MetadataExtractor.perform_async(@medium.id)
+      @medium.video.refresh_metadata!(action: :store)
+      pp @medium.video
+      @medium.save
+      pp @medium.video
     end
     if @medium.sort == 'Quiz' &&params[:medium][:create_quiz_graph] == '1'
       @medium.becomes(Quiz).update(level: 1,

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -73,11 +73,10 @@ class MediaController < ApplicationController
     end
     changed_video = @medium.video_data != old_video_data
     if @medium.video.present? && changed_video
-      # MetadataExtractor.perform_async(@medium.id)
-      @medium.video.refresh_metadata!(action: :store)
-      pp @medium.video
-      @medium.save
-      pp @medium.video
+      MetadataExtractor.perform_async(@medium.id)
+      # @medium.video.refresh_metadata!(action: :store)
+      # refreshed_video = @medium.video
+      # @medium.update(video_data: refreshed_video.to_json)
     end
     if @medium.sort == 'Quiz' &&params[:medium][:create_quiz_graph] == '1'
       @medium.becomes(Quiz).update(level: 1,

--- a/app/uploaders/submission_uploader.rb
+++ b/app/uploaders/submission_uploader.rb
@@ -6,4 +6,5 @@ class SubmissionUploader < Shrine
   plugin :determine_mime_type, analyzer: :marcel
   plugin :upload_endpoint, max_size: 10*1024*1024 # 10 MB
 	plugin :default_storage, cache: :submission_cache, store: :submission_store
+	plugin :restore_cached_data
 end

--- a/app/uploaders/video_uploader.rb
+++ b/app/uploaders/video_uploader.rb
@@ -5,18 +5,22 @@ class VideoUploader < Shrine
   # shrine plugins
   plugin :upload_endpoint
   plugin :add_metadata
-  plugin :determine_mime_type
+  # plugin :determine_mime_type
   plugin :validation_helpers
   plugin :pretty_location
+  plugin :refresh_metadata
 
   # add metadata to uploaded video: duration, bitrate, resolution, framerate
-  add_metadata do |io|
-    movie = Shrine.with_file(io) { |file| FFMPEG::Movie.new(file.path) }
+  add_metadata do |io, **options|
+    pp options[:action]
+    if options[:action] != :upload
+      movie = Shrine.with_file(io) { |file| FFMPEG::Movie.new(file.path) }
 
-    { 'duration'   => movie.duration,
-      'bitrate'    => movie.bitrate,
-      'resolution' => movie.resolution,
-      'frame_rate' => movie.frame_rate }
+      { 'duration'   => movie.duration,
+        'bitrate'    => movie.bitrate,
+        'resolution' => movie.resolution,
+        'frame_rate' => movie.frame_rate }
+    end
   end
 
   Attacher.validate do

--- a/app/views/media/_upload_video.html.erb
+++ b/app/views/media/_upload_video.html.erb
@@ -37,15 +37,15 @@
           </span>
         </div>
       </div>
-      <div class="row">
+      <div class="row" style="display: <%= show(medium.video_resolution) %>">
         <div class="col-12">
           <%= t('video.resolution') %>:
           <span id="video-resolution">
             <%= medium.video_resolution %>
           </span>
-        </div>
+       </div>
       </div>
-      <div class="row">
+      <div class="row" style="display: <%= show(medium.video_duration) %>">
         <div class="col-12">
           <%= t('video.length') %>:
           <span id="video-duration">

--- a/app/workers/metadata_extractor.rb
+++ b/app/workers/metadata_extractor.rb
@@ -5,6 +5,7 @@ class MetadataExtractor
     medium = Medium.find(medium_id)
     return unless medium && medium.video.present?
     medium.video.refresh_metadata!(action: :store)
-    medium.save
+    refreshed_video = medium.video
+    medium.update(video_data: refreshed_video.to_json)
   end
 end

--- a/app/workers/metadata_extractor.rb
+++ b/app/workers/metadata_extractor.rb
@@ -1,0 +1,10 @@
+class MetadataExtractor
+  include Sidekiq::Worker
+
+  def perform(medium_id)
+    medium = Medium.find(medium_id)
+    return unless medium && medium.video.present?
+    medium.video.refresh_metadata!(action: :store)
+    medium.save
+  end
+end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -33,7 +33,7 @@ end
 Shrine.plugin :activerecord
 Shrine.plugin :determine_mime_type
 Shrine.plugin :cached_attachment_data # for forms
-Shrine.plugin :restore_cached_data
+# Shrine.plugin :restore_cached_data
 Shrine.plugin :instrumentation
 
 # use mv instead of cp when promoting files from cache to store

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -31,7 +31,7 @@ elsif Rails.env.test?
 end
 
 Shrine.plugin :activerecord
-Shrine.plugin :determine_mime_type
+# Shrine.plugin :determine_mime_type
 Shrine.plugin :cached_attachment_data # for forms
 # Shrine.plugin :restore_cached_data
 Shrine.plugin :instrumentation


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix attempt.

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

Upload of large files videos sometimes (#143). One reason maybe that metadata extractiontakes too long (especially when RAM is scarce) and causes a timeout.

* **What is the new behavior (if this is a feature change)?**

This PR moves the extraction of video metadata to a sidekiq worker that is triggered only when the user saves the video.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
