### PR TITLE
Don't use VSCode ESLint experimental flag anymore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
         "source.fixAll.eslint": "explicit"
     },
     "eslint.format.enable": true, // use ESLint as formatter
-    "eslint.experimental.useFlatConfig": true,
     // this disables VSCode built-in formatter (instead we want to use ESLint)
     "javascript.validate.enable": false,
     "eslint.options": {
@@ -54,6 +53,7 @@
         "definition": true
     },
     "rubyLsp.enableExperimentalFeatures": true,
+    "rubyLsp.customRubyCommand": "set -o allexport && . ./docker-dummy.env && set +o allexport",
     //////////////////////////////////////
     // Ruby Test Explorer
     //////////////////////////////////////
@@ -71,7 +71,8 @@
         "node_modules/": true,
         "pdfcomprezzor/": true,
         "coverage/": true,
-        "solr/": true
+        "solr/": true,
+        ".docker/": true
     },
     "files.associations": {
         "*.js.erb": "javascript",
@@ -106,6 +107,5 @@
         "commontator",
         "helpdesk",
         "turbolinks"
-    ],
-    "rubyLsp.customRubyCommand": "set -o allexport && . ./docker-dummy.env && set +o allexport"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,7 +53,6 @@
         "definition": true
     },
     "rubyLsp.enableExperimentalFeatures": true,
-    "rubyLsp.customRubyCommand": "set -o allexport && . ./docker-dummy.env && set +o allexport",
     //////////////////////////////////////
     // Ruby Test Explorer
     //////////////////////////////////////


### PR DESCRIPTION
## **Changes**
- Don't use ESLint experimental flag anymore (it's now in the official plugin version)
- Add the `.docker` folder to hidden folders
- Remove custom Ruby LSP command. This was an attempt to mitigate https://github.com/Shopify/ruby-lsp-rails/issues/382, however it did not work (or rather was too much effort), so we just don't use the few Ruby LSP server-dependent features (for that we would have to run it inside docker containers) and stick with the static code analysis with is sufficient for us.