### PR TITLE
Use new preseed links to init data in local db

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -115,8 +115,8 @@ services:
       PROJECT_EMAIL_MAILBOX: INBOX
       BLOG: https://mampf.blog
       # uncomment DB_SQL_PRESEED_URL and UPLOADS_PRESEED_URL to enable db preseeding
-      # DB_SQL_PRESEED_URL: "https://heibox.uni-heidelberg.de/d/6fb4a9d2e7f54d8b9931/files/?p=%2F20220923120841_mampf.sql&dl=1"
-      # UPLOADS_PRESEED_URL: "https://heibox.uni-heidelberg.de/f/1c4804dcd78446139fd9/?dl=1"
+      DB_SQL_PRESEED_URL: "https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/20220923120841_mampf.sql"
+      UPLOADS_PRESEED_URL: "https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/uploads.zip"
     volumes:
       - type: bind
         source: ../../


### PR DESCRIPTION
Previously, files to initialize an empty database with some development data was stored on a cloud storage associated to a university. We now have a custom repo for that: https://github.com/MaMpf-HD/mampf-init-data

This PR updates the links accordingly.

Tested locally with Docker and it works.