### PR TITLE
Add endpoint to skip validation in Cypress tests

### DIFF
--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       dockerfile: docker/test/Dockerfile
     image: mampf:tests
     ports:
-      - "3000:3000"
+      - "3100:3000"
     environment:
       RAILS_ENV: test
       TEST_DATABASE_ADAPTER: postgresql

--- a/spec/cypress/support/factorybot.js
+++ b/spec/cypress/support/factorybot.js
@@ -17,6 +17,11 @@ class FactoryBot {
   create(...args) {
     return BackendCaller.callCypressRoute("factories", "FactoryBot.create()", args);
   }
+
+  createNoValidate(...args) {
+    args.push({ validate: false });
+    return this.create(...args);
+  }
 }
 
 export default new FactoryBot();


### PR DESCRIPTION
In this PR we
- add an endpoint to skip the validation in the FactoryBot `create()` method. The function can be called from Cypress tests via `FactoryBot.createNoValidate(...)`
- expose Docker to another port (externally) to be able to start Cypress while the dev environment is running. The internal Docker port stays `3000`.