### PR TITLE
Fix DB preseeding

### DIFF
--- a/.config/commands/docker.justfile
+++ b/.config/commands/docker.justfile
@@ -16,7 +16,7 @@ up-reseed *args:
     cd {{justfile_directory()}}/docker/development/
     export DB_SQL_PRESEED_URL="https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/20220923120841_mampf.sql"
     export UPLOADS_PRESEED_URL="https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/uploads.zip"
-    docker compose up {{args}}
+    docker compose rm --stop --force mampf && docker compose up {{args}}
 
 # Removes the development docker containers
 @down:

--- a/initialize.sh
+++ b/initialize.sh
@@ -31,7 +31,7 @@ if [ "$RAILS_ENV" = "production" ]; then
 fi
 
 if ! [ -f /completed_initial_run ]; then
-  echo "▶  Initialising MaMpf in environment: $RAILS_ENV"
+  echo "▶  Initializing MaMpf in environment: $RAILS_ENV"
 
   echo "🕖  Waiting for Redis to come online"
   wait-for-it redis:6379 -t 30 || exit 1

--- a/initialize.sh
+++ b/initialize.sh
@@ -13,7 +13,7 @@ check_for_preseeds() {
     done
     bundle exec rails db:restore pattern=$(echo $latest | rev | cut -d "/" -f1 | rev | cut -d "_" -f1)
     bundle exec rails db:create:interactions
-    bundle exec rails db:schema:load
+    bundle exec rails db:migrate
   fi
 
   # Files (uploads) preseed
@@ -49,8 +49,8 @@ if ! [ -f /completed_initial_run ]; then
   bundle exec rails db:create:interactions
   bundle exec rails db:create
 
-  echo running: bundle exec rails db:schema:load
-  bundle exec rails db:schema:load
+  echo running: bundle exec rails db:migrate
+  bundle exec rails db:migrate
 
   echo Waiting for SOLR to come online
   wait-for-it ${SOLR_HOST}:${SOLR_PORT} -t 30 || exit 1

--- a/initialize.sh
+++ b/initialize.sh
@@ -11,9 +11,9 @@ check_for_preseeds() {
     for file in db/backups/docker_development/*.sql; do
       [[ $file -nt $latest ]] && latest=$file
     done
-    rails db:restore pattern=$(echo $latest | rev | cut -d "/" -f1 | rev | cut -d "_" -f1)
-    rails db:create:interactions
-    rails db:schema:load
+    bundle exec rails db:restore pattern=$(echo $latest | rev | cut -d "/" -f1 | rev | cut -d "_" -f1)
+    bundle exec rails db:create:interactions
+    bundle exec rails db:schema:load
   fi
 
   # Files (uploads) preseed

--- a/initialize.sh
+++ b/initialize.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 check_for_preseeds() {
-  echo Checking for preseeds
+  echo "💾  Checking for preseeds (in development env)"
 
   # Database preseed
   if [[ "${DB_SQL_PRESEED_URL}" ]]; then
-    echo "Found DB preseed at URL: $DB_SQL_PRESEED_URL"
+    echo "💾  Found DB preseed at URL: $DB_SQL_PRESEED_URL"
     mkdir -pv db/backups/docker_development
     wget --content-disposition --directory-prefix=db/backups/docker_development/ --timestamping $DB_SQL_PRESEED_URL
     for file in db/backups/docker_development/*.sql; do
@@ -18,7 +18,7 @@ check_for_preseeds() {
 
   # Files (uploads) preseed
   if [[ "${UPLOADS_PRESEED_URL}" ]]; then
-    echo "Found upload preseed at URL: $UPLOAD_PRESEED_URL"
+    echo "💾  Found upload preseed at URL: $UPLOAD_PRESEED_URL"
     wget --content-disposition --directory-prefix=public/ --timestamping --progress=dot:mega $UPLOADS_PRESEED_URL
     mkdir -p public/uploads
     bsdtar -xvf public/uploads.zip -s'|[^/]*/||' -C public/uploads
@@ -26,19 +26,18 @@ check_for_preseeds() {
 }
 
 if [ "$RAILS_ENV" = "production" ]; then
-    echo "This script is not intended for usage with RAILS_ENV=production. Aborting."
+    echo "❌  This script is not intended for usage with RAILS_ENV=production. Aborting."
     exit 1
 fi
 
-echo Waiting for redis to come online
-wait-for-it redis:6379 -t 30 || exit 1
-
 if ! [ -f /completed_initial_run ]; then
-  echo Initialising MaMpf
-  echo Waiting for the DB to come online
-  echo RAILS ENV: $RAILS_ENV
+  echo "▶  Initialising MaMpf in environment: $RAILS_ENV"
+
+  echo "🕖  Waiting for Redis to come online"
+  wait-for-it redis:6379 -t 30 || exit 1
 
   # Wait for database to come online
+  echo "🕖  Waiting for database to come online"
   if [ "$RAILS_ENV" = "docker_development" ]; then
       wait-for-it ${DEVELOPMENT_DATABASE_HOST}:${DEVELOPMENT_DATABASE_PORT} -t 30 || exit 1
   fi
@@ -46,7 +45,7 @@ if ! [ -f /completed_initial_run ]; then
       wait-for-it ${TEST_DATABASE_HOST}:${TEST_DATABASE_PORT} -t 30 || exit 1
   fi
 
-  echo running: bundle exec rails db:create
+  echo "➕  Creating database (db:create)"
   bundle exec rails db:create:interactions
   bundle exec rails db:create
 
@@ -54,14 +53,14 @@ if ! [ -f /completed_initial_run ]; then
       check_for_preseeds
   fi
   if [ "$RAILS_ENV" = "test" ]; then
-      echo Loading DB schema
+      echo "💾  Loading DB schema (in test env)"
       bundle exec rails db:schema:load
   fi
 
-  echo Waiting for SOLR to come online
+  echo "🕖  Waiting for SOLR to come online"
   wait-for-it ${SOLR_HOST}:${SOLR_PORT} -t 30 || exit 1
   bundle exec rake sunspot:solr:reindex
 
-  echo 'finished initialisation'
+  echo "✅  Finished initialization of MaMpf in environment: $RAILS_ENV"
   touch /completed_initial_run
 fi


### PR DESCRIPTION
This fixes DB preseeding that was introduced wrongly in #652.

For development, instead of seeding, we restore a sample database and then still use migrations.
For testing, we continue to use db seeding.

The respective Just command was adjusted to allow for reseeding without having to manually stop the mampf service beforehand. This will now be done automatically.

We also moved the SOLR indexing step to the end to avoid errors when SOLR is accessing the database while it is reseeded in the background.

Previously, the `db:create` command as issued twice, I've reduced it such that it only occurs once at the very beginning.