### PR TITLE
Use `warn` log level instead of `debug` for unread comments migration

### DIFF
--- a/db/migrate/20240116180000_fix_unread_comments_inconsistencies.rb
+++ b/db/migrate/20240116180000_fix_unread_comments_inconsistencies.rb
@@ -21,8 +21,8 @@ class FixUnreadCommentsInconsistencies < ActiveRecord::Migration[7.0]
       num_fixed_users += 1 if has_flag_changed
     end
 
-    Rails.logger.debug { "Ran through #{User.count} users (unread comments flag)" }
-    Rails.logger.debug { "Fixed #{num_fixed_users} users (unread comments flag)" }
+    Rails.logger.warn { "Ran through #{User.count} users (unread comments flag)" }
+    Rails.logger.warn { "Fixed #{num_fixed_users} users (unread comments flag)" }
   end
 
   # Checks and returns whether the user has unread comments.


### PR DESCRIPTION
After merging #587, I found we don't see the "Fixed ..." lines in the log. That's because `config/environments/production.rb` sets the log level to `warn` which is above `debug` (and also above `info`). That's why I now use `warn` for the migration. Happy to hear if there are better solutions than this, but this should work ;)