### PR TITLE
Synchronize timeout settings

### DIFF
--- a/app/assets/javascripts/upload.coffee
+++ b/app/assets/javascripts/upload.coffee
@@ -66,7 +66,7 @@ videoUpload = (fileInput) ->
   uppy.use Uppy.XHRUpload,
     endpoint: '/videos/upload'
     fieldName: 'file'
-    timeout: 3600 * 1000
+    timeout: 240 * 1000
 
   # give the user feedback after upload has started
   uppy.on 'upload', (data) ->

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3096,7 +3096,7 @@ de:
     no_lecture: 'Eine Veranstaltung mit der angeforderten id existiert nicht.'
     no_lesson: 'Eine Sitzung mit der angeforderten id existiert nicht.'
     no_page: >
-      Die angeforderte Seit existiert nicht. Du wurdest auf die
+      Die angeforderte Seite existiert nicht. Du wurdest auf die
       MaMpf-Homepage umgeleitet.
     no_video: 'Zu diesem Medium existiert kein Video.'
     no_manuscript: 'Zu diesem Medium existiert kein Manuskript.'

--- a/docker/production/proxy_location_config.txt
+++ b/docker/production/proxy_location_config.txt
@@ -1,3 +1,3 @@
 proxy_set_header  X-Accel-Mapping       /private=/__accel_redirect;
-proxy_read_timeout 120s;
-proxy_send_timeout 120s;
+proxy_read_timeout 240s;
+proxy_send_timeout 240s;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

#143 

* **What is the new behavior (if this is a feature change)?**

Timeouts are different between client and server. This PR synchronizes this. Also, the server sided timeouts are raised to 240s. From my experiments, larger files take a long time to be parsed by Rack (this is what is causing the delay). In the current setup, rasing the timeouts seems to be the only option. The question is of course whether we want that - during the parsing of large files, CPU use is 100% for a long time, probably slowing down the rest of the application. 
EDIT: Parsing probably does not stop when a timeout is triggered, so raising the timeout should probably come with no harm with regards to CPU use.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
