### PR TITLE
Fix wrong naming of codecov config file

### DIFF
--- a/.config/codecov.yml
+++ b/.config/codecov.yml
@@ -1,5 +1,5 @@
 # Ignore test files themselves in the Codecov report
 # see: https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations/
 ignore:
-  - "spec/"
-  - "*_spec.rb"
+  - "../spec/**/*"
+  - "**/*_spec.rb"

--- a/.config/codecov.yml
+++ b/.config/codecov.yml
@@ -1,5 +1,5 @@
 # Ignore test files themselves in the Codecov report
 # see: https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations/
 ignore:
-  - "../spec/"
-  - "**/*_spec.rb"
+  - "spec/"
+  - "*_spec.rb"

--- a/.config/codecov.yml
+++ b/.config/codecov.yml
@@ -1,5 +1,5 @@
 # Ignore test files themselves in the Codecov report
 # see: https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations/
 ignore:
-  - "spec/"
-  - "*_spec.rb"
+  - "../spec/"
+  - "**/*_spec.rb"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,4 @@ jobs:
           files: ./coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-          codecov_yml_path: ./config/codecov.yml
+          codecov_yml_path: ./.config/codecov.yml


### PR DESCRIPTION
The `spec/` folder should be ignored by Codecov [here](https://app.codecov.io/gh/MaMpf-HD/mampf). Apparently this is not the case due to a wrong naming of the config file (it is referenced in the last line of `.github/workflows/tests.yml`).

Linked issue: https://github.com/codecov/codecov-action/issues/1465 -> it's being worked on, yeah ❤

### For reviewers

- [ ] `spec` folder does not count to code coverage anymore (for the current PR view in Codecov, Link TODO)