### PR TITLE
Redesign admin navbar & background

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,4 @@
+.admin-background {
+    background-size: 20px 20px;
+    background-image: radial-gradient(circle, #bebebe 1px, #ffffff00 1px);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -303,7 +303,3 @@ a {
     text-decoration: underline;
   }
 }
-
-.nav-item {
-  position: relative;
-}

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -25,6 +25,10 @@
     .new-comment {
         color: #ffc107 !important;
     }
+
+    .nav-item {
+        position: relative;
+    }
 }
 
 .navbar .navbar-nav a.nav-link {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -27,7 +27,7 @@
     }
 }
 
-.navbar-nav a {
+.navbar .navbar-nav a.nav-link {
     filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
 
     &:hover {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -2,18 +2,19 @@
     background: linear-gradient(110deg, #223e62 0%, #405d75 100%);
 }
 
+.admin-navbars-container {
+    background: linear-gradient(110deg, #821A3B 0%, #8d1c40 100%);
+}
+
 #mampfbrand {
     color: white;
+
     font-weight: bold;
     filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
 }
 
 #mampf-logo {
     width: 35px;
-}
-
-.navbar-nav a {
-    filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
 }
 
 .navbar {
@@ -26,7 +27,17 @@
     }
 }
 
-#navbar-buttons a {
+.navbar-nav a {
+    filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
+
+    &:hover {
+        color: #cee2ff;
+    }
+
+    &:focus {
+        color: white;
+    }
+
     text-decoration: none;
     font-size: 1.35rem;
     padding: 0 9px;
@@ -34,11 +45,17 @@
 
     &::after {
         &.active-item {
-            content: "\2022";
+            content: "\2022"; // dot
             font-size: 1rem;
             position: absolute;
             top: 21px;
             left: 16px;
         }
+    }
+}
+
+.admin-buttons a {
+    &:hover {
+        color: #ffe5ed;
     }
 }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -29,31 +29,31 @@
     .nav-item {
         position: relative;
     }
-}
 
-.navbar .navbar-nav a.nav-link {
-    filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
+    .navbar-nav .nav-link {
+        filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
 
-    &:hover {
-        color: #cee2ff;
-    }
+        &:hover {
+            color: #cee2ff;
+        }
 
-    &:focus {
+        &:focus {
+            color: white;
+        }
+
+        text-decoration: none;
+        font-size: 1.35rem;
+        padding: 0 9px;
         color: white;
-    }
 
-    text-decoration: none;
-    font-size: 1.35rem;
-    padding: 0 9px;
-    color: white;
-
-    &::after {
-        &.active-item {
-            content: "\2022"; // dot
-            font-size: 1rem;
-            position: absolute;
-            top: 21px;
-            left: 16px;
+        &::after {
+            &.active-item {
+                content: "\2022"; // dot
+                font-size: 1rem;
+                position: absolute;
+                top: 21px;
+                left: 16px;
+            }
         }
     }
 }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -58,7 +58,7 @@
     }
 }
 
-.admin-buttons a {
+.admin-navbars-container .navbar-nav .nav-link {
     &:hover {
         color: #ffe5ed;
     }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -8,7 +8,6 @@
 
 #mampfbrand {
     color: white;
-
     font-weight: bold;
     filter: drop-shadow(1px 4px 7px rgba(0, 0, 0, 0.2));
 }

--- a/app/views/administration/_navbar.html.erb
+++ b/app/views/administration/_navbar.html.erb
@@ -16,7 +16,7 @@
                 title: t('admin.navbar.exit'),
                 data: { 'bs-toggle': 'tooltip' } %>
 
-    <ul class="navbar-nav admin-buttons me-auto" id="adminHome">
+    <ul class="navbar-nav" id="adminHome">
       <li class="nav-item" id="adminHome">
         <%= link_to '', administration_path,
                 class: 'nav-link bi bi-house-fill',
@@ -49,7 +49,7 @@
       </li>
     </ul>
 
-    <ul class="navbar-nav admin-buttons me-auto" id="adminDetails">
+    <ul class="navbar-nav ms-auto me-auto" id="adminDetails">
       <% if current_user.admin? %>
         <li class="nav-item">
           <%= link_to '', terms_path,
@@ -94,7 +94,7 @@
     </ul>
 
     <% if current_user.admin? %>
-      <ul class="navbar-nav admin-buttons" id="adminUsers">
+      <ul class="navbar-nav" id="adminUsers">
         <li class="nav-item <%= active_controller?('users') %>">
           <%= link_to '', users_path,
                   class: 'nav-link bi bi-people-fill',
@@ -104,7 +104,7 @@
       </ul>
     <% end %>
 
-    <ul class="navbar-nav admin-buttons" id="adminProfile">
+    <ul class="navbar-nav" id="adminProfile">
       <li class="nav-item">
         <%= link_to '', elevated_profile_path,
                 class: 'nav-link bi bi-person-fill',

--- a/app/views/administration/_navbar.html.erb
+++ b/app/views/administration/_navbar.html.erb
@@ -19,7 +19,7 @@
     <ul class="navbar-nav" id="adminHome">
       <li class="nav-item" id="adminHome">
         <%= link_to '', administration_path,
-                class: 'nav-link bi bi-house-fill',
+                class: 'nav-link bi bi-house-fill ' + get_class_for_path(administration_path()),
                 data: { 'bs-toggle': "tooltip" },
                 title: t('admin.navbar.main') %>
       </li>
@@ -29,7 +29,7 @@
         <li class="nav-item" id="adminCurrentLecture">
           <%= link_to '',
                   edit_lecture_path(Lecture.find_by_id(current_user.current_lecture_id)),
-                  class: 'nav-link bi bi-bookmark-fill',
+                  class: 'nav-link bi bi-bookmark-fill ' + get_class_for_path_startswith(lectures_path()),
                   data: { 'bs-toggle': "tooltip" },
                   title: t('admin.navbar.current_lecture') %>
         </li>
@@ -37,7 +37,7 @@
 
       <li class="nav-item" id="adminSearch">
         <%= link_to '', administration_search_path,
-                  class: 'nav-link bi bi-binoculars-fill',
+                  class: 'nav-link bi bi-binoculars-fill ' + get_class_for_path(administration_search_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('navbar.search') %>
       </li>
@@ -53,20 +53,20 @@
       <% if current_user.admin? %>
         <li class="nav-item">
           <%= link_to '', terms_path,
-                  class: 'nav-link bi bi-calendar-range-fill',
+                  class: 'nav-link bi bi-calendar-range-fill ' + get_class_for_path(terms_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('admin.navbar.terms') %>
         </li>
         <li class="nav-item">
           <%= link_to '',
                   classification_path,
-                  class: 'nav-link bi bi-node-plus-fill',
+                  class: 'nav-link bi bi-node-plus-fill ' + + get_class_for_path(classification_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('admin.navbar.classification') %>
         </li>
         <li>
           <%= link_to '', announcements_path,
-                  class: 'nav-link bi bi-megaphone-fill',
+                  class: 'nav-link bi bi-megaphone-fill ' + get_class_for_path(announcements_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('admin.navbar.news') %>
         </li>
@@ -86,7 +86,7 @@
         </li>
         <li>
           <%= link_to '', interactions_path,
-                  class: 'nav-link bi-cloud-arrow-down-fill',
+                  class: 'nav-link bi-cloud-arrow-down-fill ' + get_class_for_path(interactions_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('admin.navbar.export_stats') %>
         </li>
@@ -97,7 +97,7 @@
       <ul class="navbar-nav" id="adminUsers">
         <li class="nav-item <%= active_controller?('users') %>">
           <%= link_to '', users_path,
-                  class: 'nav-link bi bi-people-fill',
+                  class: 'nav-link bi bi-people-fill ' + get_class_for_path(users_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('admin.navbar.users') %>
         </li>
@@ -107,7 +107,7 @@
     <ul class="navbar-nav" id="adminProfile">
       <li class="nav-item">
         <%= link_to '', elevated_profile_path,
-                class: 'nav-link bi bi-person-fill',
+                class: 'nav-link bi bi-person-fill ' + get_class_for_path(elevated_profile_path()),
                 data: { 'bs-toggle': 'tooltip' },
                 title: t('admin.navbar.profile') %>
       </li>

--- a/app/views/administration/_navbar.html.erb
+++ b/app/views/administration/_navbar.html.erb
@@ -1,127 +1,119 @@
 <% I18n.with_locale(current_user.try(:locale)) do %>
-<nav class="navbar navbar-expand-md navbar-dark bg-dark"
-     id="first-admin-nav">
-  <div class="container-fluid">
-    <%= link_to image_tag('/MaMpf-Logo_32x32.png',
-                          class: 'img-fluid me-2'),
+<%= stylesheet_link_tag 'navbar' %>
+<div class="admin-navbars-container">
+  <nav class="navbar navbar-expand" id="first-admin-nav">
+    <%= link_to image_tag('MaMpf-Logo.svg',
+                          class: 'me-2',
+                          id: 'mampf-logo'),
                 exit_administration_path,
                 title: t('admin.navbar.exit'),
-                data: { toggle: 'tooltip' }%>
+                data: { 'bs-toggle': 'tooltip' } %>
     <%= link_to t('mampf'),
                 exit_administration_path,
                 class: 'navbar-brand',
+                style: "text-decoration: none;",
+                id: 'mampfbrand',
                 title: t('admin.navbar.exit'),
-                data: { toggle: 'tooltip' },
-                style: "text-decoration: none;" %>
-    <ul class="navbar-nav me-auto" id="adminMain">
-      <li class="nav-item"
-          id="adminHome">
+                data: { 'bs-toggle': 'tooltip' } %>
+
+    <ul class="navbar-nav admin-buttons me-auto" id="adminHome">
+      <li class="nav-item" id="adminHome">
         <%= link_to '', administration_path,
-                    class: 'fas fa-home fa-lg text-light nav-link',
-                    style: 'text-decoration: none;',
-                    data: { toggle: "tooltip" },
-                    title: t('admin.navbar.main') %>
+                class: 'nav-link bi bi-house-fill',
+                data: { 'bs-toggle': "tooltip" },
+                title: t('admin.navbar.main') %>
       </li>
+
       <% if current_user.current_lecture_id
                         .in?(current_user.teaching_related_lectures.map(&:id)) %>
-        <li class="nav-item"
-            id="adminCurrentLecture">
+        <li class="nav-item" id="adminCurrentLecture">
           <%= link_to '',
-                      edit_lecture_path(Lecture.find_by_id(current_user.current_lecture_id)),
-                      class: 'fas fa-chalkboard-teacher fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: "tooltip" },
-                      title: t('admin.navbar.current_lecture') %>
+                  edit_lecture_path(Lecture.find_by_id(current_user.current_lecture_id)),
+                  class: 'fas fa-chalkboard-teacher fa-lg text-light nav-link',
+                  data: { 'bs-toggle': "tooltip" },
+                  title: t('admin.navbar.current_lecture') %>
         </li>
       <% end %>
-      <li class="nav-item"
-          id="adminSearch">
+
+      <li class="nav-item" id="adminSearch">
         <%= link_to '', administration_search_path,
-                    class: 'fas fa-search fa-lg text-light nav-link',
-                    style: 'text-decoration: none;',
-                    data: { toggle: 'tooltip' },
-                    title: t('navbar.search') %>
+                  class: 'nav-link bi bi-binoculars-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('navbar.search') %>
       </li>
       <li class="nav-item">
         <%= link_to '', destroy_user_session_path,
-                    class: 'fas fa-sign-out-alt fa-lg text-light nav-link',
-                    style: 'text-decoration: none;',
-                    data: { toggle: 'tooltip', method: 'delete' },
-                    title: t('admin.navbar.logout') %>
+                  class: 'nav-link bi bi-box-arrow-right',
+                  data: { 'bs-toggle': 'tooltip', method: 'delete' },
+                  title: t('admin.navbar.logout') %>
       </li>
     </ul>
-    <ul class="navbar-nav me-auto" id="adminDetails">
+
+    <ul class="navbar-nav admin-buttons me-auto" id="adminDetails">
       <% if current_user.admin? %>
         <li class="nav-item">
           <%= link_to '', terms_path,
-                      class: 'far fa-calendar-alt fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.terms') %>
+                  class: 'nav-link bi bi-calendar-range-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.terms') %>
         </li>
         <li class="nav-item">
           <%= link_to '',
-                      classification_path,
-                      class: 'fas fa-clipboard-list fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.classification') %>
+                  classification_path,
+                  class: 'nav-link bi bi-node-plus-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.classification') %>
         </li>
         <li>
           <%= link_to '', announcements_path,
-                      class: 'far fa-newspaper fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.news') %>
+                  class: 'nav-link bi bi-megaphone-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.news') %>
         </li>
         <li>
           <%= link_to '', thredded_path,
-                      class: 'fas fa-comment-alt fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.boards'),
-                      target: :_blank %>
+                  class: 'nav-link bi bi-chat-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.boards'),
+                  target: :_blank %>
         </li>
         <li>
           <%= link_to '', sidekiq_web_path,
-                      class: 'fas fa-chart-line fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.stats'),
-                      target: :_blank %>
+                  class: 'nav-link bi bi-bar-chart-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.stats'),
+                  target: :_blank %>
         </li>
         <li>
           <%= link_to '', interactions_path,
-                      class: 'fas fa-download fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.export_stats') %>
+                  class: 'nav-link bi-cloud-arrow-down-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.export_stats') %>
         </li>
       <% end %>
     </ul>
+
     <% if current_user.admin? %>
-      <ul class="navbar-nav me-auto" id="adminUsers">
+      <ul class="navbar-nav admin-buttons" id="adminUsers">
         <li class="nav-item <%= active_controller?('users') %>">
           <%= link_to '', users_path,
-                      class: 'fas fa-users-cog fa-lg text-light nav-link',
-                      style: 'text-decoration: none;',
-                      data: { toggle: 'tooltip' },
-                      title: t('admin.navbar.users') %>
+                  class: 'nav-link bi bi-people-fill',
+                  data: { 'bs-toggle': 'tooltip' },
+                  title: t('admin.navbar.users') %>
         </li>
       </ul>
     <% end %>
-    <ul class="navbar-nav" id="adminProfile">
+
+    <ul class="navbar-nav admin-buttons" id="adminProfile">
       <li class="nav-item">
         <%= link_to '', elevated_profile_path,
-                    class: 'fas fa-user fa-lg text-light nav-link',
-                    style: 'text-decoration: none;',
-                    data: { toggle: 'tooltip' },
-                    title: t('admin.navbar.profile') %>
+                class: 'nav-link bi bi-person-fill',
+                data: { 'bs-toggle': 'tooltip' },
+                title: t('admin.navbar.profile') %>
       </li>
     </ul>
-  </div>
-</nav>
-<nav class="navbar navbar-expand navbar-dark bg-dark" id="second-admin-nav"
-     style="display: none;">
-</nav>
+  </nav>
+  <nav class="navbar navbar-expand" id="second-admin-nav" style="display: none;">
+  </nav>
+</div>
 <% end %>

--- a/app/views/administration/_navbar.html.erb
+++ b/app/views/administration/_navbar.html.erb
@@ -29,7 +29,7 @@
         <li class="nav-item" id="adminCurrentLecture">
           <%= link_to '',
                   edit_lecture_path(Lecture.find_by_id(current_user.current_lecture_id)),
-                  class: 'fas fa-chalkboard-teacher fa-lg text-light nav-link',
+                  class: 'nav-link bi bi-bookmark-fill',
                   data: { 'bs-toggle': "tooltip" },
                   title: t('admin.navbar.current_lecture') %>
         </li>

--- a/app/views/layouts/administration.html.erb
+++ b/app/views/layouts/administration.html.erb
@@ -3,9 +3,10 @@
   <head>
     <%= render partial: 'layouts/head' %>
     <%= render partial: 'layouts/head_additional_js' %>
+    <%= stylesheet_link_tag 'admin' %>
   </head>
   <body data-locale="<%= I18n.locale %>"
-        class="bg-lime-lighten-5">
+        class="admin-background">
     <div id="admin-navbar">
       <%= render partial: 'administration/navbar' %>
     </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,12 +6,12 @@
                           class: 'me-2',
                           id: 'mampf-logo'),
                 home_path %>
-    <%= link_to "MaMpf",
+    <%= link_to t('mampf'),
                 home_path,
                 class: 'navbar-brand',
                 style: "text-decoration: none;",
                 id: 'mampfbrand' %>
-      <ul class="navbar-nav mr-auto" id="navbar-buttons">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item">
           <% is_home_active = !get_class_for_any_path_startswith([start_path(), lectures_path()]).empty?\
             || !get_class_for_path(root_path()).empty? %>
@@ -30,7 +30,6 @@
           </a>
         </li>
 
-
         <% if current_user.admin || current_user.editor? || current_user.teacher? %>
           <li class="nav-item">
             <a href="<%= administration_path %>"
@@ -41,7 +40,6 @@
           </li>
         <% end %>
 
-
         <li class="nav-item">
           <a href="<%= watchlists_path %>"
             id="watchlistsIcon"
@@ -50,7 +48,6 @@
             title="<%= t('navbar.watchlist') %>">
           </a>
         </li>
-
 
         <li class="nav-item">
           <a href="<%= comments_path %>"
@@ -63,7 +60,6 @@
           </a>
         </li>
 
-
         <li class="nav-item">
           <a href="<%= news_path %>"
             class="nav-link bi bi-megaphone-fill <%= get_class_for_path(news_path()) %>"
@@ -72,7 +68,6 @@
           </a>
         </li>
 
-
         <li class="nav-item">
           <a href="<%= DefaultSetting::BLOG_LINK %>"
             class="nav-link bi bi-newspaper"
@@ -80,7 +75,6 @@
             title="<%= t('navbar.blog') %>">
           </a>
         </li>
-
 
         <li class="nav-item">
           <a href="<%= destroy_user_session_path(params: { locale: current_user.locale }) %>"
@@ -96,7 +90,7 @@
         <%= render partial: 'shared/dropdown_lectures',
                   locals: { lecture: @lecture || current_lecture } %>
       </ul>
-      <%= render partial: 'shared/dropdown_notifications'%>
+      <%= render partial: 'shared/dropdown_notifications' %>
       <%= form_tag(search_index_path,
                   method: 'get',
                   class: 'form-inline mt-2 mt-md-0',

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,7 +11,7 @@
                 class: 'navbar-brand',
                 style: "text-decoration: none;",
                 id: 'mampfbrand' %>
-      <ul class="navbar-nav me-auto">
+      <ul class="navbar-nav">
         <li class="nav-item">
           <% is_home_active = !get_class_for_any_path_startswith([start_path(), lectures_path()]).empty?\
             || !get_class_for_path(root_path()).empty? %>


### PR DESCRIPTION
**I've redesigned the admin navbar to reflect the new look & feel introduced in #451**. I hope this new design is ok - even though of course every redesign might have its opponents ;)

With regards to the background: In my opinion, the old yellow background color conveys the impression of yellowed paper. It was originally introduced to make clear to teachers, editors etc. that they are in a mode where one has to pay more attention as one can add/edit/delete things. I hope this is also clear with the new design: instead of a blue navbar, it is red/purple-ish and the background is covered with a grey dot pattern inspired by the [Photoshop Beta](https://static1.makeuseofimages.com/wordpress/wp-content/uploads/2023/06/photoshop-beta-app-logo.jpg) logo (however they use lines instead of dots).

## Preview

Beforehand:
![image](https://github.com/MaMpf-HD/mampf/assets/37160523/bd714dc9-f9da-4235-a198-8f62272ff9c0)

Afterwards:
![image](https://github.com/MaMpf-HD/mampf/assets/37160523/29a8cff9-dbcd-4c22-abee-b8a3db966116)

## For reviewers

- [x] Login as student with lecture edit rights, teacher and admin and check for each if the following works.
- [x] Check for styling: does everything look and feel right?
- [x] Check that all icons still work on "mobile" (small width) -> second navbar should show up
- [x] Check that small dot below icons indicates current active navbar item
- [x] Check that every icon is clickable and directs to the right page
- [x] Check that tooltips still work
- [ ] Other checks?
