### PR TITLE
remove integer id from submission

### DIFF
--- a/db/migrate/20201129133117_remove_integer_id_from_submission.rb
+++ b/db/migrate/20201129133117_remove_integer_id_from_submission.rb
@@ -1,0 +1,9 @@
+class RemoveIntegerIdFromSubmission < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :submissions, :integer_id, :integer
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_223030) do
+ActiveRecord::Schema.define(version: 2020_11_29_133117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -486,7 +486,6 @@ ActiveRecord::Schema.define(version: 2020_11_24_223030) do
   end
 
   create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "integer_id", default: -> { "nextval('submissions_id_seq'::regclass)" }, null: false
     t.bigint "tutorial_id", null: false
     t.bigint "assignment_id", null: false
     t.text "token"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix (kind of)

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

The integer_id column in the submission model (which has been uuid based since some migration) prevents db:schema:load form working. 

* **What is the new behavior (if this is a feature change)?**

The interger_id column has been removed. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Run `db:migrate`.