### PR TITLE
Only run unit tests after explicit approval

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     environment: testing
     runs-on: ubuntu-latest
     permissions: write-all
-    if: ${{ github.event.issue.pull_request }} && ${{ github.event.issue_comment.comment.body }} == "run tests" && ${{ github.event.issue_comment.comment.author_association }} == "COLLABORATOR"
+    if: ${{ github.event.issue_comment.comment.body }} == "run tests"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     environment: testing
     runs-on: ubuntu-latest
     permissions: write-all
-    if: ${{ github.event.issue_comment.comment.body }} == "run tests"
+    if: ${{ github.event.issue.comment.body }} == "run tests"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ on:
       - main
       - dev
       - experimental
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
 
 jobs:
   # For the setup idea using Docker Buildx, see StackOverflow answer [1].
@@ -23,6 +23,7 @@ jobs:
     environment: testing
     runs-on: ubuntu-latest
     permissions: write-all
+    if: ${{ github.event.issue.pull_request }} && ${{ github.event.issue.body }} == "run tests" && ${{ github.event.issue.author_association }} == "COLLABORATOR"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     environment: testing
     runs-on: ubuntu-latest
     permissions: write-all
-    if: ${{ github.event.issue.pull_request }} && ${{ github.event.issue.body }} == "run tests" && ${{ github.event.issue.author_association }} == "COLLABORATOR"
+    if: ${{ github.event.issue.pull_request }} && ${{ github.event.issue_comment.comment.body }} == "run tests" && ${{ github.event.issue_comment.comment.author_association }} == "COLLABORATOR"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently, we use a custom environment named `testing` to only run our unit tests when approved. This is to avoid unnecessary strain on GitHub servers when a commit is pushed to a PR as many commits might not require extra unit tests to run and a few commits at the end of a PR with unit tests run should suffice.

However, with this approach the commit view in PRs clutters as described in my [comment here](https://github.com/orgs/community/discussions/25100#discussioncomment-9442821). See that thread for more background information. Unfortunately, there's probably not much we can do for right now, except for waiting that the GitHub team might pick up our request.

## References
- https://github.com/orgs/community/discussions/25100
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only
- https://docs.github.com/de/webhooks/webhook-events-and-payloads#issues
- https://stackoverflow.com/a/59349906/
- This might be another possible way to achieve it via comment triggers in a PR: https://stackoverflow.com/a/75087724/