### PR TITLE
Track last sign in date

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -751,6 +751,19 @@ class User < ApplicationRecord
     return false
   end
 
+  # make sure that no IP adress data are stored via the :trackable module
+  # of Devise
+  # see https://github.com/heartcombo/devise/issues/4849#issuecomment-534733131
+
+  def current_sign_in_ip
+  end
+
+  def last_sign_in_ip=(_ip)
+  end
+
+  def current_sign_in_ip=(_ip)
+  end
+
   private
 
     def set_defaults

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -751,8 +751,6 @@ class User < ApplicationRecord
     return false
   end
 
-  # make sure that no IP adress data are stored via the :trackable module
-  # of Devise
   # see https://github.com/heartcombo/devise/issues/4849#issuecomment-534733131
   # We use the Devise::Trackable module to track sign-in count and current/last
   # sign-in timestamp. However, we don't want to track IP address, but Trackable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   include ApplicationHelper
 
   # use devise for authentification, include the following modules
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :trackable,
          :recoverable, :rememberable, :validatable, :confirmable, :lockable
 
   # a user has many subscribed lectures

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -754,6 +754,10 @@ class User < ApplicationRecord
   # make sure that no IP adress data are stored via the :trackable module
   # of Devise
   # see https://github.com/heartcombo/devise/issues/4849#issuecomment-534733131
+  # We use the Devise::Trackable module to track sign-in count and current/last
+  # sign-in timestamp. However, we don't want to track IP address, but Trackable
+  # tries to, so we have to manually override the accessor methods so they do
+  # nothing.
 
   def current_sign_in_ip
   end

--- a/db/migrate/20231101100015_add_devise_trackable_columns_to_users.rb
+++ b/db/migrate/20231101100015_add_devise_trackable_columns_to_users.rb
@@ -1,0 +1,9 @@
+class AddDeviseTrackableColumnsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_27_124337) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_01_100015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -848,6 +848,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_124337) do
     t.datetime "locked_at", precision: nil
     t.text "image_data"
     t.string "ghost_hash"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
In preparation of a later PR that will allow us to remove users that have not logged in for a very long time (see #532), we add tracking of the last sign in date. This is done via Devise's `:trackable` module. By default, this also stores IP adresses, which we do not want for GDPR reasons, so we make sure that the default is overridden and no IP data are stored.