### PR TITLE
Fix flaky watchlist tests

### DIFF
--- a/spec/models/watchlist_entry_spec.rb
+++ b/spec/models/watchlist_entry_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe(WatchlistEntry, type: :model) do
 
   it "must have a medium" do
     entry = FactoryBot.build(:watchlist_entry, :with_watchlist)
-    entry.valid?
-    expect(entry.errors[:medium]).to include("muss ausgefüllt werden")
+    expect(entry).not_to be_valid
+    expect(entry.errors).to have_key(:medium)
+    expect(entry.errors).not_to have_key(:watchlist)
   end
 
   it "must have a watchlist" do
     entry = FactoryBot.build(:watchlist_entry, :with_medium)
-    entry.valid?
-    expect(entry.errors[:watchlist]).to include("muss ausgefüllt werden")
+    expect(entry).not_to be_valid
+    expect(entry.errors).to have_key(:watchlist)
+    expect(entry.errors).not_to have_key(:medium)
   end
 
   it "can only be once inside a watchlist" do

--- a/spec/models/watchlist_spec.rb
+++ b/spec/models/watchlist_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe(Watchlist, type: :model) do
 
   it "must have a name" do
     watchlist = Watchlist.new(name: nil)
-    watchlist.valid?
-    expect(watchlist.errors[:name]).to include("muss ausgefüllt werden")
+    expect(watchlist).not_to be_valid
+    expect(watchlist.errors).to have_key(:name)
   end
 
   it "must have a unique name" do


### PR DESCRIPTION
Watchlist tests relied on strings coming from Rails. Instead, we now just check if errors are present and if they contain the respective keys.

(I noticed that these tests are flaky in #647).