### PR TITLE
Fix styling of small dot indicating current navbar item

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -303,3 +303,7 @@ a {
     text-decoration: underline;
   }
 }
+
+.nav-item {
+  position: relative;
+}


### PR DESCRIPTION
In the Apple Safari browser, the dot under the currently active navbar-item was not placed at the correct position. This is how it should be:

![image](https://github.com/MaMpf-HD/mampf/assets/37160523/74bf1644-5350-4b10-a7a1-b9e181abc713)

⚠ Before merging: let Apple user actually test this on mampf-experimental.
