### PR TITLE
Upgrade bootstrap to v5.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/sprockets-rails
-  revision: 73e7351abff3506f6dca6b2da8abedfd5c7c0d77
+  revision: 065cbe83989c44019eca7161782ed4fdb6473517
   branch: master
   specs:
     sprockets-rails (3.4.2)
@@ -142,9 +142,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    bootstrap (5.2.1)
+    bootstrap (5.3.1)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.11.6, < 3)
+      popper_js (>= 2.11.8, < 3)
       sassc-rails (>= 2.0.0)
     bootstrap_form (5.1.0)
       actionpack (>= 5.2)
@@ -278,7 +278,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
@@ -329,9 +329,9 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    loofah (2.19.1)
+    loofah (2.21.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -344,7 +344,7 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    minitest (5.18.0)
+    minitest (5.19.0)
     msgpack (1.7.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)
@@ -360,7 +360,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     onebox (2.2.19)
       addressable (~> 2.8.0)
@@ -383,7 +383,7 @@ GEM
       ttfunk
     pg (1.4.6)
     pgreset (0.3)
-    popper_js (2.11.6)
+    popper_js (2.11.8)
     pr_geohash (1.0.0)
     premailer (1.21.0)
       addressable
@@ -404,8 +404,8 @@ GEM
     pundit (2.3.0)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
-    racc (1.6.2)
-    rack (2.2.7)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-proxy (0.7.6)
       rack
     rack-test (2.1.0)
@@ -424,16 +424,18 @@ GEM
       activesupport (= 7.0.4.3)
       bundler (>= 1.15.0)
       railties (= 7.0.4.3)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
     rails-erd (1.7.2)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
-    rails-html-sanitizer (1.5.0)
-      loofah (~> 2.19, >= 2.19.1)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
     rails-i18n (7.0.6)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
@@ -587,7 +589,7 @@ GEM
       tins (~> 1.0)
     terser (1.1.14)
       execjs (>= 0.3.0, < 3)
-    thor (1.2.1)
+    thor (1.2.2)
     thredded (1.1.0)
       active_record_union (>= 1.3.0)
       autoprefixer-rails
@@ -609,7 +611,7 @@ GEM
       sassc-rails (>= 2.0.0)
       sprockets-es6
       timeago_js (>= 3.0.2.2)
-    tilt (2.1.0)
+    tilt (2.2.0)
     timeago_js (3.0.2.2)
     timeout (0.3.2)
     tins (1.32.1)
@@ -648,7 +650,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.1)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   x86_64-linux
@@ -734,7 +736,7 @@ DEPENDENCIES
   sunspot_rails!
   sunspot_solr
   terser
-  thredded!
+  thredded
   thredded-markdown_katex!
   trix-rails
   turbolinks (~> 5)

--- a/app/views/layouts/devise_mailer.html.erb
+++ b/app/views/layouts/devise_mailer.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <div class="small text-center">
-      <small class="text-muted">
+      <small class="text-body-secondary">
         <%= t('.reason',
               default: "",
               locale: @resource.locale) %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <%= stylesheet_link_tag :email %>
   </head>
 
@@ -17,7 +17,7 @@
     </div>
 
     <div class="small text-center">
-      <small class="text-muted">
+      <small class="text-body-secondary">
         <%= t('mailer.unsubscribe_html',
               profile: link_to(t('notifications.profile'),
                                edit_profile_url)) %>


### PR DESCRIPTION
**Update `bootstrap` version from `5.2.1` to `5.3.1`**, so that #527 works correctly (`z-index` did not work properly, see comment [over there](https://github.com/MaMpf-HD/mampf/pull/527#issuecomment-1694698091)).

Command used:
```
bundle update bootstrap
```

Note that `bundle update bootstrap --conservative` did not work (containers did not start due to dependency errors).

See migration guide [here](https://getbootstrap.com/docs/5.3/migration/) for what has changed in Bootstrap.