### PR TITLE
small docker fixes

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -16,11 +16,11 @@ services:
         source: ../../solr/development/conf/
         target: /solrconfig/
         read_only: true
-#    command: ["bash -c \"solr-precreate development /solrconfig ; solr-precreate test /solrconfig \""]
+    # command: ["bash -c \"solr-precreate development /solrconfig ; solr-precreate test /solrconfig \""]
     entrypoint:
-    - bash
-    - "-c"
-    - "precreate-core development /solrconfig; precreate-core test /solrconfig; exec solr -f"
+      - bash
+      - "-c"
+      - "precreate-core development /solrconfig; precreate-core test /solrconfig; exec solr -f"
 
   db:
     image: postgres
@@ -110,6 +110,7 @@ services:
       - mailcatcher
     labels:
       de.uni-heidelberg.mathi.mampf.container-type: worker
+
   webpacker:
     build:
       context: ./../..

--- a/docker/production/docker-compose.production.yml
+++ b/docker/production/docker-compose.production.yml
@@ -2,7 +2,7 @@ version: '3.4'
 x-mampf:
   &mampf
   build:
-    context: git@github.com:MaMpf-HD/mampf.git#production
+    context: https://github.com/MaMpf-HD/mampf.git#production
     dockerfile: docker/production/Dockerfile
   env_file: docker.env
   networks:
@@ -52,8 +52,8 @@ services:
 
   dockergen:
     build:
-      context: git@github.com:MaMpf-HD/mampf.git#production
       dockerfile: docker/production/Dockerfile.dockergen
+      context: https://github.com/MaMpf-HD/mampf.git#production
     command: -notify-sighup mampf-docker-proxy -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
     restart: always
     volumes:

--- a/docker/production/docker-compose.production.yml
+++ b/docker/production/docker-compose.production.yml
@@ -52,7 +52,7 @@ services:
 
   dockergen:
     build:
-      dockerfile: docker/production/Dockerfile.dockergen
+      dockerfile: docker/Dockerfile.dockergen
       context: https://github.com/MaMpf-HD/mampf.git#production
     command: -notify-sighup mampf-docker-proxy -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
     restart: always


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
  Bug fix

* **Please check if the PR fulfills these requirements**
  - [ ] E2E Tests for the changes have been added  via Cypress
  - [ ] Meaningful rspec tests have been added
  - [ ] Docs have been added / updated 

* **What is the current behavior?**
  Maybe its a docker upstream bug, but there really is no reason to use ssh references :)
  ```
  $ docker compose -f docker-compose.production.yml build
  [+] Building 0.0s (0/0)
  [+] Building 0.1s (0/1)
  [+] Building 5.0s (1/1) FINISHED
   => ERROR [internal] load git source git@github.com:MaMpf-HD/mampf.git#production 5.0s
  ------
  [+] Building 5.0s (1/1) FINISHED
   => ERROR [internal] load git source git@github.com:MaMpf-HD/mampf.git#production 5.0s
  ------
   > [internal] load git source git@github.com:MaMpf-HD/mampf.git#production:
  ------
  failed to solve: Unimplemented: Unimplemented: unknown service moby.sshforward.v1.SSH
  ```

* **What is the new behavior (if this is a feature change)?**

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
