### PR TITLE
Playback statistics

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -375,12 +375,12 @@ class MediaController < ApplicationController
     medium_consumption = Consumption.where(medium_id: @medium.id)
     if @medium.video.present?
       @video_downloads = medium_consumption.where(sort: 'video',
-                                                  mode: 'download').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
+                                                  mode: 'download').pluck(:created_at).map(&:to_date).tally.map{|k,t| {x: k,y:t}}.to_json
       @video_thyme = medium_consumption.where(sort: 'video',
-                                              mode: 'thyme').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
+                                              mode: 'thyme').pluck(:created_at).map(&:to_date).tally.map{|k,t| {x: k,y:t}}.to_json
     end
     if @medium.manuscript.present?
-      @manuscript_access = medium_consumption.where(sort: 'manuscript').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
+      @manuscript_access = medium_consumption.where(sort: 'manuscript').pluck(:created_at).map(&:to_date).tally.map{|k,t| {x: k,y:t}}.to_json
     end
     if @medium.sort == 'Quiz'
       @quiz_access = Probe.finished_quizzes(@medium)

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -375,9 +375,9 @@ class MediaController < ApplicationController
     medium_consumption = Consumption.where(medium_id: @medium.id)
     if @medium.video.present?
       @video_downloads = medium_consumption.where(sort: 'video',
-                                                  mode: 'download').count
+                                                  mode: 'download').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
       @video_thyme = medium_consumption.where(sort: 'video',
-                                              mode: 'thyme').count
+                                              mode: 'thyme').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
     end
     if @medium.manuscript.present?
       @manuscript_access = medium_consumption.where(sort: 'manuscript').count

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -380,7 +380,7 @@ class MediaController < ApplicationController
                                               mode: 'thyme').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
     end
     if @medium.manuscript.present?
-      @manuscript_access = medium_consumption.where(sort: 'manuscript').count
+      @manuscript_access = medium_consumption.where(sort: 'manuscript').map.with_index{|c,i| {x: c.created_at,y:i+1}}.to_json
     end
     if @medium.sort == 'Quiz'
       @quiz_access = Probe.finished_quizzes(@medium)

--- a/app/views/layouts/_head_additional_js.html.erb
+++ b/app/views/layouts/_head_additional_js.html.erb
@@ -1,8 +1,6 @@
-<link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.css"
-      integrity="sha256-aa0xaJgmK/X74WM224KMQeNQC2xYKwlAt08oZqjeF0E="
-      crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"
-        integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI="
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"
+        integrity="sha512-Wt1bJGtlnMtGP0dqNFH1xlkLBNpEodaiQ8ZN5JLA5wpc1sUlk/O5uuOMNgvzddzkpvZ9GLyYNa8w2s7rqiTk5Q=="
         crossorigin="anonymous">
 </script>
+<script src="https://cdn.jsdelivr.net/npm/moment@2.27.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>

--- a/app/views/layouts/_head_additional_js.html.erb
+++ b/app/views/layouts/_head_additional_js.html.erb
@@ -2,5 +2,5 @@
         integrity="sha512-Wt1bJGtlnMtGP0dqNFH1xlkLBNpEodaiQ8ZN5JLA5wpc1sUlk/O5uuOMNgvzddzkpvZ9GLyYNa8w2s7rqiTk5Q=="
         crossorigin="anonymous">
 </script>
-<script src="https://cdn.jsdelivr.net/npm/moment@2.27.0"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment-with-locales.min.js" integrity="sha512-LGXaggshOkD/at6PFNcp2V2unf9LzFq6LE+sChH7ceMTDP0g2kn6Vxwgg7wkPP7AAtX+lmPqPdxB47A0Nz0cMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-adapter-moment/1.0.0/chartjs-adapter-moment.min.js" integrity="sha512-oh5t+CdSBsaVVAvxcZKy3XJdP7ZbYUBSRCXDTVn0ODewMDDNnELsrG9eDm8rVZAQg7RsDD/8K3MjPAFB13o6eA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/app/views/media/_statistics.html.erb
+++ b/app/views/media/_statistics.html.erb
@@ -69,22 +69,9 @@
         <%= t('video.video') %>
       </strong>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <%= t('statistics.video_thyme') %>
-    </div>
-    <div class="col-4 text-right">
-      <%= video_thyme %>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <%= t('statistics.video_downloads') %>
-    </div>
-    <div class="col-4 text-right">
-      <%= video_downloads %>
-    </div>
+    <div class="col-12" width="300px">
+    <canvas id="videoStats"> <!-- data-videostats="<%= video_thyme %>" data-downloads="<%= video_downloads%>" -->
+    </canvas>
   </div>
 <% end %>
 <% if medium.manuscript.present? %>

--- a/app/views/media/_statistics.html.erb
+++ b/app/views/media/_statistics.html.erb
@@ -63,15 +63,16 @@
   </div>
 <% end %>
 <% if medium.video.present? %>
-  <div class="row">
+  <div class="row mt-3">
     <div class="col-12">
       <strong>
         <%= t('video.video') %>
       </strong>
     </div>
-    <div class="col-12" width="300px">
-    <canvas id="videoStats"> <!-- data-videostats="<%= video_thyme %>" data-downloads="<%= video_downloads%>" -->
-    </canvas>
+    <div style="width: 400px;">
+      <canvas id="videoStats">
+      </canvas>
+    </div>
   </div>
 <% end %>
 <% if medium.manuscript.present? %>

--- a/app/views/media/_statistics.html.erb
+++ b/app/views/media/_statistics.html.erb
@@ -68,27 +68,25 @@
       <strong>
         <%= t('video.video') %>
       </strong>
-    </div>
-    <div style="width: 400px;">
-      <canvas id="videoStats">
+    
+      <div style="height: 20vh">
+      <canvas id="videoStats" >
       </canvas>
+      </div>
     </div>
   </div>
 <% end %>
 <% if medium.manuscript.present? %>
-  <div class="row">
+  <div class="row mt-3">
     <div class="col-12">
       <strong>
         <%= t('manuscript.manuscript') %>
       </strong>
+    
+    <div style="height: 20vh">
+      <canvas id="manuscriptStats" >
+      </canvas>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <%= t('statistics.manuscript_access') %>
-    </div>
-    <div class="col-4 text-right">
-      <%= manuscript_access %>
     </div>
   </div>
 <% end %>

--- a/app/views/media/get_statistics.coffee
+++ b/app/views/media/get_statistics.coffee
@@ -77,7 +77,7 @@ myChart = new Chart(ctx,
         type: 'time'
         time: 
           unit: 'month'
-          tooltipFormat: 'DD T'
+          tooltipFormat: 'DD.MM.'
         title:
           display: true
           text: 'Date'

--- a/app/views/media/get_statistics.coffee
+++ b/app/views/media/get_statistics.coffee
@@ -42,7 +42,6 @@ myChart = new Chart(ctx,
 <% if @medium.sort == 'Kaviar' %>
 
 ctx = $('#videoStats')
-console.log(<%= raw @video_thyme %>)
 data2=  <%= raw @video_thyme %>
 data4=  <%= raw @video_downloads %>
 data3 = data2.map((d)-> {x:new Date(d.x),y:d.y})
@@ -64,7 +63,6 @@ data =
       data: data4
     }
   ]
-console.log data
 myChart = new Chart(ctx,
   type: 'line'
   data: data
@@ -72,6 +70,8 @@ myChart = new Chart(ctx,
     plugins: title:
       text: 'Video'
       display: true
+    responsive: true
+    maintainAspectRatio: false
     scales:
       x:
         type: 'time'
@@ -81,9 +81,52 @@ myChart = new Chart(ctx,
         title:
           display: true
           text: 'Date'
-      y: title:
-        display: true
-        text: 'count' )
+      y: 
+        ticks:
+          precision: 0
+        title:
+          display: true
+          text: 'count' )
 <% end %>
+<% if @medium.manuscript.present? %>
 
+ctx = $('#manuscriptStats')
+data21=  <%= raw @manuscript_access %>
+data31 = data21.map((d)-> {x:new Date(d.x),y:d.y})
+data = 
+  labels: data21.map((d)-> return d.x)
+  datasets: [
+    {
+      label: 'Downloads'
+      backgroundColor: '#4dc9f6'
+      borderColor: '#4dc9f6'
+      fill: false
+      data: data31
+    }
+  ]
+myChart = new Chart(ctx,
+  type: 'line'
+  data: data
+  options:
+    plugins: title:
+      text: 'Manuscript'
+      display: true
+    responsive: true
+    maintainAspectRatio: false
+    scales:
+      x:
+        type: 'time'
+        time: 
+          unit: 'month'
+          tooltipFormat: 'DD.MM.'
+        title:
+          display: true
+          text: 'Date'
+      y: 
+        ticks:
+          precision: 0
+        title:
+          display: true
+          text: 'count' )
+<% end %>
 $('#statisticsModal').modal('show')

--- a/app/views/media/get_statistics.coffee
+++ b/app/views/media/get_statistics.coffee
@@ -83,7 +83,7 @@ myChart = new Chart(ctx,
           text: 'Date'
       y: title:
         display: true
-        text: 'value' )
+        text: 'count' )
 <% end %>
 
 $('#statisticsModal').modal('show')

--- a/app/views/media/get_statistics.coffee
+++ b/app/views/media/get_statistics.coffee
@@ -42,5 +42,46 @@ myChart = new Chart(ctx,
           beginAtZero: true
           precision: 0] )
 <% end %>
+<% if @medium.sort == 'Kaviar' %>
+Chart.platform.disableCSSInjection = true;
+Chart.defaults.global.elements.rectangle.backgroundColor = 'rgba(255, 99, 132, 0.2)'
+Chart.defaults.global.elements.rectangle.borderColor =  'rgba(255, 99, 132, 1)'
+
+ctx = $('#videoStats')
+console.log(<%= raw @video_thyme %>)
+data2=  <%= raw @video_thyme %>
+data3 = data2.map((d)-> {x:new Date(d.x),y:d.y})
+data = 
+  labels: data2.map((d)-> return d.x)
+  datasets: [
+    {
+      label: 'Thyme'
+      backgroundColor: '#4dc9f6'
+      borderColor: '#4dc9f6'
+      fill: false
+      data: data3
+    }
+  ]
+console.log data
+myChart = new Chart(ctx,
+  type: 'line'
+  data: data
+  options:
+    plugins: title:
+      text: 'Chart.js Time Scale'
+      display: true
+    scales:
+      x:
+        type: 'time'
+        time: 
+          unit: 'month'
+          tooltipFormat: 'DD T'
+        title:
+          display: true
+          text: 'Date'
+      y: title:
+        display: true
+        text: 'value' )
+<% end %>
 
 $('#statisticsModal').modal('show')

--- a/app/views/media/get_statistics.coffee
+++ b/app/views/media/get_statistics.coffee
@@ -14,9 +14,6 @@ $('#statistics-modal-content').empty()
 $('[data-toggle="popover"]').popover()
 
 <% if @medium.sort == 'Quiz' %>
-Chart.platform.disableCSSInjection = true;
-Chart.defaults.global.elements.rectangle.backgroundColor = 'rgba(255, 99, 132, 0.2)'
-Chart.defaults.global.elements.rectangle.borderColor =  'rgba(255, 99, 132, 1)'
 
 ctx = $('#successChart')
 myChart = new Chart(ctx,
@@ -43,13 +40,11 @@ myChart = new Chart(ctx,
           precision: 0] )
 <% end %>
 <% if @medium.sort == 'Kaviar' %>
-Chart.platform.disableCSSInjection = true;
-Chart.defaults.global.elements.rectangle.backgroundColor = 'rgba(255, 99, 132, 0.2)'
-Chart.defaults.global.elements.rectangle.borderColor =  'rgba(255, 99, 132, 1)'
 
 ctx = $('#videoStats')
 console.log(<%= raw @video_thyme %>)
 data2=  <%= raw @video_thyme %>
+data4=  <%= raw @video_downloads %>
 data3 = data2.map((d)-> {x:new Date(d.x),y:d.y})
 data = 
   labels: data2.map((d)-> return d.x)
@@ -61,6 +56,13 @@ data =
       fill: false
       data: data3
     }
+    {
+      label: 'Downloads'
+      backgroundColor: '#990000'
+      borderColor: '#990000'
+      fill: false
+      data: data4
+    }
   ]
 console.log data
 myChart = new Chart(ctx,
@@ -68,7 +70,7 @@ myChart = new Chart(ctx,
   data: data
   options:
     plugins: title:
-      text: 'Chart.js Time Scale'
+      text: 'Video'
       display: true
     scales:
       x:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updates the chart.js dependency and creates plots for video access and downloads.


<img width="302" alt="Bildschirmfoto 2021-08-25 um 10 59 09" src="https://user-images.githubusercontent.com/10349817/130761190-bd93b759-cf63-4b7b-b1f1-9aa33349f07c.png">



* **What is the current behavior?** (You can also link to an open issue here)

The statistics only show the total number of downloads/thyme play backs.



* **What is the new behavior (if this is a feature change)?**

There is a nice plot.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
