### PR TITLE
Add `just` commands for docker logs

### DIFF
--- a/.config/commands/docker.justfile
+++ b/.config/commands/docker.justfile
@@ -16,7 +16,7 @@ up-logs *args:
     docker compose up -d {{args}}
     docker compose logs -f mampf
 
-# Shows the log of the MaMpf container
+# Shows the log of the specified container
 @logs name="mampf":
     #!/usr/bin/env bash
     cd {{justfile_directory()}}/docker/development/

--- a/.config/commands/docker.justfile
+++ b/.config/commands/docker.justfile
@@ -9,6 +9,19 @@ help:
     cd {{justfile_directory()}}/docker/development/
     docker compose up {{args}}
 
+# Starts the dev docker containers (detached) & shows MaMpf logs
+up-logs *args:
+    #!/usr/bin/env bash
+    cd {{justfile_directory()}}/docker/development/
+    docker compose up -d {{args}}
+    docker compose logs -f mampf
+
+# Shows the log of the MaMpf container
+@logs name="mampf":
+    #!/usr/bin/env bash
+    cd {{justfile_directory()}}/docker/development/
+    docker compose logs -f {{name}}
+
 # Starts the dev docker containers and preseeds the database
 [confirm("This will reset all your data in the database locally. Continue? (y/n)")]
 up-reseed *args:


### PR DESCRIPTION
We add the two `just` commands

```
just docker up-logs
just docker logs
```

`just docker up-logs` allows you to start the containers in detached mode while still seeing the logs afterwards. Therefore, you can `Ctrl + C` out of your terminal afterwards and the containers will continue to run. `just docker logs` is used to attach back to the logs for a running container (by default the mampf container).