### PR TITLE
Fix card body flex css

### DIFF
--- a/app/assets/stylesheets/sidebar.scss
+++ b/app/assets/stylesheets/sidebar.scss
@@ -33,7 +33,7 @@
     }
 }
 
-li {
+.sidebar-item li {
     display: flex;
     align-items: center;
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug, closes #467 

* **Please check if the PR fulfills these requirements**
  - [ ] E2E Tests for the changes have been added  via Cypress
  - [ ] Meaningful rspec tests have been added
  - [ ] Docs have been added / updated 

* **What is the current behavior?** (You can also link to an open issue here)
See #467


* **What is the new behavior (if this is a feature change)?**
List items are now shown correctly (again). The problem was that I didn't know our pipeline (with webpacker and the like) compiled all `.js` files together into one big bundle that gets applied to the whole page. Thus, I used `.li { ... }` as a selector in the sidebar `.css` file as of #446. The `display: flex` was therefore applied to every `li` item on the page, including the pane that showed up in a very weird way. Fixed this by restricting the CSS selector.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No (maybe watch out for this in the future, always use restrictive CSS selectors)
