### PR TITLE
remove redundant course_user_join_model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,6 @@ class ApplicationController < ActionController::Base
                                                              edited_courses: [:editors, lectures: [:term, :teacher]],
                                                              edited_lectures: [:course, :term, :teacher],
                                                              given_lectures: [:course, :term, :teacher],
-                                                             course_user_joins: [:course],
                                                              notifications: [:notifiable]])
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,10 +17,6 @@ class Course < ApplicationRecord
   has_many :imports, as: :teachable, dependent: :destroy
   has_many :imported_media, through: :imports, source: :medium
 
-  # users in this context are users who have subscribed to this course
-  has_many :course_user_joins, dependent: :destroy
-  has_many :users, -> { distinct }, through: :course_user_joins
-
   # preceding courses are courses that this course is based upon
   has_many :course_self_joins, dependent: :destroy
   has_many :preceding_courses, through: :course_self_joins

--- a/app/models/course_user_join.rb
+++ b/app/models/course_user_join.rb
@@ -1,7 +1,0 @@
-# CourseUserJoin class
-# JoinTable for course <-> user many-to-many-relation
-# that describes which sers whave subscribed to which courses
-class CourseUserJoin < ApplicationRecord
-  belongs_to :course
-  belongs_to :user
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,6 @@ class User < ApplicationRecord
            through: :user_favorite_lecture_joins,
            source: :lecture
 
-  # a user has many subscribed courses
-  has_many :course_user_joins, dependent: :destroy
-
   # a user has many courses as an editor
   has_many :editable_user_joins, foreign_key: :user_id, dependent: :destroy
   has_many :edited_courses, through: :editable_user_joins,

--- a/db/migrate/20201213123754_drop_course_user_join_table.rb
+++ b/db/migrate/20201213123754_drop_course_user_join_table.rb
@@ -1,0 +1,9 @@
+class DropCourseUserJoinTable < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :course_user_joins
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_06_161307) do
+ActiveRecord::Schema.define(version: 2020_12_13_123754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -141,16 +141,6 @@ ActiveRecord::Schema.define(version: 2020_12_06_161307) do
     t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_course_tag_joins_on_course_id"
     t.index ["tag_id"], name: "index_course_tag_joins_on_tag_id"
-  end
-
-  create_table "course_user_joins", force: :cascade do |t|
-    t.bigint "course_id"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "primary_lecture_id"
-    t.index ["course_id"], name: "index_course_user_joins_on_course_id"
-    t.index ["user_id"], name: "index_course_user_joins_on_user_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -852,8 +842,6 @@ ActiveRecord::Schema.define(version: 2020_12_06_161307) do
   add_foreign_key "commontator_comments", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "commontator_subscriptions", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_self_joins", "courses"
-  add_foreign_key "course_user_joins", "courses"
-  add_foreign_key "course_user_joins", "users"
   add_foreign_key "divisions", "programs"
   add_foreign_key "imports", "media"
   add_foreign_key "items", "media"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Removal of redundant stuff

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

The course_user_join model is removed from the codebases. It has been redundant for a while, but is has apparently been forgotten to remove it.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
