### PR TITLE
update the pdfcomprezzor to use docker 1.16

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,18 +1,15 @@
 # First build the PDF compressor Web assembly binary
-FROM golang:1.15 AS build-pdfcomprezzor
+FROM golang:1.16 AS build-pdfcomprezzor
 WORKDIR /go/src
 COPY pdfcomprezzor/go.mod .
 COPY pdfcomprezzor/go.sum .
 COPY pdfcomprezzor/main.go .
-RUN go mod vendor
-RUN sed -i 's/init(/init2(/g' vendor/github.com/pdfcpu/pdfcpu/pkg/font/metrics.go
 RUN GOOS=js GOARCH=wasm go build -o pdfcomprezzor.wasm
 
 # Now build the actual mampf application
 FROM ruby:2.7.2
 ENV RAILS_ENV=production
 EXPOSE 3000
-#ENTRYPOINT [""]
 
 # https://github.com/nodesource/distributions#installation-instructions
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,13 +1,10 @@
 # First build the PDF compressor Web assembly binary
-FROM golang:1.15 AS build-pdfcomprezzor
+FROM golang:1.16 AS build-pdfcomprezzor
 WORKDIR /go/src
 COPY pdfcomprezzor/go.mod .
 COPY pdfcomprezzor/go.sum .
 COPY pdfcomprezzor/main.go .
-RUN go mod vendor
-RUN sed -i 's/init(/init2(/g' vendor/github.com/pdfcpu/pdfcpu/pkg/font/metrics.go
 RUN GOOS=js GOARCH=wasm go build -o pdfcomprezzor.wasm
-
 
 # Now build the actual mampf application
 FROM ruby:2.7.2

--- a/docker/run_cypress_tests/Dockerfile
+++ b/docker/run_cypress_tests/Dockerfile
@@ -1,18 +1,15 @@
 # First build the PDF compressor Web assembly binary
-FROM golang:1.15 AS build-pdfcomprezzor
+FROM golang:1.16 AS build-pdfcomprezzor
 WORKDIR /go/src
 COPY pdfcomprezzor/go.mod .
 COPY pdfcomprezzor/go.sum .
 COPY pdfcomprezzor/main.go .
-RUN go mod vendor
-RUN sed -i 's/init(/init2(/g' vendor/github.com/pdfcpu/pdfcpu/pkg/font/metrics.go
 RUN GOOS=js GOARCH=wasm go build -o pdfcomprezzor.wasm
 
 # Now build the actual mampf application
 FROM ruby:2.7.2
 ENV RAILS_ENV=production
 EXPOSE 3000
-#ENTRYPOINT [""]
 
 # https://github.com/nodesource/distributions#installation-instructions
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

update the pdfcomprezzor build process to use the newest version of docker! 

Note that there currently is no test for the upload feature .. Testing has been done manually :blush: