### PR TITLE
Add `public` prefix for `gen_random_uuid()` in db schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -433,7 +433,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_29_230010) do
     t.index ["subject_id"], name: "index_programs_on_subject_id"
   end
 
-  create_table "quiz_certificates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "quiz_certificates", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "quiz_id", null: false
     t.bigint "user_id"
     t.text "code"
@@ -519,7 +519,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_29_230010) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "tutorial_id", null: false
     t.bigint "assignment_id", null: false
     t.text "token"


### PR DESCRIPTION
This change was performed automatically by Rails locally.