### PR TITLE
Update thyme.coffee

### DIFF
--- a/app/assets/javascripts/thyme.coffee
+++ b/app/assets/javascripts/thyme.coffee
@@ -449,6 +449,13 @@ $(document).on 'turbolinks:load', ->
     $('#caption').show()
     $('#video-controlBar').show()
     video.style.width = '82%'
+    # directly closes the IA again, if the IA-button status is "-"
+    if iaButton.dataset.status == 'false'
+      iaButton.innerHTML = 'remove_from_queue'
+      $('#caption').hide()
+      video.style.width = '100%'
+      $('#video-controlBar').css('width', '100%')
+      $(window).trigger('resize')
     return
 
   # display native control bar if screen is very small


### PR DESCRIPTION
Currently, if one presses the "hide interactive area"-button and then resizes the window until the control bar is hidden and back again, the interactive area opens again.

This issue is fixed with the added if-statement in the largeDisplay-method in the file "thyme.coffe": It now directly closed the IA when the button status is "-" and the window is resized back to normal.

Actually, there might be a better way of fixing this bug, as now the IA is opened and closed again. But for the moment, I didn't found out which part of the code causes the IA to be opened again.