### PR TITLE
Upgrade Node.js to v20 (LTS)

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,8 +2,47 @@ const { environment } = require("@rails/webpacker");
 const coffee = require("./loaders/coffee");
 const css = require("./loaders/css");
 
-environment.loaders.prepend("coffee", coffee);
+// Fix OpenSSL error starting with Node.js 17.
+//
+// This error occurred since a new version of OpenSSL shipping with Node.js 17+
+// removed support for MD4. This is actually very good as MD4 is insecure.
+// However, webpack 5 is using MD4 as default hashing algorithm, that's why we
+// got the error "error:0308010C:digital envelope routines::unsupported".
+// Note that webpacker uses webpack v4.x but this also uses MD4 as default, see [3].
+//
+// To fix this, we configure webpack (via webpacker) to use a newer hash algorithm.
+// This is done by setting the output.hashFunction to "sha256".
+// This fix was proposed in [1] and [2]. The syntax for how to configure
+// webpack when using webpacker is documented in [4].
+// environment.config.set("output.hashFunction", "sha256");
+// -> However, that didn't work, even when specifying the hashFunction in the
+// webpack loaders, for example for the css loader.
+//
+// SOLUTION: That's why we use a more brute-force approach here, by replacing the
+// crypto.createHash function with a function that replaces the algorithm
+// "md4" with "sha256". This way, whenever any code calls crypto.createHash("md4"),
+// it will actually call crypto.createHash("sha256") instead. This might not work
+// in multiprocess environments, but it works for us as we only compile the assets
+// in one container.
+// This solution was proposed in [5].
+//
+// Note that while sha256 is a good choice, sha512 is more secure.
+// However, we don't specify hashing for passwords here, just for files we serve
+// statically to the client. So we don't need the extra security of sha512,
+// and can leverage the benefit of sha256 being faster to compute.
+//
+// [1] https://stackoverflow.com/a/73027407/
+// [2] https://stackoverflow.com/a/69476335/
+// [3] Webpack: https://v4.webpack.js.org/configuration/output/#outputhashfunction
+// [4] https://github.com/rails/webpacker/blob/5-x-stable/docs/webpack.md#configuration
+// [5] https://stackoverflow.com/a/72219174/
+const crypto = require("crypto");
+const originalHashFunction = crypto.createHash;
+crypto.createHash = (algorithm, options) => {
+  return originalHashFunction(algorithm === "md4" ? "sha256" : algorithm, options);
+};
 
+environment.loaders.prepend("coffee", coffee);
 environment.loaders.prepend("css", css);
 
 module.exports = environment;

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -24,7 +24,7 @@ const css = require("./loaders/css");
 // it will actually call crypto.createHash("sha256") instead. This might not work
 // in multiprocess environments, but it works for us as we only compile the assets
 // in one container.
-// This solution was proposed in [5].
+// This solution was proposed in [5]. The code below is an adaption of it.
 //
 // Note that while sha256 is a good choice, sha512 is more secure.
 // However, we don't specify hashing for passwords here, just for files we serve
@@ -39,7 +39,8 @@ const css = require("./loaders/css");
 const crypto = require("crypto");
 const originalHashFunction = crypto.createHash;
 crypto.createHash = (algorithm, options) => {
-  return originalHashFunction(algorithm === "md4" ? "sha256" : algorithm, options);
+  const updatedAlgorithm = (algorithm === "md4") ? "sha256" : algorithm;
+  return originalHashFunction(updatedAlgorithm, options);
 };
 
 environment.loaders.prepend("coffee", coffee);

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -21,9 +21,9 @@ SHELL ["/bin/bash", "--login", "-c"]
 # https://github.com/nodesource/distributions/issues/1583#issuecomment-1597489401
 # https://stackoverflow.com/a/57546198/
 # Unfortunately, we have to explicitly specify the node version here
-# and cannot use 16.x as we need to put the node binary into the PATH
+# and cannot use 20.x as we need to put the node binary into the PATH
 # and therefore require the exact version to find the folder
-ENV NODE_VERSION=16.20.1
+ENV NODE_VERSION=20.10.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN source "${NVM_DIR}/nvm.sh" && nvm install "${NODE_VERSION}" && \

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -23,9 +23,9 @@ SHELL ["/bin/bash", "--login", "-c"]
 # https://github.com/nodesource/distributions/issues/1583#issuecomment-1597489401
 # https://stackoverflow.com/a/57546198/
 # Unfortunately, we have to explicitly specify the node version here
-# and cannot use 16.x as we need to put the node binary into the PATH
+# and cannot use 20.x as we need to put the node binary into the PATH
 # and therefore require the exact version to find the folder
-ENV NODE_VERSION=16.20.1
+ENV NODE_VERSION=20.10.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN source "${NVM_DIR}/nvm.sh" && nvm install "${NODE_VERSION}" && \

--- a/docker/run_cypress_tests/Dockerfile
+++ b/docker/run_cypress_tests/Dockerfile
@@ -20,9 +20,9 @@ SHELL ["/bin/bash", "--login", "-c"]
 # https://github.com/nodesource/distributions/issues/1583#issuecomment-1597489401
 # https://stackoverflow.com/a/57546198/
 # Unfortunately, we have to explicitly specify the node version here
-# and cannot use 16.x as we need to put the node binary into the PATH
+# and cannot use 20.x as we need to put the node binary into the PATH
 # and therefore require the exact version to find the folder
-ENV NODE_VERSION=16.20.1
+ENV NODE_VERSION=20.10.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN source "${NVM_DIR}/nvm.sh" && nvm install "${NODE_VERSION}" && \


### PR DESCRIPTION
Upgrade Node.js to v20.10.0 (LTS until April 2026).

~~I tested this on the `experimental` branch and the run was successful (see Dozzle). Also check out [mampf-experimental](https://mampf-experimental.mathi.uni-heidelberg.de/).~~ Nope, that's what I hoped, but of course the old error keeps hunting us.

And we are not alone, the question for this error was viewed 2.5million times on Stack overflow [here](https://stackoverflow.com/q/69692842/9655481)! I will fix this! [maybe useful](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported#comment131441027_73465262)

### Finally fixed
In 8f67ce9, I finally fixed this issue after several failed attempts. See the comment in the code for further details. The `experimental` branch currently also points to this commit and you can see in the logs that it's working. [mampf-experimental](https://mampf-experimental.mathi.uni-heidelberg.de/) also shows the monotiles on the landing page.