### PR TITLE
fix missing media in user edit view

### DIFF
--- a/app/views/users/_data.html.erb
+++ b/app/views/users/_data.html.erb
@@ -44,7 +44,7 @@
       </div>
       <div class="card-body">
         <% if user.edited_courses.any? || user.edited_lectures.any? ||
-              user.given_lectures.any? %>
+              user.given_lectures.any? || user.edited_media.any? %>
           <%= render partial: 'users/content',
                      locals: { user: user,
                                f: f } %>


### PR DESCRIPTION
This PR adds a missing case in an `if` statement in the user edit view and closes issue #448.