### PR TITLE
Replace admin search icon

### DIFF
--- a/app/views/administration/_navbar.html.erb
+++ b/app/views/administration/_navbar.html.erb
@@ -37,7 +37,7 @@
 
       <li class="nav-item" id="adminSearch">
         <%= link_to '', administration_search_path,
-                  class: 'nav-link bi bi-binoculars-fill ' + get_class_for_path(administration_search_path()),
+                  class: 'nav-link bi bi-search ' + get_class_for_path(administration_search_path()),
                   data: { 'bs-toggle': 'tooltip' },
                   title: t('navbar.search') %>
       </li>


### PR DESCRIPTION
A user complained that the binocular was not identifiable as a "search function" at first glance. This is why we are replacing it by a magnifier icon in this PR.

![image](https://github.com/MaMpf-HD/mampf/assets/37160523/057627a8-c352-4274-a186-a8d8f251038d)
