### PR TITLE
Fix ghost links in nested tabs

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -315,21 +315,6 @@
   text-decoration: none;
 }
 
-.tab-content {
-  display: flex;
-}
-
-.tab-content > .tab-pane {
-  display: block; /* undo "display: none;" */
-  visibility: hidden;
-  margin-right: -100%;
-  width: 100%;
-}
-
-.tab-content > .active {
-  visibility: visible;
-}
-
 .break-text-any-where {
   word-break: break-all;
 }

--- a/app/views/lectures/edit/_media.html.erb
+++ b/app/views/lectures/edit/_media.html.erb
@@ -29,12 +29,12 @@
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-4">
+      <div class="col-5">
         <ul class="nav flex-column nav-pills"
             id="edited-media-tab"
             role="tablist">
           <% media_sorts.each do |s| %>
-            <li class="nav-item">
+            <li class="nav-item w-100">
               <a class="nav-link <%= active(s == 'kaviar') %>"
                  id="<%= s %>-tab"
                  data-toggle="tab" href="#<%= s %>-media" role="tab"
@@ -47,14 +47,14 @@
           <% end %>
         </ul>
       </div>
-      <div class="col-8">
+      <div class="col-7">
         <div class="tab-content" id="edited-media-tabContent">
           <% media_sorts.each do |s| %>
             <div class="tab-pane fade <%= show_tab(s == 'kaviar') %>"
                  id="<%= s %>-media"
                  role="tabpanel"
                  aria-labelledby="<%= s %>-tab">
-              <ul>
+              <ul class="pl-2">
                 <% media.select { |m| m.sort.in?(media_types[s]) }
                         .sort_by(&:created_at)
                         .reverse

--- a/app/views/media/_table_column.html.erb
+++ b/app/views/media/_table_column.html.erb
@@ -1,63 +1,66 @@
 <% if media.present? %>
   <% if small %>
-    <ul>
-      <% media.each do |m| %>
-        <li>
-          <%= link_to m.local_info,
-                      edit_or_inspect_medium_path(m),
-                      class: textcolor(m) %>
-        </li>
-      <% end %>
-    </ul>
+    <div class="tab-content">
+      <ul>
+        <% media.each do |m| %>
+          <li>
+            <%= link_to m.local_info,
+                        edit_or_inspect_medium_path(m),
+                        class: textcolor(m) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   <% else %>
     <% teachables = lecture_course_teachables(media) %>
-    <div class="row">
-      <div class="col-3">
-        <div class="nav flex-column nav-tabs"
-             id="v-<%= sort %>-media-tab"
-             role="tablist"
-             aria-orientation="vertical">
-          <% teachables.each_with_index do |t, i| %>
-            <a class="nav-link <%= active(i.zero?) %>"
-               id="v-pills-<%= sort %>-<%= t.class %>-<%= t.id %>-tab"
-               data-toggle="pill"
-               href="#v-pills-<%= sort %>-<%= t.class %>-<%= t.id %>"
-               role="tab">
-              <%= t.short_title %>
-            </a>
-          <% end %>
+    <div class="tab-content">
+      <div class="row">
+        <div class="col-3">
+          <div class="nav flex-column nav-tabs"
+              id="v-<%= sort %>-media-tab"
+              role="tablist"
+              aria-orientation="vertical">
+            <% teachables.each_with_index do |t, i| %>
+              <a class="nav-link <%= active(i.zero?) %>"
+                id="v-pills-<%= sort %>-<%= t.class %>-<%= t.id %>-tab"
+                data-toggle="pill"
+                href="#v-pills-<%= sort %>-<%= t.class %>-<%= t.id %>"
+                role="tab">
+                <%= t.short_title %>
+              </a>
+            <% end %>
+          </div>
         </div>
-      </div>
-      <div class="col-9">
-        <div class="tab-content"
-             id="v-<%= sort %>-media-tabContent">
-          <% teachables.each_with_index do |t, i| %>
-            <div class="tab-pane fade <%= show_tab(i == 0) %>"
-                 id="v-pills-<%= sort %>-<%= t.class %>-<%= t.id %>"
-                 role="tabpanel">
-              <% relevant = relevant_media(t, media, 50)&.sort_by(&:created_at)
-                                                        &.natural_sort_by(&:local_info) %>
-              <% if relevant.present? %>
-                <div class="row">
-                  <% split_list(relevant, 2).each do |media_list| %>
-                    <div class="col-6">
-                      <ul>
-                        <%= render partial: 'media/table/entry',
-                                   collection: media_list.compact,
-                                   as: :medium,
-                                   cached: true %>
-                      </ul>
-                    </div>
-                  <% end %>
-                </div>
-              <% end %>
-              <% if relevant.size == 50 %>
-                <%= t('admin.medium.use_search_html',
-                      media_search: link_to(t('admin.main.media_search'),
-                                            administration_search_path)) %>
-              <% end %>
-            </div>
-          <% end %>
+        <div class="col-9">
+          <div class="tab-content" id="v-<%= sort %>-media-tabContent">
+            <% teachables.each_with_index do |t, i| %>
+              <div class="tab-pane fade <%= show_tab(i == 0) %>"
+                  id="v-pills-<%= sort %>-<%= t.class %>-<%= t.id %>"
+                  role="tabpanel">
+                <% relevant = relevant_media(t, media, 50)&.sort_by(&:created_at)
+                                                          &.natural_sort_by(&:local_info) %>
+                <% if relevant.present? %>
+                  <div class="row">
+                    <% split_list(relevant, 2).each do |media_list| %>
+                      <div class="col-6">
+                        <ul>
+                          <%= render partial: 'media/table/entry',
+                                    collection: media_list.compact,
+                                    as: :medium,
+                                    cached: true %>
+                        </ul>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+                <% if relevant.size == 50 %>
+                  <%= t('admin.medium.use_search_html',
+                        media_search: link_to(t('admin.main.media_search'),
+                                              administration_search_path)) %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Closes #497 


![image](https://github.com/MaMpf-HD/mampf/assets/37160523/7e20f1d7-8484-4fe7-a7a8-cb79d089afcc)

While viewing the media of a course, links were randomly placed and invisible (e.g. on the route: `http://localhost:3000/courses/2/edit`). This was (mainly) due to a wrongly placed bootstrap class `tab-content` inside a column layout (wrapping only one column instead of the whole row).