### PR TITLE
Remove talk speakers who have talk media from elevated users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,6 +100,7 @@ class UsersController < ApplicationController
   end
 
   def set_elevated_users
-    @elevated_users = User.where(admin: true).or(User.editors).or(User.teachers)
+    @elevated_users = User.where(admin: true).or(User.proper_editors)
+                          .or(User.teachers)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,6 +114,15 @@ class User < ApplicationRecord
     User.where(id: EditableUserJoin.pluck(:user_id).uniq)
   end
 
+  # returns the array of all editors minus those that are only editors of talks
+  def self.proper_editors
+    talk_media_ids = Medium.where(teachable_type: 'Talk').pluck(:id)
+    talk_media_joins = EditableUserJoin.where(editable_type: 'Medium',
+                                              editable_id: talk_media_ids)
+    User.where(id: EditableUserJoin.where.not(id: talk_media_joins.pluck(:id))
+                                   .pluck(:user_id).uniq)
+  end
+
   # Returns the array of all editors (of courses, lectures, media), together
   # with their ids
   # Is used in options_for_select in form helpers.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

Speakers of talks who have added a medium are listed in the admin section as "Editors".

* **What is the new behavior (if this is a feature change)?**

They are no longer listed in the admin section as "Editors".

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
