### PR TITLE
Fix broken deletion of questions

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -101,8 +101,6 @@ class Medium < ApplicationRecord
   after_create :create_self_item
   # if medium is a question or remark, delete all quiz vertices that refer to it
   before_destroy :delete_vertices
-  # if medium is a question, delete all answers that belong to it
-  after_destroy :delete_answers
   # some information about media are cached
   # to find out whether the cache is out of date, always touch'em after saving
   after_save :touch_teachable
@@ -1240,12 +1238,6 @@ class Medium < ApplicationRecord
         return
       end
       becomes(Remark).delete_vertices
-    end
-
-    def delete_answers
-      return unless type == "Question"
-
-      becomes(Question).answers.delete_all
     end
 
     def text_join


### PR DESCRIPTION
This fixes #639 by removing the redundant `after_destroy` callback in the `Medium` model.