### PR TITLE
Stay with FontAwesome5 icons

### DIFF
--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -22,6 +22,24 @@ function startInitialization() {
     });
 }
 
+function getDateTimePickerIcons() {
+    // At the moment: continue to use FontAwesome 5 icons
+    // see https://getdatepicker.com/6/plugins/fa5.html
+    // see https://github.com/Eonasdan/tempus-dominus/blob/master/dist/plugins/fa-five.js
+    return {
+        type: 'icons',
+        time: 'fas fa-clock',
+        date: 'fas fa-calendar',
+        up: 'fas fa-arrow-up',
+        down: 'fas fa-arrow-down',
+        previous: 'fas fa-chevron-left',
+        next: 'fas fa-chevron-right',
+        today: 'fas fa-calendar-check',
+        clear: 'fas fa-trash',
+        close: 'fas fa-times',
+    }
+}
+
 function initDatetimePicker(element) {
     // see https://getdatepicker.com
     return new tempusDominus.TempusDominus(
@@ -29,6 +47,7 @@ function initDatetimePicker(element) {
         {
             display: {
                 sideBySide: true, // clock to the right of the calendar
+                icons: getDateTimePickerIcons(),
             },
             localization: {
                 startOfTheWeek: 1,

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -9,6 +9,7 @@
 <%= stylesheet_link_tag 'application',
                         media: 'all',
                         'data-turbolinks-track': 'reload' %>
+
 <link rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.12.0/css/all.min.css"
       integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0="
@@ -36,9 +37,7 @@
 </script>
 
 <!-- Tempus Dominus Datetimepicker -->
-<!-- Font awesome required for icons in Datetimepicker -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/js/solid.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/js/fontawesome.min.js"></script>
+<!-- Popper is required for Tempus Dominus -->
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" crossorigin="anonymous">
 </script>
 <script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.7.10/dist/js/tempus-dominus.js">


### PR DESCRIPTION
As of #526, the icons in the admin navbar did not work anymore as we have included FontAwesome6 for Tempus Dominus, however they seem to not be compliant with v5 we use so far. Hence, we remove v6 now and continue to rely on v5 and can then upgrade to v6 later by upgrading all icons in MaMpf to v6 (not just the datetimepicker icons).