### PR TITLE
allowed other filetypes for bulkupload

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -224,8 +224,9 @@ class Submission < ApplicationRecord
           report[:invalid_filenames].push(filename)
           next
         end
-        submission = Submission.find_by_id(filename.split('-ID-').last
-                                                .remove('.pdf'))
+        submission_id = File.basename(filename.split('-ID-').last,
+                                        File.extname(filename.split('-ID-').last))
+        submission = Submission.find_by_id(submission_id)
         if !submission
           report[:invalid_id].push(filename)
           next

--- a/app/views/tutorials/_bulk_correction_form.html.erb
+++ b/app/views/tutorials/_bulk_correction_form.html.erb
@@ -1,4 +1,4 @@
-<input type="file" accept="application/pdf" id="upload-bulk-correction"
+<input type="file" id="upload-bulk-correction"
  multiple=true/>
 <%= form_with url: bulk_upload_corrections_path(id: @tutorial.id,
                                                 ass_id: @assignment.id),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Changed filetypes for bulkupload of corrections to allow all types. Tested on experimental.

(Small) Issue:
If you bulkupload zip files, the files in the zip get counted to the total, meaning number of successful correction uploads can exceed the number of submissions currently.