### PR TITLE
Warn about too long GitHub commit messages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,6 +79,12 @@
         }
     ],
     //////////////////////////////////////
+    // Git
+    //////////////////////////////////////
+    "git.inputValidation": "warn",
+    "git.inputValidationSubjectLength": 50,
+    "git.inputValidationLength": 72,
+    //////////////////////////////////////
     // Spell Checker
     //////////////////////////////////////
     "cSpell.words": [


### PR DESCRIPTION
![line too long image](https://github.com/MaMpf-HD/mampf/assets/37160523/5edb823b-da31-4131-8b7b-f7fb38d9146a)

Also see the 50/72 rule by [tpope](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).