### PR TITLE
Imap server

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -38,6 +38,17 @@ services:
     ports:
       - "127.0.0.1:1080:1080"
 
+  imap:
+    image: antespi/docker-imap-devel:latest
+    ports:
+      - "1025:25"
+      - "10143:143"
+      - "10993:993"
+    environment:
+      - MAILNAME=localhost
+      - MAIL_ADDRESS=mampf@localhost
+      - MAIL_PASS=mampf
+
   mampf:
     build:
       context: ./../..
@@ -79,10 +90,11 @@ services:
       WEBPACKER_DEV_SERVER_HOST: webpacker
       MAMPF_REGISTRATION_TIMEFRAME: 25
       MAMPF_MAX_REGISTRATION_PER_TIMEFRAME: 40
-      IMAPSERVER: localhost
+      IMAPSERVER: imap:10993
+      IMAP_TLS_IGNORE_CERT: 1
       PROJECT_EMAIL_USERNAME: mampf
       PROJECT_EMAIL_PASSWORD: mampf
-      PROJECT_EMAIL_MAILBOX: mampf
+      PROJECT_EMAIL_MAILBOX: INBOX
       # uncomment DB_SQL_PRESEED_URL and UPLOADS_PRESEED_URL to enable db preseeding
       # DB_SQL_PRESEED_URL: "https://heibox.uni-heidelberg.de/d/6fb4a9d2e7f54d8b9931/files/?p=%2F20201128165713_mampf.sql&dl=1"
       # UPLOADS_PRESEED_URL: "https://heibox.uni-heidelberg.de/f/d2f72a4069814debaf69/?dl=1"

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -79,6 +79,10 @@ services:
       WEBPACKER_DEV_SERVER_HOST: webpacker
       MAMPF_REGISTRATION_TIMEFRAME: 25
       MAMPF_MAX_REGISTRATION_PER_TIMEFRAME: 40
+      IMAPSERVER: localhost
+      PROJECT_EMAIL_USERNAME: mampf
+      PROJECT_EMAIL_PASSWORD: mampf
+      PROJECT_EMAIL_MAILBOX: mampf
       # uncomment DB_SQL_PRESEED_URL and UPLOADS_PRESEED_URL to enable db preseeding
       # DB_SQL_PRESEED_URL: "https://heibox.uni-heidelberg.de/d/6fb4a9d2e7f54d8b9931/files/?p=%2F20201128165713_mampf.sql&dl=1"
       # UPLOADS_PRESEED_URL: "https://heibox.uni-heidelberg.de/f/d2f72a4069814debaf69/?dl=1"

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: "redis:alpine"
 
   solr:
-    image: "solr:8"
+    image: "solr:8.11"
     ports:
       - "127.0.0.1:8983:8983"
     volumes:

--- a/docker/production/docker-compose.production.yml
+++ b/docker/production/docker-compose.production.yml
@@ -63,7 +63,7 @@ services:
       - default
 
   solr:
-    image: solr:8.1
+    image: solr:8.11
     container_name: solr
     ports:
       - "127.0.0.1:8983:8983"

--- a/docker/production/docker.env
+++ b/docker/production/docker.env
@@ -16,6 +16,10 @@ MAILSERVER=mail.mathi.uni-heidelberg.de
 PROJECT_EMAIL=mampf@mathi.uni-heidelberg.de
 ERROR_EMAIL=mampf-error@mathi.uni-heidelberg.de
 MAILID_DOMAIN=mathi.uni-heidelberg.de
+IMAPSERVER=mail.mathi.uni-heidelberg.de
+PROJECT_EMAIL_USERNAME=creativeusername
+PROJECT_EMAIL_PASSWORD=secretsecret
+PROJECT_EMAIL_MAILBOX=Other Users/mampf
 
 # Due to CORS constraints, some urls are proxied to the media server
 DOWNLOAD_LOCATION=https://mampf.mathi.uni-heidelberg.de/mediaforward


### PR DESCRIPTION
Hey,

here are the changes to environment variables in production. I've also added an IMAP container to the development setup.

Note the additional variable IMAP_IGNORE_TLS_CERT=1 in development. The development server runs with TLS, but uses a self-signed certificate. You can setup your mail client as described [here](https://github.com/antespi/docker-imap-devel). Username is mampf@localhost, password: mampf. Take a look at the changes in docker-compose.yaml to find out what the actual values for the ports are.

The SMTP Server is separate from the one offered by mailcatcher and there currently is no environment variable indicating where to find it. (it listens on port 1025). Maybe if you want to add automated tests, you should add an other variable yourself.

In addition to all this I took the liberty to bump solr to 8.11 in development too. In production this change happened during Log4Shell mitigation.