### PR TITLE
Avoid confusion with "Request data" button

### DIFF
--- a/app/views/profile/_data.html.erb
+++ b/app/views/profile/_data.html.erb
@@ -1,7 +1,7 @@
-<div class="col-12 mb-3">
+<div class="mb-3">
   <%= t('profile.data_explanation') %>
 </div>
-<div class="col-12 text-center">
+<div>
   <%= link_to t('profile.data_request'),
               request_data_path,
               class: 'btn btn-sm btn-primary',

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -137,3 +137,10 @@
 <%= render partial: 'shared/generic_modal',
            locals: { sort: 'deleteAccount',
                      title: t('profile.delete_account') } %>
+
+<div>
+  <%= link_to :root, class: "btn btn-sm btn-primary" do %>
+    <span class="bi bi-arrow-left">
+    <%= t('back_to_home') %>
+  <% end %>
+</div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2103,6 +2103,7 @@ de:
   details: 'Details'
   none: 'keine'
   back: 'Zurück'
+  back_to_home: 'Zurück zur Startseite'
   today: 'heute'
   yesterday: 'gestern'
   chapter: 'Kapitel %{number}. %{title}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1977,6 +1977,7 @@ en:
   details: 'Details'
   none: 'none'
   back: 'Back'
+  back_to_home: 'Back to home'
   today: 'today'
   yesterday: 'yesterday'
   chapter: 'Chapter %{number}. %{title}'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small redesign

* **What is the current behavior?** (You can also link to an open issue here)
During registrations, users are redirected to the profile view, so that they can finish their profile. In the bottom, of that page, the "request data" button might be mistaken for a kind-of "Finish registration" button.


* **What is the new behavior (if this is a feature change)?**
The request data button is now left-aligned. Additionally, I've added a "Back to home" button below that.
![image](https://user-images.githubusercontent.com/37160523/233664686-32e774ed-38b1-49fc-92c0-0925c7c66ba1.png)
