### PR TITLE
Fix `git.inputValidation` VSCode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,7 +81,7 @@
     //////////////////////////////////////
     // Git
     //////////////////////////////////////
-    "git.inputValidation": "warn",
+    "git.inputValidation": true,
     "git.inputValidationSubjectLength": 50,
     "git.inputValidationLength": 72,
     //////////////////////////////////////


### PR DESCRIPTION
In a new version of VSCode, the API was changed. We now use a boolean flag instead of a string.
