### PR TITLE
Tests: Fix database cleaner separation

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,11 +1,11 @@
 # See the docs here: https://www.rubydoc.info/github/DatabaseCleaner/database_cleaner
 RSpec.configure do |config|
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:deletion)
   end
 
   config.before(:each) do
+    DatabaseCleaner.strategy = :deletion
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION
In #647, we noticed that our unit tests were failing in the pipeline (GitHub Actions). We noticed locally that the database is not fully cleaned and there are users left between tests. We now use the slower `deletion` strategy which will entirely delete the tables since transactions was not working for us. This might be due to `after_commit`or `after_save` callbacks as discussed [here](https://devopsvoyage.com/2018/09/26/get-most-of-the-database-cleaner.html).

Note that for the deletion strategy, we also tried out to set `pre_count` and `reset_ids` to `true` as described [here](https://github.com/DatabaseCleaner/database_cleaner-active_record?tab=readme-ov-file#strategy-configuration-options), but this made the tests slower, so we will omit those options.

For a discussion on delete vs. truncate, see [this StackOverflow answer](https://stackoverflow.com/questions/11419536/postgresql-truncation-speed/11423886#11423886).

Note that this PR was opened after a long night session were Denis and I both tried to dig down deep. We hope this PR doesn't break anything 😅 But it shouldn't and if it does, then only our tests.