### PR TITLE
Upgrade Puma version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "activerecord-nulldb-adapter"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1.4"
 # Use Puma as the app server
-gem "puma", "~> 5"
+gem "puma", "< 7"
 # Use SCSS for stylesheets
 gem "sass-rails", ">= 6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "activerecord-nulldb-adapter"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1.4"
 # Use Puma as the app server
-gem "puma", "~> 4.1"
+gem "puma", "~> 5"
 # Use SCSS for stylesheets
 gem "sass-rails", ">= 6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -705,7 +705,7 @@ DEPENDENCIES
   premailer-rails
   progress_bar
   prometheus_exporter
-  puma (~> 5)
+  puma (< 7)
   rack
   rails (~> 7.0.4.3)
   rails-erd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ GEM
     prometheus_exporter (2.0.8)
       webrick
     public_suffix (5.0.1)
-    puma (4.3.12)
+    puma (5.6.7)
       nio4r (~> 2.0)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
@@ -705,7 +705,7 @@ DEPENDENCIES
   premailer-rails
   progress_bar
   prometheus_exporter
-  puma (~> 4.1)
+  puma (~> 5)
   rack
   rails (~> 7.0.4.3)
   rails-erd
@@ -734,7 +734,7 @@ DEPENDENCIES
   sunspot_rails!
   sunspot_solr
   terser
-  thredded!
+  thredded
   thredded-markdown_katex!
   trix-rails
   turbolinks (~> 5)


### PR DESCRIPTION
We jump up two major versions! See the release changes here:
- [4 to 5](https://github.com/puma/puma/blob/master/5.0-Upgrade.md)
- [5 to 6](https://github.com/puma/puma/blob/master/6.0-Upgrade.md)

_This is to prevent [this security issue](https://github.com/puma/puma/security/advisories/GHSA-68xg-gqqm-vgj8)._