### PR TITLE
Don't just mount `spec` folder, but complete `app` folder for tests

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -67,6 +67,7 @@ RUN yarn install --production=false
 COPY --from=build-pdfcomprezzor /go/src/pdfcomprezzor.wasm /go/src/wasm_exec.js /usr/src/app/public/pdfcomprezzor/
 COPY --from=build-pdfcomprezzor /go/src/pdfcomprezzor.wasm /go/src/wasm_exec.js /
 
+COPY . /usr/src/app
 COPY ./docker/production/docker.env ./docker-dummy.env
 
 RUN set -o allexport && . ./docker-dummy.env && set +o allexport && \

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -58,6 +58,7 @@ RUN apt update && \
 RUN sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
 
 WORKDIR /usr/src/app
+ENTRYPOINT ["./entrypoint.sh"]
 
 COPY ./Gemfile ./Gemfile.lock ./yarn.lock ./package.json /usr/src/app/
 RUN bundle install
@@ -66,7 +67,6 @@ RUN yarn install --production=false
 COPY --from=build-pdfcomprezzor /go/src/pdfcomprezzor.wasm /go/src/wasm_exec.js /usr/src/app/public/pdfcomprezzor/
 COPY --from=build-pdfcomprezzor /go/src/pdfcomprezzor.wasm /go/src/wasm_exec.js /
 
-COPY . /usr/src/app/
 COPY ./docker/production/docker.env ./docker-dummy.env
 
 RUN set -o allexport && . ./docker-dummy.env && set +o allexport && \

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -65,9 +65,8 @@ services:
       SPROCKETS_CACHE: /cache
       BLOG: https://mampf.blog
     volumes:
-      - type: bind
-        source: ../../
-        target: /usr/src/app/
+      - "public:/usr/src/app/public"
+      - ../../:/usr/src/app/
       - ../../coverage:/usr/src/app/coverage
     depends_on:
       - db
@@ -77,3 +76,6 @@ services:
     networks:
       - backend
       - frontend
+
+volumes:
+  public:

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -65,9 +65,9 @@ services:
       SPROCKETS_CACHE: /cache
       BLOG: https://mampf.blog
     volumes:
-      - "public:/usr/src/app/public"
       - ../../:/usr/src/app/
-      - ../../coverage:/usr/src/app/coverage
+      - ../../coverage:/usr/src/app/coverage/
+      - "/usr/src/app/public/"
     depends_on:
       - db
       - solr
@@ -76,6 +76,3 @@ services:
     networks:
       - backend
       - frontend
-
-volumes:
-  public:

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -37,9 +37,6 @@ services:
       context: ./../..
       dockerfile: docker/test/Dockerfile
     image: mampf:tests
-    # TODO: Use this
-    # entrypoint: /usr/src/app/docker/test/run_tests.sh
-    entrypoint: /usr/src/app/entrypoint.sh
     environment:
       RAILS_ENV: test
       TEST_DATABASE_ADAPTER: postgresql
@@ -68,10 +65,10 @@ services:
       SPROCKETS_CACHE: /cache
       BLOG: https://mampf.blog
     volumes:
-        - type: bind
-          source: ../../spec/
-          target: /usr/src/app/spec/
-        - ../../coverage:/usr/src/app/coverage
+      - type: bind
+        source: ../../
+        target: /usr/src/app/
+      - ../../coverage:/usr/src/app/coverage
     depends_on:
       - db
       - solr


### PR DESCRIPTION
This is to ensure that local changes in the `app` folder are reflected in the Docker container such that newly written tests can be run through without having to rebuild the whole Docker image.

- While the whole `app` folder is mounted to `/usr/src/app/app`, wee construct a specific `public` volume such that the `rake assets:precompile` task can populate the folder `usr/src/app/public/packs-test/`.

- Note that all files are still copied in the `Dockerfile` such that `rails assets:precompile` can work correctly. The `app/` folder is then later mounted "on top" of that.

- Also moved the entrypoint declaration to the place where it's declared in the development setup, just to achieve symmetry.



### For reviewers

Please delete your old mampf test image (if you have one locally) before testing the changes made in this PR.

A good way to test the changes in this PR could be as follows:
- `git fetch`
- `git switch feature/user-cleaner`
- `git merge tests/mount-app-folder` (only for your local playground, so please don't push)
- Check if tests run through locally. Everything should work fine.
- Rename `app/models/user_cleaner.rb` to `user_cleaner_changed.rb` (also the class name). Adjust accordingly in `user_cleaner_spec.rb`. Then, run the tests again. Everything should still work fine. With this procedure, you've checked that the locally changed file content (`user_cleaner_changed.rb`) is available in the Docker container. If it wasn't, you would get an error saying that there was no class called `UserCleanerChanged`.
- After this, reset your local git merge: `git reset --hard origin/feature/user-cleaner`. Note this will hard-reset any modified changes! Instead, you could also do `git reset HEAD~1` to keep your modifications (and those by the initial git merge you made).