### PR TITLE
Resolve template error in nginx config generation

### DIFF
--- a/docker/production/Dockerfile.proxy
+++ b/docker/production/Dockerfile.proxy
@@ -6,7 +6,7 @@ RUN sed -i 's/^nginx.\+/nginx\:x\:501\:501\:nginx\:\/var\/cache\/nginx\:\/sbin\/
 # redirect to
 RUN sed -i 's/^\(\s*\)location \/ {\(\s*\)$/\1location @rails {\2/' /app/nginx.tmpl
 
-RUN mkdir /private /public
+RUN mkdir /private /public /etc/nginx/certs
 
 
 COPY docker/production/proxy_server_config.txt /etc/nginx/vhost.d/localhost


### PR DESCRIPTION
This is a minor bugfix. The nginx proxy complains, that a directory is missing during config generation. It needs to be created to fix the error.