### PR TITLE
double nginx timeout for worker read/write operations

### DIFF
--- a/docker/production/proxy_location_config.txt
+++ b/docker/production/proxy_location_config.txt
@@ -1,1 +1,3 @@
 proxy_set_header  X-Accel-Mapping       /private=/__accel_redirect;
+proxy_read_timeout 120s;
+proxy_send_timeout 120s;


### PR DESCRIPTION
This change increases the timeout on the nginx reverse proxy to handle slow workers during large file uploads.