### PR TITLE
Replace datetimepicker

### DIFF
--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,0 +1,12 @@
+// see https://getdatepicker.com
+console.log('trying to import datetimepicker');
+$('#assignment-picker').tempusDominus({
+    display: {
+        sideBySide: true
+    },
+    localization: {
+        startOfTheWeek: 1,
+        format: 'yyyy-MM-dd HH:mm',
+        hourCycle: 'h23'
+    }
+});

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,12 +1,14 @@
 // see https://getdatepicker.com
 var datetimePicker = new tempusDominus.TempusDominus(
-    document.getElementById('assignment-picker'),
+    // currently, we only support one datetimepicker on a page
+    document.getElementsByClassName('td-picker')[0],
     {
         display: {
             sideBySide: true,
         },
         localization: {
             startOfTheWeek: 1,
+            // choose format to be compliant with backend time format
             format: 'yyyy-MM-dd HH:mm',
             hourCycle: 'h23',
         }
@@ -20,15 +22,27 @@ datetimePicker.dates.parseInput = (input) => {
     try {
         return datetimePicker.dates.oldParseInput(input);
     } catch (err) {
+        console.log($('.td-error'));
+        const errorMsg = $('.td-error').data('td-invalid-date');
+        $('.td-error').text(errorMsg).show();
         datetimePicker.dates.clear();
     }
 };
 
-var isButtonInvokingFocus = false;
+datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
+    // see https://getdatepicker.com/6/namespace/events.html#change
+    if (e.isValid && !e.isClear) {
+        $('.td-error').empty();
+    }
+});
+
+
 
 // Show datetimepicker when user clicks in text field next to button
 // or when input field receives focus
-$('#assignment-picker-input').on('click focusin', (e) => {
+var isButtonInvokingFocus = false;
+
+$('.td-input').on('click focusin', (e) => {
     try {
         if (!isButtonInvokingFocus) {
             datetimePicker.show();
@@ -39,13 +53,13 @@ $('#assignment-picker-input').on('click focusin', (e) => {
     }
 });
 
-$('#assignment-picker-button').on('click', () => {
+$('.td-picker-button').on('click', () => {
     isButtonInvokingFocus = true;
-    $('#assignment-picker-input').focus();
+    $('.td-input').focus();
 });
 
 // Hide datetimepicker when input field loses focus
-$('#assignment-picker-input').blur((e) => {
+$('.td-input').blur((e) => {
     if (!e.relatedTarget) {
         return;
     }

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,70 +1,91 @@
 $(document).ready(function () {
 
-    // see https://getdatepicker.com
-    var datetimePicker = new tempusDominus.TempusDominus(
-        // currently, we only support one datetimepicker on a page
-        document.getElementsByClassName('td-picker')[0],
-        {
-            display: {
-                sideBySide: true,
-            },
-            localization: {
-                startOfTheWeek: 1,
-                // choose format to be compliant with backend time format
-                format: 'yyyy-MM-dd HH:mm',
-                hourCycle: 'h23',
-            }
-        }
-    );
-
-    // Catch Tempus Dominus error when user types in invalid date
-    // this is rather hacky at the moment, see this discussion:
-    // https://github.com/Eonasdan/tempus-dominus/discussions/2656
-    datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
-    datetimePicker.dates.parseInput = (input) => {
-        try {
-            return datetimePicker.dates.oldParseInput(input);
-        } catch (err) {
-            const errorMsg = $('.td-error').data('td-invalid-date');
-            $('.td-error').text(errorMsg).show();
-            datetimePicker.dates.clear();
-        }
-    };
-
-    datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
-        // see https://getdatepicker.com/6/namespace/events.html#change
-        if (e.isValid && !e.isClear) {
-            $('.td-error').empty();
-            datetimePicker.hide();
-        }
-    });
-
-    // Show datetimepicker when user clicks in text field next to button
-    // or when input field receives focus
-    var isButtonInvokingFocus = false;
-
-    $('.td-input').on('click focusin', (e) => {
-        try {
-            if (!isButtonInvokingFocus) {
-                datetimePicker.show();
-            }
-        }
-        finally {
-            isButtonInvokingFocus = false;
-        }
-    });
-
-    $('.td-picker-button').on('click', () => {
-        isButtonInvokingFocus = true;
-        $('.td-input').focus();
-    });
-
-    // Hide datetimepicker when input field loses focus
-    $('.td-input').blur((e) => {
-        if (!e.relatedTarget) {
+    // Initialize Tempus Dominus datetimepicker(s)
+    startInitialization();
+    function startInitialization() {
+        const pickerElements = $('.td-picker');
+        if (pickerElements.length == 0) {
+            console.error('No datetimepicker element found on page, although requested.');
             return;
         }
-        datetimePicker.hide();
-    });
 
+        pickerElements.each((i, element) => {
+            element = $(element);
+            const datetimePicker = initDatetimePicker(element);
+            registerErrorHandlers(datetimePicker, element);
+            registerFocusHandlers(datetimePicker, element);
+        });
+    }
+
+    function initDatetimePicker(element) {
+        // see https://getdatepicker.com
+        return new tempusDominus.TempusDominus(
+            element.get(0),
+            {
+                display: {
+                    sideBySide: true, // clock to the right of the calendar
+                },
+                localization: {
+                    startOfTheWeek: 1,
+                    // choose format to be compliant with backend time format
+                    format: 'yyyy-MM-dd HH:mm',
+                    hourCycle: 'h23',
+                }
+            }
+        );
+    }
+
+    function registerErrorHandlers(datetimePicker, element) {
+        // Catch Tempus Dominus error when user types in invalid date
+        // this is rather hacky at the moment, see this discussion:
+        // https://github.com/Eonasdan/tempus-dominus/discussions/2656
+        datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
+        datetimePicker.dates.parseInput = (input) => {
+            try {
+                return datetimePicker.dates.oldParseInput(input);
+            } catch (err) {
+                const errorMsg = element.find('.td-error').data('td-invalid-date');
+                element.find('.td-error').text(errorMsg).show();
+                datetimePicker.dates.clear();
+            }
+        };
+
+        datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
+            // see https://getdatepicker.com/6/namespace/events.html#change
+            if (e.isValid && !e.isClear) {
+                element.find('.td-error').empty();
+                datetimePicker.hide();
+            }
+        });
+    }
+
+    function registerFocusHandlers(datetimePicker, element) {
+        // Show datetimepicker when user clicks in text field next to button
+        // or when input field receives focus
+        var isButtonInvokingFocus = false;
+
+        element.find('.td-input').on('click focusin', (e) => {
+            try {
+                if (!isButtonInvokingFocus) {
+                    datetimePicker.show();
+                }
+            }
+            finally {
+                isButtonInvokingFocus = false;
+            }
+        });
+
+        element.find('.td-picker-button').on('click', () => {
+            isButtonInvokingFocus = true;
+            element.find('.td-input').focus();
+        });
+
+        // Hide datetimepicker when input field loses focus
+        element.find('.td-input').blur((e) => {
+            if (!e.relatedTarget) {
+                return;
+            }
+            datetimePicker.hide();
+        });
+    }
 });

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -2,7 +2,7 @@
 $(document).ready(startInitialization);
 
 // On page change (e.g. go back and forth in browser)
-document.addEventListener('turbolinks:load', () => {
+$(document).on('turbolinks:before-cache', () => {
     // Remove stale datetimepickers
     $('.tempus-dominus-widget').remove();
 });

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -16,13 +16,13 @@ var datetimePicker = new tempusDominus.TempusDominus(
 );
 
 // Catch Tempus Dominus error when user types in invalid date
-// see this discussion: https://github.com/Eonasdan/tempus-dominus/discussions/2656
+// this is rather hacky at the moment, see this discussion:
+// https://github.com/Eonasdan/tempus-dominus/discussions/2656
 datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
 datetimePicker.dates.parseInput = (input) => {
     try {
         return datetimePicker.dates.oldParseInput(input);
     } catch (err) {
-        console.log($('.td-error'));
         const errorMsg = $('.td-error').data('td-invalid-date');
         $('.td-error').text(errorMsg).show();
         datetimePicker.dates.clear();
@@ -35,8 +35,6 @@ datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
         $('.td-error').empty();
     }
 });
-
-
 
 // Show datetimepicker when user clicks in text field next to button
 // or when input field receives focus

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -12,8 +12,42 @@ var datetimePicker = new tempusDominus.TempusDominus(
         }
     }
 );
+
+// Catch Tempus Dominus error when user types in invalid date
+// see this discussion: https://github.com/Eonasdan/tempus-dominus/discussions/2656
+datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
+datetimePicker.dates.parseInput = (input) => {
+    try {
+        return datetimePicker.dates.oldParseInput(input);
+    } catch (err) {
+        datetimePicker.dates.clear();
+    }
+};
+
+var isButtonInvokingFocus = false;
+
+// Show datetimepicker when user clicks in text field next to button
+// or when input field receives focus
+$('#assignment-picker-input').on('click focusin', (e) => {
+    try {
+        if (!isButtonInvokingFocus) {
+            datetimePicker.show();
+        }
+    }
+    finally {
+        isButtonInvokingFocus = false;
+    }
 });
 
-$('#assignment-picker-input').on('click', () => {
-    $('#assignment-picker-button').click();
+$('#assignment-picker-button').on('click', () => {
+    isButtonInvokingFocus = true;
+    $('#assignment-picker-input').focus();
+});
+
+// Hide datetimepicker when input field loses focus
+$('#assignment-picker-input').blur((e) => {
+    if (!e.relatedTarget) {
+        return;
+    }
+    datetimePicker.hide();
 });

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,13 +1,17 @@
 // see https://getdatepicker.com
-$('#assignment-picker').tempusDominus({
-    display: {
-        sideBySide: true
-    },
-    localization: {
-        startOfTheWeek: 1,
-        format: 'yyyy-MM-dd HH:mm',
-        hourCycle: 'h23'
+var datetimePicker = new tempusDominus.TempusDominus(
+    document.getElementById('assignment-picker'),
+    {
+        display: {
+            sideBySide: true,
+        },
+        localization: {
+            startOfTheWeek: 1,
+            format: 'yyyy-MM-dd HH:mm',
+            hourCycle: 'h23',
+        }
     }
+);
 });
 
 $('#assignment-picker-input').on('click', () => {

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,103 +1,107 @@
-$(document).ready(function () {
+// Initialize on page load (when js file is dynamically loaded)
+$(document).ready(startInitialization);
 
-    // Initialize Tempus Dominus datetimepicker(s)
-    startInitialization();
-    function startInitialization() {
-        const pickerElements = $('.td-picker');
-        if (pickerElements.length == 0) {
-            console.error('No datetimepicker element found on page, although requested.');
-            return;
+// On page change (e.g. go back and forth in browser)
+document.addEventListener('turbolinks:load', () => {
+    // Remove stale datetimepickers
+    $('.tempus-dominus-widget').remove();
+});
+
+function startInitialization() {
+    const pickerElements = $('.td-picker');
+    if (pickerElements.length == 0) {
+        console.error('No datetimepicker element found on page, although requested.');
+        return;
+    }
+
+    pickerElements.each((i, element) => {
+        element = $(element);
+        const datetimePicker = initDatetimePicker(element);
+        registerErrorHandlers(datetimePicker, element);
+        registerFocusHandlers(datetimePicker, element);
+    });
+}
+
+function initDatetimePicker(element) {
+    // see https://getdatepicker.com
+    return new tempusDominus.TempusDominus(
+        element.get(0),
+        {
+            display: {
+                sideBySide: true, // clock to the right of the calendar
+            },
+            localization: {
+                startOfTheWeek: 1,
+                // choose format to be compliant with backend time format
+                format: 'yyyy-MM-dd HH:mm',
+                hourCycle: 'h23',
+            }
+        }
+    );
+}
+
+function registerErrorHandlers(datetimePicker, element) {
+    // Catch Tempus Dominus error when user types in invalid date
+    // this is rather hacky at the moment, see this discussion:
+    // https://github.com/Eonasdan/tempus-dominus/discussions/2656
+    datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
+    datetimePicker.dates.parseInput = (input) => {
+        try {
+            return datetimePicker.dates.oldParseInput(input);
+        } catch (err) {
+            const errorMsg = element.find('.td-error').data('td-invalid-date');
+            element.find('.td-error').text(errorMsg).show();
+            datetimePicker.dates.clear();
+        }
+    };
+
+    datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
+        // see https://getdatepicker.com/6/namespace/events.html#change
+
+        // Clear error message
+        if (e.isValid && !e.isClear) {
+            element.find('.td-error').empty();
         }
 
-        pickerElements.each((i, element) => {
-            element = $(element);
-            const datetimePicker = initDatetimePicker(element);
-            registerErrorHandlers(datetimePicker, element);
-            registerFocusHandlers(datetimePicker, element);
-        });
-    }
-
-    function initDatetimePicker(element) {
-        // see https://getdatepicker.com
-        return new tempusDominus.TempusDominus(
-            element.get(0),
-            {
-                display: {
-                    sideBySide: true, // clock to the right of the calendar
-                },
-                localization: {
-                    startOfTheWeek: 1,
-                    // choose format to be compliant with backend time format
-                    format: 'yyyy-MM-dd HH:mm',
-                    hourCycle: 'h23',
-                }
-            }
-        );
-    }
-
-    function registerErrorHandlers(datetimePicker, element) {
-        // Catch Tempus Dominus error when user types in invalid date
-        // this is rather hacky at the moment, see this discussion:
-        // https://github.com/Eonasdan/tempus-dominus/discussions/2656
-        datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
-        datetimePicker.dates.parseInput = (input) => {
-            try {
-                return datetimePicker.dates.oldParseInput(input);
-            } catch (err) {
-                const errorMsg = element.find('.td-error').data('td-invalid-date');
-                element.find('.td-error').text(errorMsg).show();
-                datetimePicker.dates.clear();
-            }
-        };
-
-        datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
-            // see https://getdatepicker.com/6/namespace/events.html#change
-
-            // Clear error message
-            if (e.isValid && !e.isClear) {
-                element.find('.td-error').empty();
-            }
-
-            // If date was selected, close datetimepicker.
-            // However: leave the datetimepicker open if user only changed time
-            if (e.oldDate && e.date && !hasUserChangedDate(e.oldDate, e.date)) {
-                datetimePicker.hide();
-            }
-        });
-    }
-
-    function hasUserChangedDate(oldDate, newDate) {
-        return oldDate.getHours() != newDate.getHours()
-            || oldDate.getMinutes() != newDate.getMinutes();
-    }
-
-    function registerFocusHandlers(datetimePicker, element) {
-        // Show datetimepicker when user clicks in text field next to button
-        // or when input field receives focus
-        var isButtonInvokingFocus = false;
-
-        element.find('.td-input').on('click focusin', (e) => {
-            try {
-                if (!isButtonInvokingFocus) {
-                    datetimePicker.show();
-                }
-            }
-            finally {
-                isButtonInvokingFocus = false;
-            }
-        });
-
-        element.find('.td-picker-button').on('click', () => {
-            isButtonInvokingFocus = true;
-            element.find('.td-input').focus();
-        });
-
-        // Hide datetimepicker when input field loses focus
-        element.find('.td-input').blur((e) => {
-            if (!e.relatedTarget) {
-                return;
-            }
+        // If date was selected, close datetimepicker.
+        // However: leave the datetimepicker open if user only changed time
+        if (e.oldDate && e.date && !hasUserChangedDate(e.oldDate, e.date)) {
             datetimePicker.hide();
-        });
-    }
-});
+        }
+    });
+}
+
+function hasUserChangedDate(oldDate, newDate) {
+    return oldDate.getHours() != newDate.getHours()
+        || oldDate.getMinutes() != newDate.getMinutes();
+}
+
+function registerFocusHandlers(datetimePicker, element) {
+    // Show datetimepicker when user clicks in text field next to button
+    // or when input field receives focus
+    var isButtonInvokingFocus = false;
+
+    element.find('.td-input').on('click focusin', (e) => {
+        try {
+            if (!isButtonInvokingFocus) {
+                datetimePicker.show();
+            }
+        }
+        finally {
+            isButtonInvokingFocus = false;
+        }
+    });
+
+    element.find('.td-picker-button').on('click', () => {
+        isButtonInvokingFocus = true;
+        element.find('.td-input').focus();
+    });
+
+    // Hide datetimepicker when input field loses focus
+    element.find('.td-input').blur((e) => {
+        if (!e.relatedTarget) {
+            return;
+        }
+        datetimePicker.hide();
+    });
+}

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,65 +1,70 @@
-// see https://getdatepicker.com
-var datetimePicker = new tempusDominus.TempusDominus(
-    // currently, we only support one datetimepicker on a page
-    document.getElementsByClassName('td-picker')[0],
-    {
-        display: {
-            sideBySide: true,
-        },
-        localization: {
-            startOfTheWeek: 1,
-            // choose format to be compliant with backend time format
-            format: 'yyyy-MM-dd HH:mm',
-            hourCycle: 'h23',
+$(document).ready(function () {
+
+    // see https://getdatepicker.com
+    var datetimePicker = new tempusDominus.TempusDominus(
+        // currently, we only support one datetimepicker on a page
+        document.getElementsByClassName('td-picker')[0],
+        {
+            display: {
+                sideBySide: true,
+            },
+            localization: {
+                startOfTheWeek: 1,
+                // choose format to be compliant with backend time format
+                format: 'yyyy-MM-dd HH:mm',
+                hourCycle: 'h23',
+            }
         }
-    }
-);
+    );
 
-// Catch Tempus Dominus error when user types in invalid date
-// this is rather hacky at the moment, see this discussion:
-// https://github.com/Eonasdan/tempus-dominus/discussions/2656
-datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
-datetimePicker.dates.parseInput = (input) => {
-    try {
-        return datetimePicker.dates.oldParseInput(input);
-    } catch (err) {
-        const errorMsg = $('.td-error').data('td-invalid-date');
-        $('.td-error').text(errorMsg).show();
-        datetimePicker.dates.clear();
-    }
-};
-
-datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
-    // see https://getdatepicker.com/6/namespace/events.html#change
-    if (e.isValid && !e.isClear) {
-        $('.td-error').empty();
-    }
-});
-
-// Show datetimepicker when user clicks in text field next to button
-// or when input field receives focus
-var isButtonInvokingFocus = false;
-
-$('.td-input').on('click focusin', (e) => {
-    try {
-        if (!isButtonInvokingFocus) {
-            datetimePicker.show();
+    // Catch Tempus Dominus error when user types in invalid date
+    // this is rather hacky at the moment, see this discussion:
+    // https://github.com/Eonasdan/tempus-dominus/discussions/2656
+    datetimePicker.dates.oldParseInput = datetimePicker.dates.parseInput;
+    datetimePicker.dates.parseInput = (input) => {
+        try {
+            return datetimePicker.dates.oldParseInput(input);
+        } catch (err) {
+            const errorMsg = $('.td-error').data('td-invalid-date');
+            $('.td-error').text(errorMsg).show();
+            datetimePicker.dates.clear();
         }
-    }
-    finally {
-        isButtonInvokingFocus = false;
-    }
-});
+    };
 
-$('.td-picker-button').on('click', () => {
-    isButtonInvokingFocus = true;
-    $('.td-input').focus();
-});
+    datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
+        // see https://getdatepicker.com/6/namespace/events.html#change
+        if (e.isValid && !e.isClear) {
+            $('.td-error').empty();
+            datetimePicker.hide();
+        }
+    });
 
-// Hide datetimepicker when input field loses focus
-$('.td-input').blur((e) => {
-    if (!e.relatedTarget) {
-        return;
-    }
-    datetimePicker.hide();
+    // Show datetimepicker when user clicks in text field next to button
+    // or when input field receives focus
+    var isButtonInvokingFocus = false;
+
+    $('.td-input').on('click focusin', (e) => {
+        try {
+            if (!isButtonInvokingFocus) {
+                datetimePicker.show();
+            }
+        }
+        finally {
+            isButtonInvokingFocus = false;
+        }
+    });
+
+    $('.td-picker-button').on('click', () => {
+        isButtonInvokingFocus = true;
+        $('.td-input').focus();
+    });
+
+    // Hide datetimepicker when input field loses focus
+    $('.td-input').blur((e) => {
+        if (!e.relatedTarget) {
+            return;
+        }
+        datetimePicker.hide();
+    });
+
 });

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -60,7 +60,7 @@ $(document).ready(function () {
 
             // If date was selected, close datetimepicker.
             // However: leave the datetimepicker open if user only changed time
-            if (e.oldDate && !hasUserChangedDate(e.oldDate, e.date)) {
+            if (e.oldDate && e.date && !hasUserChangedDate(e.oldDate, e.date)) {
                 datetimePicker.hide();
             }
         });

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -52,11 +52,23 @@ $(document).ready(function () {
 
         datetimePicker.subscribe(tempusDominus.Namespace.events.change, (e) => {
             // see https://getdatepicker.com/6/namespace/events.html#change
+
+            // Clear error message
             if (e.isValid && !e.isClear) {
                 element.find('.td-error').empty();
+            }
+
+            // If date was selected, close datetimepicker.
+            // However: leave the datetimepicker open if user only changed time
+            if (e.oldDate && !hasUserChangedDate(e.oldDate, e.date)) {
                 datetimePicker.hide();
             }
         });
+    }
+
+    function hasUserChangedDate(oldDate, newDate) {
+        return oldDate.getHours() != newDate.getHours()
+            || oldDate.getMinutes() != newDate.getMinutes();
     }
 
     function registerFocusHandlers(datetimePicker, element) {

--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -1,5 +1,4 @@
 // see https://getdatepicker.com
-console.log('trying to import datetimepicker');
 $('#assignment-picker').tempusDominus({
     display: {
         sideBySide: true
@@ -9,4 +8,8 @@ $('#assignment-picker').tempusDominus({
         format: 'yyyy-MM-dd HH:mm',
         hourCycle: 'h23'
     }
+});
+
+$('#assignment-picker-input').on('click', () => {
+    $('#assignment-picker-button').click();
 });

--- a/app/assets/javascripts/media.coffee
+++ b/app/assets/javascripts/media.coffee
@@ -17,13 +17,6 @@ fancyTimeFormat = (time) ->
   output
 
 $(document).on 'turbolinks:load', ->
-
-  # init datetimepicker
-  $('#release_date').datetimepicker
-      format: 'd.m.Y H:i'
-      inline: false
-      lang: 'en'
-
   # disable/enable search field on the media search page, depending on
   # whether 'all tags'/'all editors'/... are selected
   $('[id^="search_all_"]').on 'change', ->

--- a/app/assets/javascripts/media.coffee
+++ b/app/assets/javascripts/media.coffee
@@ -388,7 +388,7 @@ $(document).on 'turbolinks:load', ->
     return
 
   $('#release_date').on 'focus', ->
-    # Focus other radio button if user clicks on release date input field
+    # Select other option if user clicks on release date input field
     $('#medium_release_now_0').prop('checked', true)
     return
 

--- a/app/assets/javascripts/media.coffee
+++ b/app/assets/javascripts/media.coffee
@@ -388,14 +388,8 @@ $(document).on 'turbolinks:load', ->
     return
 
   $('#release_date').on 'focus', ->
+    # Focus other radio button if user clicks on release date input field
     $('#medium_release_now_0').prop('checked', true)
-    $('#release_date').datetimepicker('toggle')
-    return
-
-  $('#medium_assignment_deadline').on 'focus', ->
-    $(this).datetimepicker
-      format: 'd.m.Y H:i'
-      inline: false
     return
 
   $('#medium_create_assignment').on 'click', ->

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,23 +15,10 @@
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-// JQuery Datetimepicker fix
-// import '...' does not work, random names for the import don't work either
-// we use "css" and "myLib" imports although these strings do not show up anywhere
-// in our codebase. This is just a hack to make the imports-loader work. Maybe it has
-// to do with how webpacker resolves the imports or how jquery-datetimepicker exports
-// its module.
-import css from 'jquery-datetimepicker/build/jquery.datetimepicker.min.css'
-import myLib from 'imports-loader?imports=default%20jquery%20$!./../../../node_modules/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js'
-
-import moment from "moment"; // require
-window.moment = moment;
 import {
     WidgetInstance
 } from "friendly-challenge";
 var friendlyChallengeWidgetInstance = WidgetInstance
-$.datetimepicker.setLocale('de');
-
 
 document.addEventListener("turbolinks:load", function () {
     var doneCallback, element, options, widget;

--- a/app/javascript/packs/application.sass
+++ b/app/javascript/packs/application.sass
@@ -1,1 +1,0 @@
-@import "jquery-datetimepicker/build/jquery.datetimepicker.min.css"

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -23,6 +23,7 @@
             <%= f.text_field :deadline,
                 id: 'assignment-picker-input',
                 class: 'form-control',
+                autocomplete: 'off',
                 'data-td-target': '#assignment-picker' %>
             <span
               class="input-group-text"
@@ -76,6 +77,7 @@
         <%= link_to t('buttons.cancel'),
                     cancel_editing_assignment_path(assignment),
                     class: 'btn btn-sm btn-secondary',
+                    role: 'button',
                     remote: true %>
       </div>
     </div>

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      <div class="form-group col-2">
+      <div class="form-group col-3">
         <div class="col-sm-12" id="htmlTarget">
           <div
             class="input-group log-event td-picker"
@@ -70,7 +70,7 @@
              id="assignment-deletion-date-error">
         </div>
       </div>
-      <div class="form-group col-2">
+      <div class="form-group col-1">
         <%= f.submit t('buttons.save'),
                      class: 'btn btn-sm btn-primary ms-2' %>
         <%= link_to t('buttons.cancel'),

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag 'datetimepicker' %>
+
 <div class="list-group-item assignmentRow"
        data-id="<%= assignment.id.to_i %>">
   <%= form_with model: assignment do |f| %>
@@ -10,15 +12,33 @@
              id="assignment-title-error">
         </div>
       </div>
+
       <div class="form-group col-2">
-        <%= f.text_field :deadline,
-                         class: 'form-control',
-                         autocomplete: 'off',
-                         id: "assignment_deadline_#{assignment.id}" %>
+        <div class="col-sm-12" id="htmlTarget">
+          <div
+            class="input-group log-event td-picker"
+            id="assignment-picker"
+            data-td-target-input="nearest"
+            data-td-target-toggle="nearest">
+            <%= f.text_field :deadline,
+                id: 'assignment-picker-input',
+                class: 'form-control',
+                'data-td-target': '#assignment-picker' %>
+            <span
+              class="input-group-text"
+              data-td-target="#assignment-picker"
+              data-td-toggle="datetimepicker">
+              <i class="fas fa-calendar"></i>
+            </span>
+          </div>
+        </div>
+
         <div class="invalid-feedback"
              id="assignment-deadline-error">
         </div>
       </div>
+
+
       <div class="form-group col-2">
         <%= f.select :medium_id,
                      options_for_select(Medium.where(teachable: assignment.lecture,

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -26,9 +26,11 @@
                 'data-td-target': '#assignment-picker' %>
             <span
               class="input-group-text"
+              role="button"
+              id="assignment-picker-button"
               data-td-target="#assignment-picker"
               data-td-toggle="datetimepicker">
-              <i class="fas fa-calendar"></i>
+              <i class="bi bi-calendar-fill"></i>
             </span>
           </div>
         </div>

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -13,30 +13,28 @@
         </div>
       </div>
 
-      <div class="form-group col-3">
-        <div class="col-sm-12" id="htmlTarget">
-          <div
-            class="input-group log-event td-picker"
-            id="assignment-picker"
-            data-td-target-input="nearest"
-            data-td-target-toggle="nearest">
-            <%= f.text_field :deadline,
-                class: 'form-control td-input',
-                autocomplete: 'off',
-                'data-td-target': '#assignment-picker' %>
-            <span
-              class="input-group-text td-picker-button"
-              role="button"
-              data-td-target="#assignment-picker"
-              data-td-toggle="datetimepicker">
-              <i class="bi bi-calendar-fill"></i>
-            </span>
+      <%# Datetimepicker for assignment deadline %>
+      <div class="col-3 form-group">
+        <div
+          class="input-group log-event td-picker"
+          id="assignment-picker"
+          data-td-target-input="nearest"
+          data-td-target-toggle="nearest">
+          <%= f.text_field :deadline,
+              class: 'form-control td-input',
+              autocomplete: 'off',
+              'data-td-target': '#assignment-picker' %>
+          <span
+            class="input-group-text td-picker-button"
+            role="button"
+            data-td-target="#assignment-picker"
+            data-td-toggle="datetimepicker">
+            <i class="bi bi-calendar-fill"></i>
+          </span>
+          <div class="invalid-feedback td-error"
+            id="assignment-deadline-error"
+            data-td-invalid-date="<%= t('datetimepicker.invalid_date') %>">
           </div>
-        </div>
-
-        <div class="invalid-feedback td-error"
-             id="assignment-deadline-error"
-             data-td-invalid-date="<%= t('datetimepicker.invalid_date') %>">
         </div>
       </div>
 

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -21,14 +21,12 @@
             data-td-target-input="nearest"
             data-td-target-toggle="nearest">
             <%= f.text_field :deadline,
-                id: 'assignment-picker-input',
-                class: 'form-control',
+                class: 'form-control td-input',
                 autocomplete: 'off',
                 'data-td-target': '#assignment-picker' %>
             <span
-              class="input-group-text"
+              class="input-group-text td-picker-button"
               role="button"
-              id="assignment-picker-button"
               data-td-target="#assignment-picker"
               data-td-toggle="datetimepicker">
               <i class="bi bi-calendar-fill"></i>
@@ -36,8 +34,9 @@
           </div>
         </div>
 
-        <div class="invalid-feedback"
-             id="assignment-deadline-error">
+        <div class="invalid-feedback td-error"
+             id="assignment-deadline-error"
+             data-td-invalid-date="<%= t('datetimepicker.invalid_date') %>">
         </div>
       </div>
 

--- a/app/views/assignments/_row.html.erb
+++ b/app/views/assignments/_row.html.erb
@@ -5,7 +5,7 @@
     <div class="col-2">
       <%= assignment.title %>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <% if assignment.deadline %>
         <%= I18n.l(assignment.deadline, format: :long) %>
       <% end %>
@@ -26,7 +26,7 @@
         <%= I18n.l(assignment.deletion_date, format: :long) %>
       <% end %>
     </div>
-    <div class="col-2">
+    <div class="col-1">
       <% if assignment.persisted? %>
         <%= link_to edit_assignment_path(assignment),
                     class: 'text-dark',

--- a/app/views/assignments/create.coffee
+++ b/app/views/assignments/create.coffee
@@ -1,9 +1,9 @@
 # clean up from previous error messages
-$('#assignment_title').removeClass('is-invalid')
+$('#assignment_title_').removeClass('is-invalid')
 $('#assignment-title-error').empty()
 $('#assignment_deadline').removeClass('is-invalid')
 $('#assignment-deadline-error').empty()
-$('#assignment_deletion_date').removeClass('is-invalid')
+$('#assignment_deletion_date_').removeClass('is-invalid')
 $('#assignment-deletion-date-error').empty()
 
 # display error message
@@ -11,7 +11,7 @@ $('#assignment-deletion-date-error').empty()
 <% if @errors[:title].present? %>
 $('#assignment-title-error')
   .append('<%= @errors[:title].join(" ") %>').show()
-$('#assignment_title').addClass('is-invalid')
+$('#assignment_title_').addClass('is-invalid')
 <% end %>
 <% if @errors[:deadline].present? %>
 $('#assignment-deadline-error')
@@ -21,7 +21,7 @@ $('#assignment_deadline').addClass('is-invalid')
 <% if @errors[:deletion_date].present? %>
 $('#assignment-deletion-date-error')
   .append('<%= @errors[:deletion_date].join(" ") %>').show()
-$('#assignment_deletion_date').addClass('is-invalid')
+$('#assignment_deletion_date_').addClass('is-invalid')
 <% end %>
 <% else %>
 $('.assignmentRow[data-id="0"')

--- a/app/views/assignments/edit.coffee
+++ b/app/views/assignments/edit.coffee
@@ -16,7 +16,3 @@ new TomSelect('#assignment_medium_id_<%= @assignment.id %>',
 # make sure that no medium is preselected
 $('#assignment_medium_id_<%= @assignment.id %>').val(null).trigger('change')
 <% end %>
-
-# using moment to format the date right
-d = moment($("#assignment_deadline_<%= @assignment.id %>").val(),"YYYY-MM-DD hh:mm:ss z")
-$("#assignment_deadline_<%= @assignment.id %>").val (d.format("DD.MM.Y H:mm"))

--- a/app/views/assignments/edit.coffee
+++ b/app/views/assignments/edit.coffee
@@ -20,6 +20,3 @@ $('#assignment_medium_id_<%= @assignment.id %>').val(null).trigger('change')
 # using moment to format the date right
 d = moment($("#assignment_deadline_<%= @assignment.id %>").val(),"YYYY-MM-DD hh:mm:ss z")
 $("#assignment_deadline_<%= @assignment.id %>").val (d.format("DD.MM.Y H:mm"))
-$("#assignment_deadline_<%= @assignment.id %>").datetimepicker
-  format:'d.m.Y H:i'
-  inline:false

--- a/app/views/assignments/new.js.erb
+++ b/app/views/assignments/new.js.erb
@@ -16,8 +16,3 @@ new TomSelect('#assignment_medium_id_', {
 });
 
 $('#assignment_medium_id_').val(null).trigger('change');
-
-$("#assignment_deadline_").datetimepicker({
-  format: 'd.m.Y H:i',
-  inline: false
-});

--- a/app/views/assignments/update.coffee
+++ b/app/views/assignments/update.coffee
@@ -2,6 +2,8 @@
 # clean up from previous error messages
 $('#assignment_title_').removeClass('is-invalid')
 $('#assignment-title-error').empty()
+$('#assignment_deadline').removeClass('is-invalid')
+$('#assignment-deadline-error').empty()
 
 # display error message
 <% if @errors[:title].present? %>

--- a/app/views/assignments/update.coffee
+++ b/app/views/assignments/update.coffee
@@ -1,6 +1,6 @@
 <% if @errors.present? %>
 # clean up from previous error messages
-$('#assignment_title_').removeClass('is-invalid')
+$('#assignment_title').removeClass('is-invalid')
 $('#assignment-title-error').empty()
 $('#assignment_deadline').removeClass('is-invalid')
 $('#assignment-deadline-error').empty()
@@ -9,7 +9,7 @@ $('#assignment-deadline-error').empty()
 <% if @errors[:title].present? %>
 $('#assignment-title-error')
   .append('<%= @errors[:title].join(" ") %>').show()
-$('#assignment_title_').addClass('is-invalid')
+$('#assignment_title').addClass('is-invalid')
 <% end %>
 <% if @errors[:deadline].present? %>
 $('#assignment-deadline-error')

--- a/app/views/assignments/update.coffee
+++ b/app/views/assignments/update.coffee
@@ -1,13 +1,13 @@
 <% if @errors.present? %>
 # clean up from previous error messages
-$('#assignment_title').removeClass('is-invalid')
+$('#assignment_title_').removeClass('is-invalid')
 $('#assignment-title-error').empty()
 
 # display error message
 <% if @errors[:title].present? %>
 $('#assignment-title-error')
   .append('<%= @errors[:title].join(" ") %>').show()
-$('#assignment_title').addClass('is-invalid')
+$('#assignment_title_').addClass('is-invalid')
 <% end %>
 <% if @errors[:deadline].present? %>
 $('#assignment-deadline-error')

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -35,29 +35,16 @@
         crossorigin="anonymous">
 </script>
 
-<!-- Font awesome is not required provided you change the icon options -->
+<!-- Tempus Dominus Datetimepicker -->
+<!-- Font awesome required for icons in Datetimepicker -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/js/solid.min.js"></script>
-
 <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/js/fontawesome.min.js"></script>
-<!-- end FA -->
-
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" crossorigin="anonymous">
 </script>
-<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/tempus-dominus.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/jQuery-provider.js"></script>
-
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/tempus-dominus.js">
+</script>
 <link rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/css/tempus-dominus.css"
-/>
-
-
-<%# Datetimepicker (Tempus Dominus) %>
-<!-- Popperjs (needed for Tempus Dominus) -->
-<%# <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" crossorigin="anonymous"></script>
-<!-- Tempus Dominus JavaScript -->
-<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/tempus-dominus.min.js" crossorigin="anonymous"></script>
-<!-- Tempus Dominus Styles -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/css/tempus-dominus.min.css" crossorigin="anonymous"> %>
+  href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/css/tempus-dominus.css">
 
 <script src="https://cdn.jsdelivr.net/npm/sanitize-html@1.27.0/dist/sanitize-html.min.js" integrity="sha256-+Tha6wUu+wzAOUzilJ7AmF4OXc3CsY1aMsWopnCVwb4=" crossorigin="anonymous"></script>
 <script defer

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -34,6 +34,31 @@
         integrity="sha256-rADF2WO6GbkNb5O9gqHdjQ/XhrfnXDtPdHdRe5KQmek="
         crossorigin="anonymous">
 </script>
+
+<!-- Font awesome is not required provided you change the icon options -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/js/solid.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/js/fontawesome.min.js"></script>
+<!-- end FA -->
+
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" crossorigin="anonymous">
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/tempus-dominus.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/jQuery-provider.js"></script>
+
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/css/tempus-dominus.css"
+/>
+
+
+<%# Datetimepicker (Tempus Dominus) %>
+<!-- Popperjs (needed for Tempus Dominus) -->
+<%# <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" crossorigin="anonymous"></script>
+<!-- Tempus Dominus JavaScript -->
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/tempus-dominus.min.js" crossorigin="anonymous"></script>
+<!-- Tempus Dominus Styles -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/css/tempus-dominus.min.css" crossorigin="anonymous"> %>
+
 <script src="https://cdn.jsdelivr.net/npm/sanitize-html@1.27.0/dist/sanitize-html.min.js" integrity="sha256-+Tha6wUu+wzAOUzilJ7AmF4OXc3CsY1aMsWopnCVwb4=" crossorigin="anonymous"></script>
 <script defer
         src="https://cdn.jsdelivr.net/npm/katex@0.13.9/dist/katex.min.js"
@@ -58,6 +83,8 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/r29/html5.min.js">
   </script>
 <![endif]-->
+
+
 
 <meta name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/app/views/lectures/edit/_assignments.html.erb
+++ b/app/views/lectures/edit/_assignments.html.erb
@@ -41,7 +41,7 @@
                 <%= t('basics.title') %>
               </h6>
             </div>
-            <div class="col-2">
+            <div class="col-3">
               <h6>
                 <%= t('basics.deadline') %>
               </h6>
@@ -61,7 +61,7 @@
                 <%= t('assignment.deletion_date') %>
               </h6>
             </div>
-            <div class="col-2">
+            <div class="col-1">
               <h6>
                 <%= t('basics.action') %>
                 <%= helpdesk(t('assignment.destruction_info'), true) %>

--- a/app/views/media/_publish_modal.html.erb
+++ b/app/views/media/_publish_modal.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag 'datetimepicker' %>
+
 <div class="modal fade"
      id="publishMediumModal"
      tabindex="-1"
@@ -50,18 +52,32 @@
                         class: 'form-check-label' %>
             <%= helpdesk(t('admin.medium.info.scheduled_release'), true) %>
           </div>
-          <div class="mb-3 col-12">
+
+          <%# Datetimepicker for release date %>
+          <div
+            class="mb-3 input-group td-picker"
+            id="release-date-picker"
+            data-td-target-input="nearest"
+            data-td-target-toggle="nearest">
             <%= f.text_field :release_date,
-                             class: 'form-control',
+                             class: 'form-control td-input',
                              id: 'release_date',
                              autocomplete: 'off',
-                             value: medium.planned_release_date
-                                          .try(:strftime,
-                                               '%d.%m.%Y %H:%M') %>
-            <div class="invalid-feedback"
-                 id="release-date-error">
+                             value: medium.planned_release_date,
+                            'data-td-target': '#release-date-picker'%>
+            <span
+              class="input-group-text td-picker-button"
+              role="button"
+              data-td-target="#release-date-picker"
+              data-td-toggle="datetimepicker">
+              <i class="bi bi-calendar-fill"></i>
+            </span>
+            <div class="invalid-feedback td-error"
+                 id="release-date-error"
+                 data-td-invalid-date="<%= t('datetimepicker.invalid_date') %>">
             </div>
           </div>
+
           <% if medium.sort == 'Nuesse' && medium.teachable.is_a?(Lecture) %>
             <div class="mb-1">
               <%= t('basics.assignment') %>
@@ -88,21 +104,37 @@
                      id="assignment-title-error">
                 </div>
               </div>
-              <div class="mb-3 col-3">
+
+              <%# Datetimepicker for assignment deadline %>
+              <div class="mb-3 col-4">
                 <%= f.label :assignment_deadline, t('basics.deadline'),
                             class: "form-label" %>
-                <%= f.text_field :assignment_deadline,
-                                 class: 'form-control',
-                                 autocomplete: 'off',
-                                 value: medium.publisher
-                                             &.assignment_deadline
-                                              .try(:strftime,
-                                                   '%d.%m.%Y %H:%M') %>
-                <div class="invalid-feedback"
-                     id="assignment-deadline-error">
+                <div
+                  class="input-group td-picker"
+                  id="assignment-date-picker"
+                  data-td-target-input="nearest"
+                  data-td-target-toggle="nearest">
+                  <%= f.text_field :assignment_deadline,
+                                  class: 'form-control td-input',
+                                  autocomplete: 'off',
+                                  value: medium.publisher
+                                              &.assignment_deadline,
+                                  'data-td-target': '#assignment-date-picker' %>
+                  <span
+                    class="input-group-text td-picker-button"
+                    role="button"
+                    data-td-target="#release-date-picker"
+                    data-td-toggle="datetimepicker">
+                    <i class="bi bi-calendar-fill"></i>
+                  </span>
+                  <div class="invalid-feedback td-error"
+                      id="assignment-deadline-error"
+                      data-td-invalid-date="<%= t('datetimepicker.invalid_date') %>">
+                  </div>
                 </div>
               </div>
-              <div class="mb-3 col-3">
+
+              <div class="mb-3 col-2 col-s-4">
                 <%= f.label :assignment_file_type,
                             t('submission.file_format'),
                             class: "form-label" %>
@@ -114,7 +146,8 @@
               </div>
               <div class="mb-3 col-3">
                 <%= f.label :assignment_deletion_date,
-                            t('assignment.deletion_date') %>
+                            t('assignment.deletion_date'),
+                            class: "form-label" %>
                 <%= f.select :assignment_deletion_date,
                             Term.possible_deletion_dates_localized,
                             {},

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2442,7 +2442,7 @@ de:
     formats:
       concise: '%d.%m.%Y'
   datetimepicker:
-    invalid_date: 'Ungültiges Datums-Zeit-Format'
+    invalid_date: 'Ungültiges Datums-Zeit-Format.'
   time:
     formats:
       concise: '%d.%m.%Y'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2441,6 +2441,8 @@ de:
   date:
     formats:
       concise: '%d.%m.%Y'
+  datetimepicker:
+    invalid_date: 'Ungültiges Datumsformat'
   time:
     formats:
       concise: '%d.%m.%Y'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2442,7 +2442,7 @@ de:
     formats:
       concise: '%d.%m.%Y'
   datetimepicker:
-    invalid_date: 'Ungültiges Datumsformat'
+    invalid_date: 'Ungültiges Datums-Zeit-Format'
   time:
     formats:
       concise: '%d.%m.%Y'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2300,6 +2300,8 @@ en:
   date:
     formats:
       concise: '%Y-%m-%d'
+  datetimepicker:
+    invalid_date: 'Invalid date format'
   time:
     formats:
       concise: '%Y-%m-%d'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2301,7 +2301,7 @@ en:
     formats:
       concise: '%Y-%m-%d'
   datetimepicker:
-    invalid_date: 'Invalid date format'
+    invalid_date: 'Invalid date time format'
   time:
     formats:
       concise: '%Y-%m-%d'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2301,7 +2301,7 @@ en:
     formats:
       concise: '%Y-%m-%d'
   datetimepicker:
-    invalid_date: 'Invalid date time format'
+    invalid_date: 'Invalid date time format.'
   time:
     formats:
       concise: '%Y-%m-%d'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "css-loader": "^5.2.7",
     "friendly-challenge": "^0.9.12",
     "imports-loader": "^1.2.0",
-    "moment": "^2.29.4",
     "regenerator-runtime": "^0.13.11",
     "sass": "^1.63.4",
     "sass-loader": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "css-loader": "^5.2.7",
     "friendly-challenge": "^0.9.12",
     "imports-loader": "^1.2.0",
-    "jquery-datetimepicker": "^2.5.21",
     "moment": "^2.29.4",
     "regenerator-runtime": "^0.13.11",
     "sass": "^1.63.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4674,11 +4674,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.29.4:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,25 +4232,6 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery-datetimepicker@^2.5.21:
-  version "2.5.21"
-  resolved "https://registry.yarnpkg.com/jquery-datetimepicker/-/jquery-datetimepicker-2.5.21.tgz#00c388a78df2732fedfdb5c6529b6e84d53e0235"
-  integrity sha512-wDTpZ4f1PWd1XGaIIE0n6jLynlm+akBJ7/NjaB1bk2UJSS593CHJPZ3+FNEXoyvNVUeBlBC0oX6WTfCyfUhX/w==
-  dependencies:
-    jquery ">= 1.7.2"
-    jquery-mousewheel ">= 3.1.13"
-    php-date-formatter "^1.3.4"
-
-"jquery-mousewheel@>= 3.1.13":
-  version "3.1.13"
-  resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"
-  integrity sha512-GXhSjfOPyDemM005YCEHvzrEALhKDIswtxSHSR2e4K/suHVJKJxxRCGz3skPjNxjJjQa9AVSGGlYjv1M3VLIPg==
-
-"jquery@>= 1.7.2":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.0.tgz#fe2c01a05da500709006d8790fe21c8a39d75612"
-  integrity sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5169,11 +5150,6 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-php-date-formatter@^1.3.4:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/php-date-formatter/-/php-date-formatter-1.3.6.tgz#6d67359da890c742005fa89d20be3ded31cc1d2a"
-  integrity sha512-/CKsZYmAwXeNh8KpD/CF9hcJDZNhdb2ICN8+qgqOt5sUu9liZIxZ1R284TNj5MtPt8RjG5X0xn6WSqL0kcKMBg==
 
 picocolors@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
The previously used JQuery datetimepicker was imported like this

```js
import css from 'jquery-datetimepicker/build/jquery.datetimepicker.min.css'
import myLib from 'imports-loader?imports=default%20jquery%20$!./../../../node_modules/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js'
```

This dirty fix to direct webpack to the node modules folder has already caused too much pain since this was of course very fragile and thus failed often and seemingly in an undeterministic way. A quick fix was to change the import path, load the page again, then change the path back, so that webpack(er) picks up the changes. This has to find an end.

**Therefore, this PR replaces the previously used [JQuery datetimepicker](https://github.com/xdan/datetimepicker) with the [Tempus Dominus Datetimepicker](https://getdatepicker.com/)**.

![image](https://github.com/MaMpf-HD/mampf/assets/37160523/76a9e911-2993-4f96-b479-734b0e53a1ae)
![image](https://github.com/MaMpf-HD/mampf/assets/37160523/3adeb57d-3707-4389-9652-5418ec9459b0)


## What to look for in reviews

- [x]  Check that every occurrence of the datetimepicker is working. You can find the datetimepickers here:
    - [x] at the `/lectures/:id/edit` endpoint under the "Homework" section
    - [x] at the `/media/:id/edit` endpoint inside the publish modal. Note that when you create an exercise, there are actually two datetimepickers in this modal! check both: only one datetimepicker (when trying to publish something different than an exercise) and both datetimepickers (when publishing an exercise)
- [x] Errors should be shown if we try to enter a datetime string by hand and the format is not the requested one. The error should go away if a correct date is selected.
- [x] Datetimepicker should show up when clicking in the text input field or when using the tab key to tab into this field. The Datetimepicker should also show up when clicking on the calender button. It should go away when any date is selected. It should not go away when the time is changed.
- [x] Validation of the form when clicking on the submit button should still work, e.g. when no date is selected at all.
- [x] Users should not be able to misuse the endpoint and make a request with an invalid date (the request should then fail). This can only be checked by making a custom request in apps like Postman etc. This should already be the case as the endpoints were not changed.
- [x] No remnants of the old JQuery Datetimepicker should be left in the codebase.
- [x] In the console, there should be no error: neither for the old JQuery datetimepicker, nor for the new Tempus Dominus datetimepicker.
- [x] In the console, there should be no warnings at all. Not even related to missing sourcemaps or debug info.

## Further notes
- We dropped [`Moment.js`](https://momentjs.com/) as library for formatting datetime strings. No frontend datetimeformatting is done anymore. The backend formatting is not affected by this.
- The `javascript/packs/application.sass` file is now an empty file. We cannot delete it right now as that would also mean we'd have to change the webpacker configuration which is done in another PR addressing #454.