### PR TITLE
Fix application bundle not being served by webpacker in dev-setup

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -51,6 +51,7 @@ default: &default
 development:
   <<: *default
   compile: true
+  public_output_path: assets/packs
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
The application bundle was not correctly served in the local docker setup and instead a debug version was used and an error thrown in the browser console.

We fix this by specifying where webpacker should save the static files (default location where rails will pick it up in the "old" sprockets assets pipeline we use). Production and test environments are not affected by this as they precompile all the assets in advance and do not use the webpacker dev server to hot reload files during development.

See also [this medium post](https://medium.com/@rubalps/rails-cloudfront-webpack-823558c71b58) and [this comment](https://github.com/rails/webpacker/issues/1651#issuecomment-513482825) for the issue.