### PR TITLE
add csv export for team names

### DIFF
--- a/app/assets/stylesheets/submissions.scss
+++ b/app/assets/stylesheets/submissions.scss
@@ -60,3 +60,8 @@
 	position: relative;
 	top: 0.25em;
 }
+
+#export-teams:focus, #export-teams:active:focus, #export-teams.active:focus {
+    outline:none;
+    box-shadow:none;
+}

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,8 +1,10 @@
 # TutorialsController
 class TutorialsController < ApplicationController
   before_action :set_tutorial, only: [:edit, :destroy, :update, :cancel_edit,
-                                      :bulk_download, :bulk_upload]
-  before_action :set_assignment, only: [:bulk_download, :bulk_upload]
+                                      :bulk_download, :bulk_upload,
+                                      :export_teams]
+  before_action :set_assignment, only: [:bulk_download, :bulk_upload,
+                                        :export_teams]
   before_action :set_lecture, only: [:index, :overview]
   before_action :set_lecture_from_form, only: [:create]
   before_action :check_tutor_status, only: :index
@@ -93,6 +95,14 @@ class TutorialsController < ApplicationController
   def validate_certificate
     @lecture = Lecture.find_by_id(params[:lecture_id])
     set_tutorial_locale
+  end
+
+  def export_teams
+    respond_to do |format|
+      format.html { head :ok }
+      format.csv { send_data @tutorial.teams_to_csv(@assignment),
+                             filename: "#{@tutorial.title}-#{@assignment.title}.csv" }
+    end
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -149,7 +149,7 @@ class Ability
         tutorial.lecture.edited_by?(user)
       end
 
-      can [:bulk_download, :bulk_upload], Tutorial do |tutorial|
+      can [:bulk_download, :bulk_upload, :export_teams], Tutorial do |tutorial|
         user.in?(tutorial.tutors)
       end
 
@@ -267,7 +267,7 @@ class Ability
         user.tutor?
       end
 
-      can [:bulk_download, :bulk_upload], Tutorial do |tutorial|
+      can [:bulk_download, :bulk_upload, :export_teams], Tutorial do |tutorial|
         user.in?(tutorial.tutors)
       end
 

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,7 @@
 # Tutorial model
 class Tutorial < ApplicationRecord
+  require 'csv'
+
   belongs_to :lecture, touch: true
 
   has_many :tutor_tutorial_joins, dependent: :destroy

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -68,6 +68,16 @@ class Tutorial < ApplicationRecord
     report
   end
 
+  def teams_to_csv(assignment)
+    submissions = Submission.where(tutorial: self, assignment: assignment)
+
+    CSV.generate(headers: false) do |csv|
+      submissions.each do |s|
+        csv << [s.team]
+      end
+    end
+  end
+
   private
 
   def check_destructibility

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -65,7 +65,8 @@
                     export_teams_to_csv_path(id: @tutorial.id,
                                              ass_id: @assignment.id,
                                              format: 'csv'),
-                    class: "btn btn-primary ml-3" %>
+                    class: 'btn btn-primary ml-3',
+                    id: 'export-teams' %>
       <% end %>
       <%= link_to t('tutorial.certificate_check'),
                   validate_certificate_as_tutor_path(params:

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -61,6 +61,11 @@
                 id="show-bulk-upload-area">
           <%= t('submission.bulk_upload') %>
         </button>
+        <%= link_to t('tutorial.teams_as_csv'),
+                    export_teams_to_csv_path(id: @tutorial.id,
+                                             ass_id: @assignment.id,
+                                             format: 'csv'),
+                    class: "btn btn-primary ml-3" %>
       <% end %>
       <%= link_to t('tutorial.certificate_check'),
                   validate_certificate_as_tutor_path(params:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2618,6 +2618,7 @@ de:
     certificate_valid: >
       Der Code ist gültig. Er gehört zu NutzerIn %{user} und zum Quiz %{quiz}.
     certificate_invalid: Der Code ist ungültig.
+    teams_as_csv: Teams als .csv
     bulk_upload:
       report: Bericht zum Paketupload der Korrekturen
       number_of_submissions: Anzahl der Abgaben

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2456,6 +2456,7 @@ en:
       informed about the user and the quiz that this certificate belongs to.
     certificate_valid: >
       The code is valid. It belongs to user %{user} and quiz %{quiz}.
+    teams_as_csv: Teams as .csv
     certificate_invalid: This code is invalid.
     bulk_upload:
       report: Report on the bulk upload of the corrections

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -367,6 +367,10 @@ Rails.application.routes.draw do
       to: 'tutorials#validate_certificate',
       as: 'validate_certificate_as_tutor'
 
+  get 'tutorials/:id/assignments/:ass_id/export_teams',
+      to: 'tutorials#export_teams',
+      as: 'export_teams_to_csv'
+
   resources :tutorials, only: [ :new, :edit, :create, :update, :destroy]
 
   get 'sections/list_tags', to: 'sections#list_tags',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

A button has been added in the tutorial view for tutors that allows them to  download a .csv file with just one column that contains the names of all teams.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
