### PR TITLE
nginx no access_log and :cache_memcached

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :dalli_store, ENV["MEMCACHED_SERVER"]
+  config.cache_store = :mem_cache_store, ENV["MEMCACHED_SERVER"]
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/docker/production/Dockerfile.proxy
+++ b/docker/production/Dockerfile.proxy
@@ -2,7 +2,10 @@ FROM jwilder/nginx-proxy:alpine
 
 # Change the uid of nginx to the same as mampf-container
 RUN sed -i 's/^nginx.\+/nginx\:x\:501\:501\:nginx\:\/var\/cache\/nginx\:\/sbin\/nologin/' /etc/passwd
+# We need to manually configure the root location, so the actual proxy pass needs to be inside a special location we can
+# redirect to
 RUN sed -i 's/^\(\s*\)location \/ {\(\s*\)$/\1location @rails {\2/' /app/nginx.tmpl
+
 RUN mkdir /private /public
 
 

--- a/docker/production/proxy_server_config.txt
+++ b/docker/production/proxy_server_config.txt
@@ -1,4 +1,5 @@
 root /public;
+access_log off;
 
 location / {
     client_max_body_size 4G;


### PR DESCRIPTION
This commit disables the nginx access
logs, so only warnings remain.

Additionally the dallii store memcached
client is replaced by the rails version
that uses dallii in the background
anyway. This should remove the relevant
deprecation warnings during container
builds.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
