### PR TITLE
restrict access to media

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -81,8 +81,11 @@ class Ability
 
       can :start, :main
 
-      can [:catalog, :search, :play, :display, :geogebra,
-           :register_download, :show_comments], Medium
+      can [:catalog, :search, :register_download, :show_comments], Medium
+      cannot :show, Medium
+      can [:play, :display, :geogebra, :show], Medium do |medium|
+        medium.visible_for_user?(user)
+      end
       can [:update, :enrich, :add_item, :add_reference, :add_screenshot,
            :remove_screenshot, :export_toc, :import_script_items,
            :export_references,

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -9,7 +9,7 @@
             <%= t('content') %>
           </div>
           <div class="col-12 col-lg-8">
-            <% if singular_medium %>
+            <% if singular_medium&.visible_for_user?(current_user) %>
               <span style="display: flex; justify-content: flex-start;">
                   <%= render partial: 'media/medium/buttons',
                              locals: { medium: singular_medium,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

In the lesson view, users could download unpublished media.

* **What is the new behavior (if this is a feature change)?**

Unpublished media cannot be downloaded in the lesson view. Furthermore, access rights for editors to the show action for arbitrary  media that are not related to the editor are not granted any longer.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

see above.

* **Other information**:
