### PR TITLE
Use new identifier for Ruby LSP VSCode plugin settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,7 +30,9 @@
         "editor.formatOnSave": true
     },
     "rubyLsp.formatter": "rubocop",
-    "rubyLsp.rubyVersionManager": "rbenv",
+    "rubyLsp.rubyVersionManager": {
+        "identifier": "rbenv"
+    },
     "rubyLsp.enabledFeatures": {
         "codeActions": true,
         "diagnostics": true,


### PR DESCRIPTION
This change was performed automatically by VSCode due to https://github.com/Shopify/ruby-lsp/pull/1831