### PR TITLE
Use default version of commontator gem instead of own fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,9 +91,7 @@ gem "sidekiq-cron", "~> 1.1"
 gem "faraday", "~> 1.8"
 gem "globalize"
 gem "globalize-accessors"
-gem "commontator",
-  git: "https://github.com/MaMpf-HD/commontator.git",
-  branch: "main"
+gem "commontator"
 gem "acts_as_votable"
 gem "sprockets-rails",
   git: "https://github.com/rails/sprockets-rails",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/MaMpf-HD/commontator.git
-  revision: 38b25d2f3f4e4e2d1a0a7b608f04c579a93125f9
-  branch: main
-  specs:
-    commontator (7.0.0)
-      rails (>= 6.0)
-      sprockets-rails
-      will_paginate
-
-GIT
   remote: https://github.com/rails/sprockets-rails
   revision: 73e7351abff3506f6dca6b2da8abedfd5c7c0d77
   branch: master
@@ -174,6 +164,10 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commontator (7.0.0)
+      rails (>= 6.0)
+      sprockets-rails
+      will_paginate
     concurrent-ruby (1.2.2)
     connection_pool (2.4.0)
     content_disposition (1.0.0)
@@ -674,7 +668,7 @@ DEPENDENCIES
   cancancan
   clipboard-rails
   coffee-rails (~> 5.0.0)
-  commontator!
+  commontator
   coveralls
   cypress-on-rails (~> 1.0)
   dalli (>= 2.7)

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -1,187 +1,194 @@
 class Commontator::CommentsController < Commontator::ApplicationController
-    before_action :set_thread, only: [ :new, :create ]
-    before_action :set_comment_and_thread, except: [ :new, :create ]
-    before_action :commontator_set_thread_variables, only: [ :show, :update, :delete, :undelete ]
-  
-    # GET /comments/1
-    def show
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js
-      end
+  before_action :set_thread, only: [:new, :create]
+  before_action :set_comment_and_thread, except: [:new, :create]
+  before_action :commontator_set_thread_variables,
+                only: [:show, :update, :delete, :undelete]
+
+  # GET /comments/1
+  def show
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js
     end
-  
-    # GET /threads/1/comments/new
-    def new
-      @comment = Commontator::Comment.new(thread: @commontator_thread, creator: @commontator_user)
-      parent_id = params.dig(:comment, :parent_id)
-      unless parent_id.blank?
-        parent = Commontator::Comment.find parent_id
-        @comment.parent = parent
-        @comment.body = "<blockquote><span class=\"author\">#{
+  end
+
+  # GET /threads/1/comments/new
+  def new
+    @comment = Commontator::Comment.new(thread: @commontator_thread,
+                                        creator: @commontator_user)
+    parent_id = params.dig(:comment, :parent_id)
+    unless parent_id.blank?
+      parent = Commontator::Comment.find parent_id
+      @comment.parent = parent
+      @comment.body = "<blockquote><span class=\"author\">#{
           Commontator.commontator_name(parent.creator)
         }</span>\n#{
           parent.body
-        }\n</blockquote>\n" if [ :q, :b ].include? @commontator_thread.config.comment_reply_style
-      end
-      security_transgression_unless @comment.can_be_created_by?(@commontator_user)
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js
-      end
+        }\n</blockquote>\n" if [:q,
+                                :b].include? @commontator_thread.config.comment_reply_style
     end
-  
-    # POST /threads/1/comments
-    def create
-      @comment = Commontator::Comment.new(
-        thread: @commontator_thread, creator: @commontator_user, body: params.dig(:comment, :body)
+    security_transgression_unless @comment.can_be_created_by?(@commontator_user)
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js
+    end
+  end
+
+  # POST /threads/1/comments
+  def create
+    @comment = Commontator::Comment.new(
+      thread: @commontator_thread, creator: @commontator_user, body: params.dig(
+        :comment, :body
       )
-      parent_id = params.dig(:comment, :parent_id)
-      @comment.parent = Commontator::Comment.find(parent_id) unless parent_id.blank?
-      security_transgression_unless @comment.can_be_created_by?(@commontator_user)
-  
-      respond_to do |format|
-        if params[:cancel].blank?
-          if @comment.save
-            sub = @commontator_thread.config.thread_subscription.to_sym
-            @commontator_thread.subscribe(@commontator_user) if sub == :a || sub == :b
-            subscribe_mentioned if @commontator_thread.config.mentions_enabled
-            Commontator::Subscription.comment_created(@comment)
-            medium = @commontator_thread.commontable
-            if medium.released.in?(['all', 'users', 'subscribers'])
-              relevant_users = medium.teachable.media_scope.users
-              relevant_users.where(unread_comments: false)
-                            .update_all(unread_comments: true)
-              @update_icon = relevant_users.exists?(current_user.id)
-            end
-            @commontator_page = @commontator_thread.new_comment_page(
-              @comment.parent_id, @commontator_show_all
-            )
-  
-            format.js
-          else
-            format.js { render :new }
+    )
+    parent_id = params.dig(:comment, :parent_id)
+    @comment.parent = Commontator::Comment.find(parent_id) unless parent_id.blank?
+    security_transgression_unless @comment.can_be_created_by?(@commontator_user)
+
+    respond_to do |format|
+      if params[:cancel].blank?
+        if @comment.save
+          sub = @commontator_thread.config.thread_subscription.to_sym
+          @commontator_thread.subscribe(@commontator_user) if sub == :a || sub == :b
+          subscribe_mentioned if @commontator_thread.config.mentions_enabled
+          Commontator::Subscription.comment_created(@comment)
+          medium = @commontator_thread.commontable
+          if medium.released.in?(['all', 'users', 'subscribers'])
+            relevant_users = medium.teachable.media_scope.users
+            relevant_users.where(unread_comments: false)
+                          .update_all(unread_comments: true)
+            @update_icon = relevant_users.exists?(current_user.id)
           end
+          @commontator_page = @commontator_thread.new_comment_page(
+            @comment.parent_id, @commontator_show_all
+          )
+
+          format.js
         else
-          format.js { render :cancel }
+          format.js { render :new }
         end
-  
-        format.html { redirect_to commontable_url }
+      else
+        format.js { render :cancel }
       end
+
+      format.html { redirect_to commontable_url }
     end
-  
-    # GET /comments/1/edit
-    def edit
-      @comment.editor = @commontator_user
-      security_transgression_unless @comment.can_be_edited_by?(@commontator_user)
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js
-      end
+  end
+
+  # GET /comments/1/edit
+  def edit
+    @comment.editor = @commontator_user
+    security_transgression_unless @comment.can_be_edited_by?(@commontator_user)
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js
     end
-  
-    # PUT /comments/1
-    def update
-      @comment.editor = @commontator_user
-      @comment.body = params.dig(:comment, :body)
-      security_transgression_unless @comment.can_be_edited_by?(@commontator_user)
-  
-      respond_to do |format|
-        if params[:cancel].blank?
-          if @comment.save
-            subscribe_mentioned if @commontator_thread.config.mentions_enabled
-  
-            format.js
-          else
-            format.js { render :edit }
-          end
+  end
+
+  # PUT /comments/1
+  def update
+    @comment.editor = @commontator_user
+    @comment.body = params.dig(:comment, :body)
+    security_transgression_unless @comment.can_be_edited_by?(@commontator_user)
+
+    respond_to do |format|
+      if params[:cancel].blank?
+        if @comment.save
+          subscribe_mentioned if @commontator_thread.config.mentions_enabled
+
+          format.js
         else
-          @comment.restore_attributes
-  
-          format.js { render :cancel }
+          format.js { render :edit }
         end
-  
-        format.html { redirect_to commontable_url }
+      else
+        @comment.restore_attributes
+
+        format.js { render :cancel }
       end
+
+      format.html { redirect_to commontable_url }
     end
-  
-    # PUT /comments/1/delete
-    def delete
-      security_transgression_unless @comment.can_be_deleted_by?(@commontator_user)
-  
-      @comment.errors.add(:base, t('commontator.comment.errors.already_deleted')) \
-        unless @comment.delete_by(@commontator_user)
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js { render :delete }
-      end
+  end
+
+  # PUT /comments/1/delete
+  def delete
+    security_transgression_unless @comment.can_be_deleted_by?(@commontator_user)
+
+    @comment.errors.add(:base,
+                        t('commontator.comment.errors.already_deleted')) \
+      unless @comment.delete_by(@commontator_user)
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js { render :delete }
     end
-  
-    # PUT /comments/1/undelete
-    def undelete
-      security_transgression_unless @comment.can_be_deleted_by?(@commontator_user)
-  
-      @comment.errors.add(:base, t('commontator.comment.errors.not_deleted')) \
-        unless @comment.undelete_by(@commontator_user)
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js { render :delete }
-      end
+  end
+
+  # PUT /comments/1/undelete
+  def undelete
+    security_transgression_unless @comment.can_be_deleted_by?(@commontator_user)
+
+    @comment.errors.add(:base, t('commontator.comment.errors.not_deleted')) \
+      unless @comment.undelete_by(@commontator_user)
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js { render :delete }
     end
-  
-    # PUT /comments/1/upvote
-    def upvote
-      security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user)
-  
-      @comment.upvote_from @commontator_user
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js { render :vote }
-      end
+  end
+
+  # PUT /comments/1/upvote
+  def upvote
+    security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user)
+
+    @comment.upvote_from @commontator_user
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js { render :vote }
     end
-  
-    # PUT /comments/1/downvote
-    def downvote
-      security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user) &&\
-        @comment.thread.config.comment_voting.to_sym == :ld
-  
-      @comment.downvote_from @commontator_user
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js { render :vote }
-      end
+  end
+
+  # PUT /comments/1/downvote
+  def downvote
+    security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user) && \
+                                  @comment.thread.config.comment_voting.to_sym == :ld
+
+    @comment.downvote_from @commontator_user
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js { render :vote }
     end
-  
-    # PUT /comments/1/unvote
-    def unvote
-      security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user)
-  
-      @comment.unvote voter: @commontator_user
-  
-      respond_to do |format|
-        format.html { redirect_to commontable_url }
-        format.js { render :vote }
-      end
+  end
+
+  # PUT /comments/1/unvote
+  def unvote
+    security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user)
+
+    @comment.unvote voter: @commontator_user
+
+    respond_to do |format|
+      format.html { redirect_to commontable_url }
+      format.js { render :vote }
     end
-  
-    protected
-  
+  end
+
+  protected
+
     def set_comment_and_thread
       @comment = Commontator::Comment.find(params[:id])
       @commontator_thread = @comment.thread
     end
-  
+
     def subscribe_mentioned
-      Commontator.commontator_mentions(@commontator_user, @commontator_thread, '')
+      Commontator.commontator_mentions(@commontator_user, @commontator_thread,
+                                       '')
                  .where(id: params[:mentioned_ids])
                  .each do |user|
         @commontator_thread.subscribe(user)
       end
     end
-  end
+end

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -1,0 +1,187 @@
+class Commontator::CommentsController < Commontator::ApplicationController
+    before_action :set_thread, only: [ :new, :create ]
+    before_action :set_comment_and_thread, except: [ :new, :create ]
+    before_action :commontator_set_thread_variables, only: [ :show, :update, :delete, :undelete ]
+  
+    # GET /comments/1
+    def show
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js
+      end
+    end
+  
+    # GET /threads/1/comments/new
+    def new
+      @comment = Commontator::Comment.new(thread: @commontator_thread, creator: @commontator_user)
+      parent_id = params.dig(:comment, :parent_id)
+      unless parent_id.blank?
+        parent = Commontator::Comment.find parent_id
+        @comment.parent = parent
+        @comment.body = "<blockquote><span class=\"author\">#{
+          Commontator.commontator_name(parent.creator)
+        }</span>\n#{
+          parent.body
+        }\n</blockquote>\n" if [ :q, :b ].include? @commontator_thread.config.comment_reply_style
+      end
+      security_transgression_unless @comment.can_be_created_by?(@commontator_user)
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js
+      end
+    end
+  
+    # POST /threads/1/comments
+    def create
+      @comment = Commontator::Comment.new(
+        thread: @commontator_thread, creator: @commontator_user, body: params.dig(:comment, :body)
+      )
+      parent_id = params.dig(:comment, :parent_id)
+      @comment.parent = Commontator::Comment.find(parent_id) unless parent_id.blank?
+      security_transgression_unless @comment.can_be_created_by?(@commontator_user)
+  
+      respond_to do |format|
+        if params[:cancel].blank?
+          if @comment.save
+            sub = @commontator_thread.config.thread_subscription.to_sym
+            @commontator_thread.subscribe(@commontator_user) if sub == :a || sub == :b
+            subscribe_mentioned if @commontator_thread.config.mentions_enabled
+            Commontator::Subscription.comment_created(@comment)
+            medium = @commontator_thread.commontable
+            if medium.released.in?(['all', 'users', 'subscribers'])
+              relevant_users = medium.teachable.media_scope.users
+              relevant_users.where(unread_comments: false)
+                            .update_all(unread_comments: true)
+              @update_icon = relevant_users.exists?(current_user.id)
+            end
+            @commontator_page = @commontator_thread.new_comment_page(
+              @comment.parent_id, @commontator_show_all
+            )
+  
+            format.js
+          else
+            format.js { render :new }
+          end
+        else
+          format.js { render :cancel }
+        end
+  
+        format.html { redirect_to commontable_url }
+      end
+    end
+  
+    # GET /comments/1/edit
+    def edit
+      @comment.editor = @commontator_user
+      security_transgression_unless @comment.can_be_edited_by?(@commontator_user)
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js
+      end
+    end
+  
+    # PUT /comments/1
+    def update
+      @comment.editor = @commontator_user
+      @comment.body = params.dig(:comment, :body)
+      security_transgression_unless @comment.can_be_edited_by?(@commontator_user)
+  
+      respond_to do |format|
+        if params[:cancel].blank?
+          if @comment.save
+            subscribe_mentioned if @commontator_thread.config.mentions_enabled
+  
+            format.js
+          else
+            format.js { render :edit }
+          end
+        else
+          @comment.restore_attributes
+  
+          format.js { render :cancel }
+        end
+  
+        format.html { redirect_to commontable_url }
+      end
+    end
+  
+    # PUT /comments/1/delete
+    def delete
+      security_transgression_unless @comment.can_be_deleted_by?(@commontator_user)
+  
+      @comment.errors.add(:base, t('commontator.comment.errors.already_deleted')) \
+        unless @comment.delete_by(@commontator_user)
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js { render :delete }
+      end
+    end
+  
+    # PUT /comments/1/undelete
+    def undelete
+      security_transgression_unless @comment.can_be_deleted_by?(@commontator_user)
+  
+      @comment.errors.add(:base, t('commontator.comment.errors.not_deleted')) \
+        unless @comment.undelete_by(@commontator_user)
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js { render :delete }
+      end
+    end
+  
+    # PUT /comments/1/upvote
+    def upvote
+      security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user)
+  
+      @comment.upvote_from @commontator_user
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js { render :vote }
+      end
+    end
+  
+    # PUT /comments/1/downvote
+    def downvote
+      security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user) &&\
+        @comment.thread.config.comment_voting.to_sym == :ld
+  
+      @comment.downvote_from @commontator_user
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js { render :vote }
+      end
+    end
+  
+    # PUT /comments/1/unvote
+    def unvote
+      security_transgression_unless @comment.can_be_voted_on_by?(@commontator_user)
+  
+      @comment.unvote voter: @commontator_user
+  
+      respond_to do |format|
+        format.html { redirect_to commontable_url }
+        format.js { render :vote }
+      end
+    end
+  
+    protected
+  
+    def set_comment_and_thread
+      @comment = Commontator::Comment.find(params[:id])
+      @commontator_thread = @comment.thread
+    end
+  
+    def subscribe_mentioned
+      Commontator.commontator_mentions(@commontator_user, @commontator_thread, '')
+                 .where(id: params[:mentioned_ids])
+                 .each do |user|
+        @commontator_thread.subscribe(user)
+      end
+    end
+  end

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,10 @@ module Mampf
         end
       end
     end
+    # Make sure that our custom commontator controllers are loaded
+    # instead of the default ones
+    # see https://github.com/lml/commontator/issues/200#issuecomment-1231456146
+    Commontator::Engine.config.autoload_once_paths = []
   end
 end
 


### PR DESCRIPTION
In this PR we switch back to the current version of the commontator gem hosted on github, no longer using our own fork. This fixes #445.