### PR TITLE
Downgrade Rack to 2.2.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "jbuilder"
 # Reduces boot times through caching; required in config/boot.rb
 gem "active_model_serializers"
 gem "bootsnap", ">= 1.4.2", require: false
-gem "rack"
+gem "rack", "<3"
 # Use CoffeeScript for .coffee assets and views
 gem "coffee-rails", "~> 5.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,16 +408,16 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.7.3)
-    rack (3.0.10)
+    rack (2.2.9)
     rack-proxy (0.7.7)
       rack
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (2.1.0)
-      rack (>= 3)
-      webrick (~> 1.8)
+    rackup (1.0.0)
+      rack (< 3)
+      webrick
     rails (7.1.3.2)
       actioncable (= 7.1.3.2)
       actionmailbox (= 7.1.3.2)
@@ -718,7 +718,7 @@ DEPENDENCIES
   progress_bar
   prometheus_exporter
   puma (< 7)
-  rack
+  rack (< 3)
   rails (~> 7.1.3)
   rails-erd
   rails-i18n


### PR DESCRIPTION
Due to some change in policy regarding how rack parses requests from version 3 on, some of our nested forms are parsed in way that produces an incorrect parameters hash in the controller. In this hotfix we downgrade to Rack 2.2.9. We have to go through each form, update them and migrate to Rack 3 at a later time.