### PR TITLE
Only allow admins to change course editors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,6 +89,7 @@
     //////////////////////////////////////
     "cSpell.words": [
         "commontator",
+        "helpdesk",
         "turbolinks"
     ]
 }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -100,7 +100,7 @@ class CoursesController < ApplicationController
                         { tag_ids: [],
                           preceding_course_ids: [],
                           division_ids: [] }]
-      allowed_params.push({ editor_ids: [] }) if current_user.admin?
+      allowed_params.push(editor_ids: []) if current_user.admin?
       params.require(:course).permit(allowed_params)
     end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -94,13 +94,14 @@ class CoursesController < ApplicationController
     end
 
     def course_params
-      params.require(:course).permit(:title, :short_title, :organizational,
-                                     :organizational_concept, :locale,
-                                     :term_independent, :image,
-                                     tag_ids: [],
-                                     preceding_course_ids: [],
-                                     editor_ids: [],
-                                     division_ids: [])
+      allowed_params = [:title, :short_title, :organizational,
+                        :organizational_concept, :locale,
+                        :term_independent, :image,
+                        { tag_ids: [],
+                          preceding_course_ids: [],
+                          division_ids: [] }]
+      allowed_params.push({ editor_ids: [] }) if current_user.admin?
+      params.require(:course).permit(allowed_params)
     end
 
     def tag_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -97,9 +97,7 @@ class CoursesController < ApplicationController
       allowed_params = [:title, :short_title, :organizational,
                         :organizational_concept, :locale,
                         :term_independent, :image,
-                        { tag_ids: [],
-                          preceding_course_ids: [],
-                          division_ids: [] }]
+                        { tag_ids: [], preceding_course_ids: [], division_ids: [] }]
       allowed_params.push(editor_ids: []) if current_user.admin?
       params.require(:course).permit(allowed_params)
     end

--- a/app/views/courses/_basics.html.erb
+++ b/app/views/courses/_basics.html.erb
@@ -70,6 +70,9 @@
     </div>
   <% else %>
     <%= t('basics.editors') %>
+    <%= helpdesk(t('admin.course.info.no_right_to_change_editors',
+                   project_email: mail_to(DefaultSetting::PROJECT_EMAIL, nil)),
+                 true) %>
     <ul>
       <% course.editors.each do |e| %>
         <li>

--- a/app/views/courses/_basics.html.erb
+++ b/app/views/courses/_basics.html.erb
@@ -71,7 +71,7 @@
   <% else %>
     <%= t('basics.editors') %>
     <%= helpdesk(t('admin.course.info.no_right_to_change_editors',
-                   project_email: mail_to(DefaultSetting::PROJECT_EMAIL, nil)),
+                   project_email: mail_to(DefaultSetting::PROJECT_EMAIL)),
                  true) %>
     <ul>
       <% course.editors.each do |e| %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -807,6 +807,10 @@ de:
           das Modul bearbeiten, insbesondere können sie Veranstaltungen innerhalb
           des Moduls anlegen. ModuleditorInnen erben die Bearbeitungsrechte für
           alle Veranstaltungen innerhalb des Moduls.
+        no_right_to_change_editors: >
+          ModuleditoInnen können nur von AdministratorInnen geändert werden.
+          Bitte wende Dich per Email an %{project_email}, wenn hier
+          eine Änderung vorgenommen werden soll.
         preceding_courses: >
           Hier kannst Du angeben, auf welchen Modulen das
           vorliegende Modul aufbaut.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -808,7 +808,7 @@ de:
           des Moduls anlegen. ModuleditorInnen erben die Bearbeitungsrechte für
           alle Veranstaltungen innerhalb des Moduls.
         no_right_to_change_editors: >
-          ModuleditoInnen können nur von AdministratorInnen geändert werden.
+          ModuleditorInnen können nur von AdministratorInnen geändert werden.
           Bitte wende Dich per Email an %{project_email}, wenn hier
           eine Änderung vorgenommen werden soll.
         preceding_courses: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -772,6 +772,10 @@ en:
           in particular they can create event series within the course. Every course
           editor inherits editing access for all event series belonging to the
           course.
+        no_right_to_change_editors: >
+          Course editors can only be changed by administrators.
+          Please contact %{project_email} by email if want a change to be made
+          here.
         preceding_courses: >
           Here you can enter which courses this course builds upon.
           E.g., Linear Algebra 1 and Linear Algebra 2 might be preceding

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -774,7 +774,7 @@ en:
           course.
         no_right_to_change_editors: >
           Course editors can only be changed by administrators.
-          Please contact %{project_email} by email if want a change to be made
+          Please contact %{project_email} by email if you want a change to be made
           here.
         preceding_courses: >
           Here you can enter which courses this course builds upon.


### PR DESCRIPTION
Only admins can update the editors of a course, the course editors themselves can't do this. Until now, this was a little inconsequentially only realized in the view by leaving out the corresponding form. This PR whitelists the `editor_ids` parameter only for admins and adds a helpdesk.