### PR TITLE
outdated link removed

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2253,8 +2253,7 @@ en:
       guided proofs'
     interested_html: >
       Curious? On our %{blog} and on %{researchgate} you can find more information and news about MaMpf.
-      %{guided_tour} you can find a guided tour of MaMpf. Resources for editors
-      (e.g. the MaMpf LaTEX package) are available %{resources}.
+      %{guided_tour} you can find a guided tour of MaMpf.
     resources: here
     blog: Blog
     researchgate: Researchgate


### PR DESCRIPTION
The MaMpf-package can be found elsewhere. It might be necessary to delete "resources: here" (l. 2257) too.