### PR TITLE
Update active record schema version to 7.1

### DIFF
--- a/db/interactions_schema.rb
+++ b/db/interactions_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2020_06_13_112557) do
+ActiveRecord::Schema[7.1].define(version: 2020_06_13_112557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_22_200000) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
After a complete wipe and recreation of my Docker setup, Rails automatically updated the schema version to `7.1`. I forgot to do this in #554.