### PR TITLE
Fix zero byte uploads

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -102,8 +102,9 @@ class TutorialsController < ApplicationController
       @stack = @assignment.submissions.where(tutorial: @tutorial).proper
                           .order(:last_modification_by_users_at)
       send_correction_upload_emails
+    # in case an empty string for files is sent
     rescue JSON::ParserError
-      flash[:alert] = I18n.t8('')
+      flash[:alert] = I18n.t('tutorial.bulk_upload.error')
     end
   end
 

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -96,11 +96,15 @@ class TutorialsController < ApplicationController
   end
 
   def bulk_upload
-    files = JSON.parse(params[:files])
-    @report = Submission.bulk_corrections!(@tutorial, @assignment, files)
-    @stack = @assignment.submissions.where(tutorial: @tutorial).proper
-                        .order(:last_modification_by_users_at)
-    send_correction_upload_emails
+    begin
+      files = JSON.parse(params[:files])
+      @report = Submission.bulk_corrections!(@tutorial, @assignment, files)
+      @stack = @assignment.submissions.where(tutorial: @tutorial).proper
+                          .order(:last_modification_by_users_at)
+      send_correction_upload_emails
+    rescue JSON::ParserError
+      flash[:alert] = I18n.t8('')
+    end
   end
 
   def validate_certificate

--- a/app/views/layouts/administration.html.erb
+++ b/app/views/layouts/administration.html.erb
@@ -13,12 +13,12 @@
       <main>
         <% if alert.present? %>
           <div class="alert alert-danger my-3" role="alert">
-            <%= alert %>
+            <%= sanitize alert, :tags => %w(br) %>
           </div>
         <% end %>
         <% if notice.present? %>
           <div class="alert alert-secondary my-3" role="alert">
-            <%= notice %>
+            <%= sanitize notice, :tags => %w(br) %>
           </div>
         <% end %>
         <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,12 @@
           </div>
           <% if alert.present? %>
             <div class="alert alert-danger" role="alert">
-              <%= alert %>
+              <%= sanitize alert, :tags => %w(br) %>
             </div>
           <% end %>
           <% if notice.present? %>
             <div class="alert alert-secondary" role="alert">
-              <%= notice %>
+              <%= sanitize notice, :tags => %w(br) %>
             </div>
           <% end %>
           <%= yield %>

--- a/app/views/layouts/application_no_sidebar.html.erb
+++ b/app/views/layouts/application_no_sidebar.html.erb
@@ -13,12 +13,12 @@
           </div>
           <% if alert.present? %>
             <div class="alert alert-danger" role="alert">
-              <%= alert %>
+              <%= sanitize alert, :tags => %w(br) %>
             </div>
           <% end %>
           <% if notice.present? %>
             <div class="alert alert-secondary" role="alert">
-              <%= notice %>
+              <%= sanitize notice, :tags => %w(br) %>
             </div>
           <% end %>
           <%= yield %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -13,12 +13,12 @@
           </div>
           <% if alert.present? %>
             <div class="alert alert-danger" role="alert">
-              <%= alert %>
+              <%= sanitize alert, :tags => %w(br) %>
             </div>
           <% end %>
           <% if notice.present? %>
             <div class="alert alert-secondary" role="alert">
-              <%= notice %>
+              <%= sanitize notice, :tags => %w(br) %>
             </div>
           <% end %>
           <%= yield %>

--- a/app/views/tutorials/_bulk_correction_form.html.erb
+++ b/app/views/tutorials/_bulk_correction_form.html.erb
@@ -45,7 +45,7 @@
       <%= f.submit t('buttons.save'),
                    class: 'btn btn-sm btn-primary',
                    id: 'upload-bulk-correction-save',
-                   disabled: false %>
+                   disabled: true %>
       <button class="btn btn-sm btn-secondary"
               id="cancel-bulk-upload"
               type="button">

--- a/app/views/tutorials/bulk_upload.coffee
+++ b/app/views/tutorials/bulk_upload.coffee
@@ -1,4 +1,5 @@
 $('#upload-bulk-errors').empty().hide()
+<% if @report.present? %>
 <% if @errors.present? %>
 $('#upload-bulk-errors').append('<%= @errors.join(", ") %>').show()
 <% else %>
@@ -12,4 +13,7 @@ $('#tutorial-table').empty()
 																	tutorial: @tutorial,
 																	stack: @stack } %>')
 $('[data-toggle="popover"]').popover()
+<% end %>
+<% else %>
+location.reload(true)
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2878,6 +2878,13 @@ de:
           Korrektur hochgeladen wurde, aber bereits entschieden wurde,
           dass die verspätete Abgabe nicht akzeptiert wird. Die
           entsprechenden Korrekturen wurden deshalb nicht hochgeladen.
+      error: >
+        Dein Bundle-Upload ist leider fehlgeschlagen. Versuch es bitte nochmal.<br>
+        Falls Du diese Fehlermeldung zum wiederholten Mal siehst:<br>
+        - schließe Deinen Browser, öffne ihn wieder und versuch es nochmal.<br>
+        - fahre Dein Gerät herunter, starte es erneut und versuch es nochmal.<br>
+        - lade die Dateien einzeln hoch.<br>
+        Bei wiederholtem Auftreten kontaktiere bitte das MaMpf-Team.
   package:
     no_zip: Die Datei ist kein .zip-Archiv.
     to_big: Die Datei ist zu groß.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2709,6 +2709,13 @@ en:
           This is the list of submission teams for which you uploaded a correction
           but have already decided to reject the submission. The corresponding
           corrections have not been uploaded.
+      error: >
+        Unfortunately, your bundle upload failed. Please try again..<br>
+        If you see this error message repeatedly:<br>
+        - close your browser, open it again and try again.<br>
+        - shut down your device, restart it and try again.<br>
+        - upload the files one by one.<br>
+        In case of repeated occurrence please contact the MaMpf team.
   package:
     no_zip: This file is not a .zip archive.
     to_big: This file is too big.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Tries to address the zero-byte upload error seen recently.
For some reason, the save button was at some point enabled to be clicked on before the files
were uploaded. This might have been the cause of the error for multiple people.
It has now been disabled again and, if the error persists, a message is displayed urging
to try again or contact us.

This PR also allows <br> tags inside flash alerts.

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
