### PR TITLE
Pin `thredded` to recent Git commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ gem "erubis"
 gem "exception_handler", "~> 0.8.0.0"
 gem "faraday", "~> 1.8"
 gem "fuzzy-string-match"
-gem "html-pipeline", "~> 2.14"
 gem "jquery-rails"
 gem "jquery-ui-rails"
 gem "js-routes", "1.4.9"
@@ -96,7 +95,8 @@ gem "sunspot_rails",
     github: "sunspot/sunspot",
     glob: "sunspot_rails/*.gemspec"
 gem "sunspot_solr"
-gem "thredded"
+gem "thredded", git: "https://github.com/thredded/thredded.git",
+                ref: "1340e913affd1af5fcc060fbccd271184ece9a6a"
 gem "thredded-markdown_katex",
     git: "https://github.com/thredded/thredded-markdown_katex.git",
     branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,33 @@ GIT
       kramdown-math-katex
 
 GIT
+  remote: https://github.com/thredded/thredded.git
+  revision: 1340e913affd1af5fcc060fbccd271184ece9a6a
+  ref: 1340e913affd1af5fcc060fbccd271184ece9a6a
+  specs:
+    thredded (1.1.0)
+      active_record_union (>= 1.3.0)
+      autoprefixer-rails
+      db_text_search
+      friendly_id
+      html-pipeline (>= 2.14.1, < 3)
+      htmlentities
+      inline_svg (>= 1.6.0)
+      kaminari
+      kramdown (>= 2.0.0)
+      kramdown-parser-gfm
+      nokogiri
+      onebox (>= 1.8.99)
+      pundit (>= 1.1.0)
+      rails (> 6.0.0.rc2)
+      rails_gravatar
+      rinku
+      sanitize
+      sassc-rails (>= 2.0.0)
+      sprockets-es6
+      timeago_js (>= 3.0.2.2)
+
+GIT
   remote: https://github.com/zdennis/activerecord-import.git
   revision: f41a5782b0a3f19cf42e88063aa4adbefafe4092
   branch: master
@@ -402,7 +429,7 @@ GEM
     public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
-    pundit (2.3.1)
+    pundit (2.3.2)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.7.3)
@@ -603,27 +630,6 @@ GEM
     terser (1.2.2)
       execjs (>= 0.3.0, < 3)
     thor (1.3.1)
-    thredded (1.1.0)
-      active_record_union (>= 1.3.0)
-      autoprefixer-rails
-      db_text_search
-      friendly_id
-      html-pipeline (>= 2.14.1)
-      htmlentities
-      inline_svg (>= 1.6.0)
-      kaminari
-      kramdown (>= 2.0.0)
-      kramdown-parser-gfm
-      nokogiri
-      onebox (>= 1.8.99)
-      pundit (>= 1.1.0)
-      rails (> 6.0.0.rc2)
-      rails_gravatar
-      rinku
-      sanitize
-      sassc-rails (>= 2.0.0)
-      sprockets-es6
-      timeago_js (>= 3.0.2.2)
     tilt (2.3.0)
     timeago_js (3.0.2.2)
     timeout (0.4.1)
@@ -697,7 +703,6 @@ DEPENDENCIES
   fastimage
   filesize
   fuzzy-string-match
-  html-pipeline (~> 2.14)
   image_processing
   jbuilder
   jquery-rails
@@ -747,7 +752,7 @@ DEPENDENCIES
   sunspot_rails!
   sunspot_solr
   terser
-  thredded
+  thredded!
   thredded-markdown_katex!
   trix-rails
   turbolinks (~> 5)


### PR DESCRIPTION
In #609, we had to use an older version of `html-parser` (see commit 456ed14) for the forum engine `thredded` to still work with Rails 7.1. This was necessary due to https://github.com/thredded/thredded/issues/979. In the meantime, glebm made a commit on `thredded` to deal with this internally in their project, so we don't need to include the dependency `html-parser` on our side (see https://github.com/thredded/thredded/pull/981). Therefore, we get rid of `html-parser` and use the new commit from their GitHub repo directly.

## For reviwers
- Run `bundle install` locally.
- Additionally, you will have to run `docker compose build mampf webpacker`, otherwise bundler is complaining in the Docker images.<br>If you happen to know a way to avoid rebuilding the whole image if we just update some gems let me know since rebuilding always takes quite some time and I'd like to avoid that. I'm also wondering why this is even the case after having run `bundle install` only _locally_; why is Bundler complaining in the Docker container after that? I thought it has its own dependencies installed inside the docker container...