### PR TITLE
remove reference to specific debian repository

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -16,7 +16,6 @@ EXPOSE 9394
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
-    sed -i "s/deb\.debian\.org/ftp.halifax\.rwth-aachen.de/g" /etc/apt/sources.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y ffmpeg ghostscript imagemagick \
             libarchive-tools nodejs pdftk postgresql-client-12 sqlite3 wget \


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 





* **What is the current behavior?** (You can also link to an open issue here)

Docker container does not build because of reference to an outdated Debian archive

* **What is the new behavior (if this is a feature change)?**

Docker container builds.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
