### PR TITLE
fix error related to who can schedule a publication

### DIFF
--- a/app/models/medium_publisher.rb
+++ b/app/models/medium_publisher.rb
@@ -59,7 +59,7 @@ class MediumPublisher
     @medium = Medium.find_by_id(@medium_id)
     @user = User.find_by_id(@user_id)
     return unless @medium && @user && @medium.released_at.nil?
-    return unless @medium.edited_by?(@user) || @user.admin
+    return unless @user.in?(@medium.editors_with_inheritance) || @user.admin
 
     update_medium!
     realize_optional_stuff!


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

If a publication was scheduled for a medium by someone who is not an editor a the medium itself (e.g. a teacher of the associated lecture who did not edit the medium himself), then the publication would not occur at the scheduled time.

* **What is the new behavior (if this is a feature change)?**

All persons who can edit the medium (with inhericance) can properly schedule publication. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
