### PR TITLE
Fix broken interactions controller

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -3,6 +3,10 @@ class InteractionsController < ApplicationController
   authorize_resource
   layout "administration"
 
+  def current_ability
+    @current_ability ||= InteractionAbility.new(current_user)
+  end
+
   def index
   end
 


### PR DESCRIPTION
When clicking the `Export statistics` button in the admin view (corresponding to the `/interactions` route), we got an error. In this PR we fix the broken interactions controller by adding the missing `current_ability` method.