### PR TITLE
Disable the user cleaner

### DIFF
--- a/app/models/user_cleaner.rb
+++ b/app/models/user_cleaner.rb
@@ -89,11 +89,11 @@ class UserCleaner
   end
 
   def delete_ghosts
-    @hash_dict.each do |mail, hash|
-      u = User.find_by(email: mail, ghost_hash: hash)
-      move_mail(@email_dict[mail]) if u.present? && @email_dict.present?
-      u.destroy! if u&.generic?
-    end
+    # @hash_dict.each do |mail, hash|
+    #   u = User.find_by(email: mail, ghost_hash: hash)
+    #   move_mail(@email_dict[mail]) if u.present? && @email_dict.present?
+    #   u.destroy! if u&.generic?
+    # end
   end
 
   def move_mail(message_ids, attempt = 0)
@@ -111,14 +111,15 @@ class UserCleaner
   end
 
   def clean!
-    login
-    search_emails_and_hashes
-    return if @email_dict.blank?
+    # TODO: Implement new old user cleaner logic
+    # login
+    # search_emails_and_hashes
+    # return if @email_dict.blank?
 
-    send_hashes
-    sleep(10)
-    search_emails_and_hashes
-    delete_ghosts
-    logout
+    # send_hashes
+    # sleep(10)
+    # search_emails_and_hashes
+    # delete_ghosts
+    # logout
   end
 end


### PR DESCRIPTION
The user cleaner does not work properly right now, also see #410. We deactivate it here to avoid deleting users unintentionally. Instead, we will implement a new logic to warn users when they haven't logged in recently. For the latter we track the last login of users since #553. The new strategy should be to send users a warn mail and give them a period of grace to log in again, e.g. 60 days.

This PR is just for disabling the user cleaner.