### PR TITLE
Hotfix: Restore intended behaviour in media search

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -224,7 +224,7 @@ class MediaController < ApplicationController
     results = search.results
     @total = search.total
 
-    # in the case of a search with tag_operator 'or', we 
+    # in the case of a search with tag_operator 'or', we
     # execute two searches and merge the results, where media
     # with the selected tags are now shown at the front of the list
     if search_params[:tag_operator] == "or" and search_params[:all_tags] == "0" and search_params[:fulltext].size >= 2
@@ -657,7 +657,7 @@ class MediaController < ApplicationController
                   :teachable_inheritance, :fulltext, :per,
                   :clicker, :purpose, :answers_count,
                   :results_as_list, :all_terms, :all_teachers,
-                  :lecture_option, :user_id,
+                  :lecture_option, :user_id, :from,
                   types: [],
                   teachable_ids: [],
                   tag_ids: [],

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -102,7 +102,7 @@ module MediaHelper
     return add_prompt(Medium.select_quizzables) if purpose == 'quiz'
     return Medium.select_question if purpose == 'clicker'
     return add_prompt(Medium.select_importables) if purpose == 'import'
-    return add_prompt(Medium.select_generic) if !current_user.admin?
+    return add_prompt(Medium.select_generic) if !current_user.admin_or_editor?
     add_prompt(Medium.select_sorts)
   end
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -200,7 +200,7 @@ class Medium < ApplicationRecord
   end
 
   def self.advanced_sorts
-    ['RandomQuiz', 'Question', 'Remark', 'Erdbeere']
+    ['Question', 'Remark', 'Erdbeere']
   end
 
   def self.generic_sorts
@@ -277,23 +277,33 @@ class Medium < ApplicationRecord
   # returns search results for the media search with search_params provided
   # by the controller
   def self.search_by(search_params, page)
-    search_params[:types] = [] if search_params[:all_types] == '1'
+    # If the search is initiated from the start page, you can only get
+    # generic media sorts as results even if the 'all' radio button
+    # is seleted
+    if search_params[:all_types] == '1'
+      search_params[:types] = if search_params[:from] == 'start'
+                                Medium.generic_sorts
+                              else
+                                []
+                              end
+    end
     search_params[:teachable_ids] = TeachableParser.new(search_params)
                                                    .teachables_as_strings
     search_params[:editor_ids] = [] if search_params[:all_editors] == '1' || search_params[:all_editors].nil?
     # add media without term to current term
-    
+
     search_params[:all_terms] = '1' if search_params[:all_terms].blank?
     search_params[:all_teachers] = '1' if search_params[:all_teachers].blank?
     search_params[:term_ids].push('0') if search_params[:term_ids].present?
     if search_params[:all_tags] == '1' && search_params[:tag_operator] == 'and'
       search_params[:tag_ids] = Tag.pluck(:id)
     end
-    admin = User.find_by(id: search_params[:user_id])&.admin?
+    user = User.find_by(id: search_params[:user_id])
     search = Sunspot.new_search(Medium)
     search.build do
       with(:sort, search_params[:types])
-      without(:sort, Medium.advanced_sorts) unless admin
+      without(:sort, 'RandomQuiz')
+      without(:sort, Medium.advanced_sorts) unless user&.admin_or_editor?
       with(:editor_ids, search_params[:editor_ids])
       with(:teachable_compact, search_params[:teachable_ids])
       with(:term_id, search_params[:term_ids]) unless search_params[:all_terms] == '1'
@@ -1201,5 +1211,5 @@ class Medium < ApplicationRecord
     return -1 unless type == 'Question'
     becomes(Question).answers.count
   end
-  
+
 end

--- a/app/views/main/start/_media_search.html.erb
+++ b/app/views/main/start/_media_search.html.erb
@@ -125,7 +125,7 @@
                             '2',
                             checked: false,
                             class: 'custom-control-input',
-                            data: { type: 'toggle', 
+                            data: { type: 'toggle',
                                     id: 'search_media_lectures'} %>
         <%= f.label :lecture_option,
                     t('search.media.lecture_options.own_selection'),
@@ -162,6 +162,7 @@
   <%= f.hidden_field :purpose, value: purpose %>
   <%= f.hidden_field :results_as_list,
                      value: 'false' %>
+  <%= f.hidden_field :from, value: 'start' %>
   <div class="row mb-3">
     <div class="col-12 text-center">
       <%= f.submit t('basics.search'),

--- a/app/views/media/catalog/_search_form.html.erb
+++ b/app/views/media/catalog/_search_form.html.erb
@@ -18,16 +18,20 @@
       <% if purpose == 'clicker' %>
         <%= f.hidden_field :types, value: ['Question'] %>
       <% end %>
-      <div class="custom-control custom-checkbox mb-2">
-        <%= f.check_box :all_types,
-                        id: 'search_all_media_types',
-                        class: 'custom-control-input',
-                        checked: purpose.in?(['media', 'clicker']),
-                        data: { id: 'search_media_types'} %>
-        <%= f.label :all_media_types,
-                    t('basics.all'),
-                    { class: 'custom-control-label' } %>
-      </div>
+      <% if purpose == 'media' %>
+        <div class="custom-control custom-checkbox mb-2">
+          <%= f.check_box :all_types,
+                          id: 'search_all_media_types',
+                          class: 'custom-control-input',
+                          checked: purpose.in?(['media', 'clicker']),
+                          data: { id: 'search_media_types'} %>
+          <%= f.label :all_media_types,
+                      t('basics.all'),
+                      { class: 'custom-control-label' } %>
+        </div>
+      <% else %>
+        <%= f.hidden_field :all_types, value: '0' %>
+      <% end %>
     </div>
     <div class="col-6 col-lg-3 form-group">
       <%= f.label :teachable_ids, t('basics.associated_to') %>


### PR DESCRIPTION
As described in #496, PR #420 has introduced some unwanted behaviour (that also leads to exceptions) when the media search was made accesible to generic users via the start page. In this PR the following things have been changed

- In the 'Import Content' tab in the 'Create vertex' dialogue for quizzes, there is no more radio button that allows you to select all types of media.  You can only choose between Questions and Remarks. (This restores previous behaviour)
- In the 'Media Search' Tab that is available to editors in the admin area, it is now also possible to select media of type Questions/Remark/Erdbeere. (This restores previous behaviour)
- In the media search form on the start page, checking the 'all types' radio button now means checking all  types of media actually listed in this generic search form, which excludes e.g. Questions. For generic users these types have been filtered out anyway if you selected 'all', but for admins they were not, creating an inconsistency. I think that the exclusion of certain types makes sense in that form, because the results are rendered in a way that is not suitable for huge amounts of hits. If you are an editor/admin and want to search Questions, you can use the search form  in the admin area. Maybe it would make sense to add a helpdesk in this accordion fold for editors that explains that this media search is kind of restricted  and that it is recommended to use the media search in the admin area. (This removes an inconsistency)
