### PR TITLE
add event listener for cancel lecture comments button

### DIFF
--- a/app/assets/javascripts/lectures.coffee
+++ b/app/assets/javascripts/lectures.coffee
@@ -82,6 +82,11 @@ $(document).on 'turbolinks:load', ->
     location.reload(true)
     return
 
+  # reload current page if lecture preferences editing is cancelled
+  $('#cancel-lecture-comments').on 'click', ->
+    location.reload(true)
+    return
+
    # reload current page if lecture preferences editing is cancelled
   $('#cancel-lecture-organizational').on 'click', ->
     location.reload(true)

--- a/app/assets/javascripts/lectures.coffee
+++ b/app/assets/javascripts/lectures.coffee
@@ -82,7 +82,7 @@ $(document).on 'turbolinks:load', ->
     location.reload(true)
     return
 
-  # reload current page if lecture preferences editing is cancelled
+  # reload current page if lecture comments editing is cancelled
   $('#cancel-lecture-comments').on 'click', ->
     location.reload(true)
     return


### PR DESCRIPTION
This fixes #514. I added a missing event listener that for the cancel lecture comments button (it is done exactly the same way for the cancel buttons in the other accordion folds).