### PR TITLE
correct typo that causes bug

### DIFF
--- a/app/assets/javascripts/quizzes.coffee
+++ b/app/assets/javascripts/quizzes.coffee
@@ -311,7 +311,7 @@ $(document).on 'turbolinks:load', ->
     previousDefault = cy.filter (element, i) ->
       element.isEdge() and element.data('source') == source and
       element.data('defaultedge')
-    if previousdefault.length == 0 && defaulttarget != 0
+    if previousDefault.length == 0 && defaulttarget != 0
       cy.add
         group: 'edges'
         data:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

When selecting a default target for a quiz vertex is canceled, nothing happens

* **What is the new behavior (if this is a feature change)?**

When selecting a default target for a quiz vertex is canceled, the previous state is restored.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
