### PR TITLE
change saving policy for referrer url in interactions

### DIFF
--- a/app/workers/interaction_saver.rb
+++ b/app/workers/interaction_saver.rb
@@ -3,8 +3,8 @@ class InteractionSaver
 
   def perform(session_id, full_path, referrer, study_participant)
     referrer_url = if referrer.to_s.include?(ENV['URL_HOST'])
-                      referrer.to_s.remove(ENV['URL_HOST'])
-                                   .remove('https://').remove('http://')
+                     referrer.to_s.remove(ENV['URL_HOST'])
+                                  .remove('https://').remove('http://')
                    end
     Interaction.create(session_id: Digest::SHA2.hexdigest(session_id).first(10),
                        full_path: full_path,

--- a/app/workers/interaction_saver.rb
+++ b/app/workers/interaction_saver.rb
@@ -2,10 +2,13 @@ class InteractionSaver
   include Sidekiq::Worker
 
   def perform(session_id, full_path, referrer, study_participant)
+    referrer_url = if referrer.to_s.include?(ENV['URL_HOST'])
+                      referrer.to_s.remove(ENV['URL_HOST'])
+                                   .remove('https://').remove('http://')
+                   end
     Interaction.create(session_id: Digest::SHA2.hexdigest(session_id).first(10),
                        full_path: full_path,
-                       referrer_url: referrer&.remove(ENV['URL_HOST'])
-                                       &.remove('https://'),
+                       referrer_url: referrer_url,
                        study_participant: study_participant)
   end
 end


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Policy change

referrer_url is ignored in interactions databse if it is an external referrer

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

referrer_url is ignored in interactions databse if it is an external referrer

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
