### PR TITLE
limit filename length in bulk download zip

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -94,7 +94,7 @@ class Submission < ApplicationRecord
   end
 
   def filename_for_bulk_download
-		(users.map(&:tutorial_name).join('-') + '-' +
+		(team.first(180) + '-' +
 			last_modification_by_users_at.strftime("%F-%H%M") +
 			(too_late? ? '-LATE' : '') +
 			+ '-ID-' + id +


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

File names in bulk download zip can become too large for Windows.

* **What is the new behavior (if this is a feature change)?**

File names in bulk download zip cannot become too large for Windows.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
