### PR TITLE
Change the way registration params are sanitized

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,9 +4,11 @@ class ApplicationController < ActionController::Base
   # The callback which stores the current location must be added before you
   # authenticate the user as `authenticate_user!` (or whatever your resource is)
   # will halt the filter chain and redirect before the location can be stored.
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
   before_action :set_locale
   after_action :store_interaction, if: :user_signed_in?
+
 
   etag { current_user.try :id }
 
@@ -63,6 +65,13 @@ class ApplicationController < ActionController::Base
     response.headers["Cache-Control"] = "no-cache, no-store"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "Mon, 01 Jan 1990 00:00:00 GMT"
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    # add additional paramters to registration
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:locale, :consents])
   end
 
   private

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -30,7 +30,7 @@ class RegistrationsController < Devise::RegistrationsController
     if verify_captcha
       super
     else
-      build_resource(sign_up_params)
+      build_resource(devise_parameter_sanitizer.sanitize(:sign_up))
       clean_up_passwords(resource)
       set_flash_message :alert, :captcha_error
       render :new
@@ -64,16 +64,12 @@ class RegistrationsController < Devise::RegistrationsController
 
   def check_registration_limit
     if User.where("users.confirmed_at is NULL and users.created_at > '#{(DateTime.now()-(ENV['MAMPF_REGISTRATION_TIMEFRAME']||15).to_i.minutes)}'").count > (ENV['MAMPF_MAX_REGISTRATION_PER_TIMEFRAME'] || 40).to_i
-      self.resource = resource_class.new sign_up_params
+      self.resource = resource_class.new devise_parameter_sanitizer.sanitize(:sign_up)
       resource.validate # Look for any other validation errors besides reCAPTCHA
       set_flash_message :alert, :too_many_registrations
       set_minimum_password_length
       respond_with_navigational(resource) { render :new }
     end
-  end
-  def sign_up_params
-    params.require(:user).permit(:email, :password, :password_confirmation,
-                                 :locale, :consents)
   end
 
   def deletion_params


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Registration parameters are now sanitized in the way the devise documentation recommends it. Maybe this
fixes #436 (or at least stops the exceptions from happening in these cases). 

* **Please check if the PR fulfills these requirements**


- [ ] E2E Tests for the changes have been added  via Cypress
- [ ] Meaningful rspec tests have been added
- [ ] Docs have been added / updated 

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
