### PR TITLE
Improve bulk upload description

### DIFF
--- a/app/views/tutorials/_bulk_correction_form.html.erb
+++ b/app/views/tutorials/_bulk_correction_form.html.erb
@@ -28,7 +28,7 @@
     <div id="bulk-uploadButton-button"
        class="btn btn-sm btn-outline-secondary"
        >
-       <%= t('basics.file')%></div>
+       <%= t('basics.files')%></div>
             <button id="bulk-uploadButton-button-actual"
                     data-tr-success="<%= t('buttons.upload_success') %>"
                     data-tr-failure="<%= t('submission.upload_failure')%>"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2894,8 +2894,8 @@ de:
       info:
         general_info: >
           Hier kannst Du mehrere Korrekturen gleichzeitig hochladen.
-          Damit diese von MaMpf zugeordnet werden können, sollten die Dateinamen
-          idealerweise mit den Dateinamen der Abgaben übereinstimmen.
+          Damit diese von MaMpf zugeordnet werden können, darfst Du die mit dem
+          Paketdownload heruntergeladenen Dateien nicht umbenennen.
         invalid_filenames: >
           Hier sind die Namen derjenigen hochgeladenen Dateien aufgelistet,
           die nicht in das von MaMpf vorgegebene Namensschema passen.
@@ -3206,6 +3206,7 @@ de:
     thyme_editor: 'Editor'
     screenshot: 'Screenshot'
     file: 'Datei'
+    files: 'Dateien'
     size: 'Größe'
     please_wait: 'Bitte warten...'
     access_rights: 'Zugriffsrechte'
@@ -3297,7 +3298,6 @@ de:
     deadline: 'Abgabetermin'
     tutorial: 'Tutorium'
     code: 'Code'
-    files: 'Dateien'
     partners: 'PartnerInnen'
     team: 'Team'
     expired: 'abgelaufen'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2718,9 +2718,9 @@ en:
       files_in_cache: file(s) successfully uploaded to temporary storage
       info:
         general_info: >
-          Here you can upload several corrections. In order that MaMpf can
-          associate them to the correct submissions it would be ideal if
-          the filenames would match the filenames of the submissions.
+          Here you can upload several corrections. To ensure they can be assigned
+          correctly, you must not rename the files obtained via the package
+          download.
         invalid_filenames: >
           This is the list of all uploaded files that do not
           fit into the naming scheme that is provided by MaMpf.
@@ -3023,6 +3023,7 @@ en:
     thyme_editor: 'Editor'
     screenshot: 'Screenshot'
     file: 'File'
+    files: 'Files'
     size: 'Size'
     please_wait: 'Please wait...'
     access_rights: 'Access rights'
@@ -3113,7 +3114,6 @@ en:
     deadline: 'Due date'
     tutorial: 'Tutorial'
     code: 'Code'
-    files: 'Files'
     partners: 'Partners'
     team: 'Team'
     expired: 'expired'


### PR DESCRIPTION
This fixes #557 by aiming for a better wording and replacing "file" by "files" to make clear that multiple files can be selected.