### PR TITLE
allow putting announcements on MaMpf home page

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -10,6 +10,8 @@ class MainController < ApplicationController
     if user_signed_in?
       cookies[:locale] = strict_cookie(current_user.locale)
     end
+    @announcements = Announcement.where(on_main_page: true,
+                                        lecture: nil).pluck(:details).join
   end
 
   def error

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -43,6 +43,8 @@ class MainController < ApplicationController
                                                                    :term)
                                        .sort
     end
+    @announcements = Announcement.where(on_main_page: true,
+                                        lecture: nil).pluck(:details).join
   end
 
   private

--- a/app/views/announcements/_form.html.erb
+++ b/app/views/announcements/_form.html.erb
@@ -6,6 +6,18 @@
   <div class="invalid-feedback"
        id="announcement-error">
   </div>
+  <% unless announcement.lecture.present? %>
+    <div class="form-group my-3">
+      <div class="custom-control custom-checkbox">
+        <%= f.check_box :on_main_page,
+                        class: 'custom-control-input' %>
+        <%= f.label :on_main_page,
+                    t('admin.announcement.on_main_page'),
+                    { class: 'custom-control-label' } %>
+        <%= helpdesk(t('admin.announcement.info.on_main_page'), false) %>
+      </div>
+    </div>
+  <% end %>
   <%= f.hidden_field :lecture_id, value: @lecture&.id %>
   <div class="row my-2">
     <div class="col-12">

--- a/app/views/announcements/_row.html.erb
+++ b/app/views/announcements/_row.html.erb
@@ -4,6 +4,22 @@
 <div class="col-2">
   <%= announcement.announcer.name %>
 </div>
-<div class="col-8">
+<div class="col-5">
   <%= announcement.details.html_safe %>
+</div>
+<div class="col-1">
+  <%= ballot_box(announcement.on_main_page) %>
+</div>
+<div class="col-2">
+  <% if announcement.on_main_page %>
+  	<%= link_to t('admin.announcement.expel'),
+  							expel_announcement_path(announcement),
+  							class: 'btn btn-sm btn-primary',
+  							method: :post %>
+  <% else %>
+  	<%= link_to t('admin.announcement.propagate'),
+  							propagate_announcement_path(announcement),
+  							class: 'btn btn-sm btn-primary',
+  							method: :post %>
+  <% end %>
 </div>

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -25,9 +25,19 @@
       <%= t('basics.author') %>
     </strong>
   </div>
-  <div class="col-8 text-light">
+  <div class="col-5 text-light">
     <strong>
       <%= t('basics.text') %>
+    </strong>
+  </div>
+  <div class="col-1 text-light">
+    <strong>
+      <%= t('admin.announcement.main_page') %>
+    </strong>
+  </div>
+  <div class="col-2 text-light">
+    <strong>
+      <%= t('basics.action') %>
     </strong>
   </div>
 </div>

--- a/app/views/main/home.html.erb
+++ b/app/views/main/home.html.erb
@@ -7,6 +7,12 @@
           new_user_registration_path(params: {locale: I18n.locale}))) %>
   </div>
 <% end %>
+<% if @announcements.present? %>
+  <div class="alert alert-secondary"
+       role="alert">
+    <%= @announcements.html_safe %>
+  </div>
+<% end %>
 <div class="jumbotron bg-mdb-color-lighten-6">
   <h1>
     <%= image_tag '/MaMpf-Logo_96x96.png', class: 'img-fluid mr-2' %>

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -1,3 +1,9 @@
+<% if @announcements.present? %>
+  <div class="alert alert-secondary"
+       role="alert">
+    <%= @announcements.html_safe %>
+  </div>
+<% end %>
 <div class="accordion" id="subscriptionsAccordion">
 	<% if Term.active %>
 		<div class="card">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -307,6 +307,16 @@ de:
         Hier kannst Du den Text eingeben. Du kannst LaTEX benutzen
         (indem du den Ausdruck in $...$ setzt). Eine Vorschau Deines Textes
         siehst Du unten.
+      on_main_page: >
+        auf Startseite anzeigen
+      main_page: auf Startseite
+      propagate: auf Startseite setzen
+      expel: von Startseite nehmen
+      info:
+        on_main_page: >
+          Wenn Du diesen Haken setzt, wir die Mitteilung auf der
+          MaMpf-Homepage angezeigt. Das bietet sich z.B. an, wenn die Mitteilung
+          eine Ankündigung für Wartungsarbeiten betrifft.
     lecture:
       lecture: 'Vorlesung'
       lecture_short: 'V'
@@ -3161,6 +3171,8 @@ de:
         wurden.
     certificate_already_claimed: >
       Das Zertifikat wurde bereits auf eine andere NutzerIn ausgestellt.
+    no_announcement: >
+      Eine Mitteilung mit dieser id existiert nicht.
   exception:
     title: Fehler
     exception: Exception auf %{host}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,6 +299,17 @@ en:
         Here you can enter the text. You may use LaTEX (by putting the
         corresponding expression inside $...$). You can see a preview of your
         text below.
+      on_main_page: >
+        Display on home page
+      main_page: >
+        On Home Page
+      propagate: set on home page
+      expel: remove from home page
+      info:
+        on_main_page: >
+          If you check this box, the announcement will be displayed on the MaMpf
+          homepage. This can be useful if it is an announcement of a server
+          downtime.
     lecture:
       lecture: 'Lecture'
       lecture_short: 'L'
@@ -2983,6 +2994,7 @@ en:
         already submissions for it that include uploaded files.
     certificate_already_claimed: >
       The certificate has already been claimed by another user.
+    no_announcement: There is no announcement with this id.
   exception:
     title: Error
     exception: Exception on %{host}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,10 @@ Rails.application.routes.draw do
   get '/administration/classification', to: 'administration#classification',
                                         as: 'classification'
 
+  post 'announcements/:id/propagate', to: 'announcements#propagate',
+                                      as: 'propagate_announcement'
+  post 'announcements/:id/expel', to: 'announcements#expel',
+                                  as: 'expel_announcement'
   resources :announcements, only: [ :index, :new, :create]
 
   resources :answers, except: [:index, :show, :edit]

--- a/db/migrate/20201121151659_add_on_main_page_to_announcement.rb
+++ b/db/migrate/20201121151659_add_on_main_page_to_announcement.rb
@@ -1,0 +1,9 @@
+class AddOnMainPageToAnnouncement < ActiveRecord::Migration[6.0]
+  def up
+    add_column :announcements, :on_main_page, :boolean, default: false
+  end
+
+  def down
+    remove_column :announcements, :on_main_page, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_14_125010) do
+ActiveRecord::Schema.define(version: 2020_11_21_151659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_11_14_125010) do
     t.text "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "on_main_page", default: false
     t.index ["announcer_id"], name: "index_announcements_on_announcer_id"
     t.index ["lecture_id"], name: "index_announcements_on_lecture_id"
   end


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

As admin, you can create general announcements, bu there is no way to put them on the MaMpf homepage (which would be useful e.g. to announce server downtimes)

* **What is the new behavior (if this is a feature change)?**

As admin you can set announcements on the homepage (this is done under /announcements) and remove them from the homepage.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Run db:migrate (the announcement table has a new boolean column :on_main_page).