### PR TITLE
Add substitute method for users in course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -207,6 +207,11 @@ class Course < ApplicationRecord
     false
   end
 
+  def users
+    User.where(id: LectureUserJoin.where(lecture: lectures)
+                                  .pluck(:user_id).uniq)
+  end
+
   # a course is addable by the user if the user is an editor or teacher of
   # this course or a lecture of this course
   def addable_by?(user)

--- a/app/views/courses/_basics.html.erb
+++ b/app/views/courses/_basics.html.erb
@@ -131,11 +131,4 @@
                      data: { ajax: false } } %>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <%= t('basics.subscribers_count',
-          count: course.users&.count) %>
-      <%= helpdesk(t('admin.course.info.subscribers_count'), false) %>
-    </div>
-  </div>
 </div>

--- a/app/views/courses/_basics.html.erb
+++ b/app/views/courses/_basics.html.erb
@@ -131,4 +131,11 @@
                      data: { ajax: false } } %>
     </div>
   </div>
+  <div class="row">
+    <div class="col-12">
+      <%= t('basics.subscribers_count',
+          count: course.users.count) %>
+      <%= helpdesk(t('admin.course.info.subscribers_count'), false) %>
+    </div>
+  </div>
 </div>

--- a/app/views/courses/_inspection_details.html.erb
+++ b/app/views/courses/_inspection_details.html.erb
@@ -86,6 +86,15 @@
             </ul>
           </div>
         </div>
+        <div class="row mt-2">
+          <div class="col-2">
+            <%= t('basics.subscribers_count_nc') %>
+            <%= helpdesk(t('admin.course.info.subscribers_count'), false) %>
+          </div>
+          <div class="col-10">
+            <%= course.users.count %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/courses/_inspection_details.html.erb
+++ b/app/views/courses/_inspection_details.html.erb
@@ -86,15 +86,6 @@
             </ul>
           </div>
         </div>
-        <div class="row mt-2">
-          <div class="col-2">
-            <%= t('basics.subscribers_count_nc') %>
-            <%= helpdesk(t('admin.course.info.subscribers_count'), false) %>
-          </div>
-          <div class="col-10">
-            <%= course.users&.count %>
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -688,8 +688,8 @@ de:
           Dies ist die Liste aller Veranstaltungen zu diesem Modul.
           Unveröffentlichte Veranstaltungen sind in rötlicher Farbe gekennzeichnet.
         subscribers_count: >
-          Das ist die Zahl aller NutzerInnen, die diese
-          Veranstaltung in ihrem Profil abonniert haben.
+          Das ist die Zahl aller NutzerInnen, die Veranstaltungen aus
+          diesem Modul abonniert haben.
         tags: >
           Das ist die Liste aller zu diesem Modul
           assoziierten Tags. Diese korrespondieren typischerweise

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -653,8 +653,8 @@ en:
           This is the list of event series for this course.
           Unpublished event series are displayed in red.
         subscribers_count: >
-          This is the number of all users who have subscribed this event series in
-          their profile settings.
+          This is the number of all users who have subscribed event series
+          associated to this course.
         tags: >
           This is the list of all tags that are associated to this course.
           Typically they correspond to the content of the module handbook.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

In #189 we removed the course/user join table. Unfortunately we overlooked to references to to course#users in the views.

* **What is the new behavior (if this is a feature change)?**

Write a course#users method that takes into account all users who have subscribed to lectures in that course.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
