### PR TITLE
Enforce foreign keys for mobility translations

### DIFF
--- a/db/migrate/20240627000000_add_foreign_keys_to_mobility.rb
+++ b/db/migrate/20240627000000_add_foreign_keys_to_mobility.rb
@@ -1,0 +1,7 @@
+class AddForeignKeysToMobility < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :subject_translations, :subjects
+    add_foreign_key :program_translations, :programs
+    add_foreign_key :division_translations, :divisions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_200000) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_27_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -940,6 +940,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_200000) do
   add_foreign_key "commontator_comments", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "commontator_subscriptions", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_self_joins", "courses"
+  add_foreign_key "division_translations", "divisions"
   add_foreign_key "divisions", "programs"
   add_foreign_key "feedbacks", "users"
   add_foreign_key "imports", "media"
@@ -951,6 +952,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_200000) do
   add_foreign_key "links", "media", column: "linked_medium_id"
   add_foreign_key "medium_tag_joins", "media"
   add_foreign_key "medium_tag_joins", "tags"
+  add_foreign_key "program_translations", "programs"
   add_foreign_key "programs", "subjects"
   add_foreign_key "quiz_certificates", "media", column: "quiz_id"
   add_foreign_key "quiz_certificates", "users"
@@ -958,6 +960,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_200000) do
   add_foreign_key "referrals", "media"
   add_foreign_key "speaker_talk_joins", "talks"
   add_foreign_key "speaker_talk_joins", "users", column: "speaker_id"
+  add_foreign_key "subject_translations", "subjects"
   add_foreign_key "submissions", "assignments"
   add_foreign_key "submissions", "tutorials"
   add_foreign_key "talk_tag_joins", "tags"


### PR DESCRIPTION
In #609, we migrated from `globalize` to `mobility`, a "Pluggable Ruby translation framework". We migrated according to their [guide here](https://github.com/shioyama/mobility/wiki/Migrating-from-Globalize). However, we didn't check our own migrations file. Now we noticed that three very old migrations cannot be run anymore because the `create_translation_table!` method used in them was provided by `globalize` and is no longer part of `mobility`, see [here](https://github.com/shioyama/mobility/wiki/Migrating-from-Globalize#migrations).

For testing purposes, in #654, we deleted those non-working migrations and completely setup the database again by deleting it entirely (also its schema), then running through all migrations. After that, we used the generator provided by `mobility` to generate the respective translation tables again:

```ruby
rails generate mobility:translations subject name:text
rails generate mobility:translations program name:text
rails generate mobility:translations division name:text
```

The resulting `schema.rb` can now be diffed with what we had before, see [this diff](https://github.com/MaMpf-HD/mampf/pull/654/files#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3). **We made the following observations:**
- Foreign key constraints were added, which is probably due to https://github.com/shioyama/mobility/issues/281 and the respective PR. In this current PR you're viewing, we add those foreign keys manually in a new migration.
- Indices were merged together into one line. We don't do anything here as this is not a semantic change.
- ⚠ The field `t.text "name"` was added to the table `subjects`, `programs` and `divisions`. However, this field already exists in the respective translation tables, so we don't know why we would need it in the associated table as well. We don't change this in this PR as `mobility` already worked in the last few months without this field. **If we have problems with mobility in the future, this might be a possible reason.**
<sub>Note that in the translation tables the field `t.text` was just moved, so it seems like it was added there in the diff as well. It's different for the "non-translation tables" `subjects`, `programs` or `divisions` where the field was really newly added (there's no corresponding red "delete" line for `t.text "name"` in those tables.</sub>

_I've added a `Migration` label to GitHub such that it's easier to find out which PRs were responsible for database migrations ;)_


### Deployment to experimental
I've just deployed this commit to experimental and the server was not reachable afterwards. In the logs, I couldn't find any root cause, nor anything that pointed to the change I made here. I now reset experimental to a commit prior to db9d1f1, build it, then set it to db9d1f1 again and see if it works.

Edit: apparently it also doesn't work with the commit before this PR:

Edit: found the mistake, see [this comment](https://github.com/MaMpf-HD/mampf/pull/655#issuecomment-2200712205). TL;DR: the deployment issue was not related to this PR.