### PR TITLE
Fix missing `to_a` to convert to Rails array

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -636,7 +636,7 @@ class MediaController < ApplicationController
         unless current_user.admin || @lecture.edited_by?(current_user)
           lecture_tags = @lecture.tags_including_media_tags
           search_results.reject! do |m|
-            m.teachable_type == "Course" && !m.tags.intersect?(lecture_tags)
+            m.teachable_type == "Course" && !m.tags.to_a.intersect?(lecture_tags)
           end
         end
       end


### PR DESCRIPTION
Fixes #583.

This was due to the unsafe RuboCop rule in #566: [`Style/ArrayIntersect`](https://docs.rubocop.org/rubocop/cops_style.html#stylearrayintersect).

> Safety: This cop cannot guarantee that array1 and array2 are actually arrays while method intersect? is for arrays only.

That was the case here.

- [x] Checked locally that repro given in #583 is not applicable anymore in localhost.
- [x] I also searched for other occurrences of `intersect?` but this was the only one in our codebase.