### PR TITLE
Fix upload bug

### DIFF
--- a/app/assets/javascripts/upload.coffee
+++ b/app/assets/javascripts/upload.coffee
@@ -380,7 +380,7 @@ directUpload provides an interface to upload (multiple) files to an endpoint
             if  i == (fileInput.files.length)
               uploadedFiles2 = uploadedFiles
               if single
-                uploadedFiles2 = uploadedFiles[0]
+                [..., uploadedFiles2] = uploadedFiles
               $(progressBarElement).text(
                 $(progressBarElement).data 'tr-success'
               )
@@ -407,7 +407,7 @@ directUpload provides an interface to upload (multiple) files to an endpoint
               $(progressBarElement).data('tr-failure') + xhr.response
             )
         xhr.onload = onload(xhr)
-        
+
         xhr.onerror = onerror
         xhr.upload.onprogress = onprogress
         f = fileInput.files[0]

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -224,8 +224,9 @@ class Submission < ApplicationRecord
           report[:invalid_filenames].push(filename)
           next
         end
-        submission = Submission.find_by_id(filename.split('-ID-').last
-                                                .remove('.pdf'))
+        submission_id = File.basename(filename.split('-ID-').last,
+                                        File.extname(filename.split('-ID-').last))
+        submission = Submission.find_by_id(submission_id)
         if !submission
           report[:invalid_id].push(filename)
           next

--- a/app/views/tutorials/_bulk_correction_form.html.erb
+++ b/app/views/tutorials/_bulk_correction_form.html.erb
@@ -1,4 +1,4 @@
-<input type="file" accept="application/pdf" id="upload-bulk-correction"
+<input type="file" id="upload-bulk-correction"
  multiple=true/>
 <%= form_with url: bulk_upload_corrections_path(id: @tutorial.id,
                                                 ass_id: @assignment.id),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the behaviour described by the following comment:
"Ich habe gerade glaube ich einen Bug in dem Upload-js-Paket von Henrik Reinstädtler Henrik gefunden: Wenn man bei einem Medium bei einem Video statt eines .mp4 ein .pdf hochlädt, kriegt man korrekterweise angezeigt, dass es den falschen mime-typ hat. Wenn man direkt danach ein .mp4 hochlädt, sieht es so aus, als habe der Upload geklappt. Wenn man dann aber speichert, wird das Medium gar nicht gespeichert (es gibt einen Rollback). Offenbar wird in dem Formular was falsches übermittelt."

The issue was that uploading multiple files in a form that only supports one file still lead to a list being populated, out of which only the first element was utilized. This is now changed so that if it is a single-file form, the last element gets used in the form.

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
