### PR TITLE
outdated link removed

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2397,7 +2397,6 @@ de:
     interested_html:
       Neugierig geworden? Auf unserem %{blog} und auf %{researchgate} findest Du weitere Informationen über
       und Neuigkeiten zu MaMpf. %{guided_tour} gibt es eine geführte Tour durch MaMpf.
-      Außerdem gelangst Du auf diesem %{resources} zu Ressourcen für EditorInnen (z.B. zum MaMpf-LaTeX-Paket).
     resources: Weg
     blog: Blog
     researchgate: Researchgate


### PR DESCRIPTION
The mampf-package is now available elsewhere. It might be necessary to delete "resources: Weg" (l. 2400) too.