### PR TITLE
Set raise_on_missing_translations flag to false

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Mampf
     config.i18n.default_locale = :de
     config.i18n.fallbacks = [:en]
     config.i18n.available_locales = [:de, :en]
-    config.i18n.raise_on_missing_translations = true
+    config.i18n.raise_on_missing_translations = false
     config.time_zone = "Berlin"
 
     # Message serializing. Starting with Rails 7.2, the default is :json.


### PR DESCRIPTION
Since it caused some trouble in production, we set the `raise_on_missing_translations flag` to false. We will have to look at what went wrong in more detail and fix the underlying issues before setting the flag back to `true`.