### PR TITLE
Remove obsolete docker compose version specifiers

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -1,5 +1,3 @@
----
-version: '3.4'
 services:
   redis:
     image: "redis:6.2.6-alpine"

--- a/docker/production/docker-compose.production.yml
+++ b/docker/production/docker-compose.production.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 x-mampf:
   &mampf
   build:

--- a/docker/test/docker-compose.local.yml
+++ b/docker/test/docker-compose.local.yml
@@ -1,5 +1,3 @@
----
-version: "3.4"
 services:
   redis:
     image: "redis:alpine"

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -1,5 +1,3 @@
----
-version: "3.4"
 networks:
   frontend:
   backend:


### PR DESCRIPTION
See [this](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements) for why we don't need it anymore:

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative you'll receive a warning message that it is obsolete if used.