### PR TITLE
Remove unnecessary `with_teacher_by_id` trait

### DIFF
--- a/spec/cypress/e2e/annotations_overview_spec.cy.js
+++ b/spec/cypress/e2e/annotations_overview_spec.cy.js
@@ -23,9 +23,9 @@ function createAnnotationScenario(context, userRole = "student") {
   cy.then(() => {
     // a user is considered a teacher only iff they have given any lecture
     const teacherUser = userRole === "teacher" ? context.user : context.teacherUser;
-    FactoryBot.create("lecture_with_sparse_toc", "with_title", "with_teacher_by_id",
+    FactoryBot.create("lecture_with_sparse_toc", "with_title",
       { title: LECTURE_TITLE_1, teacher_id: teacherUser.id }).as("lectureSage");
-    FactoryBot.create("lecture_with_sparse_toc", "with_title", "with_teacher_by_id",
+    FactoryBot.create("lecture_with_sparse_toc", "with_title",
       { title: LECTURE_TITLE_2, teacher_id: teacherUser.id }).as("lectureLean");
   });
 
@@ -80,7 +80,7 @@ describe("Annotation section", () => {
     cy.createUserAndLogin("teacher").as("teacher");
     cy.then(() => {
       // a user is considered a teacher only iff they have given any lecture
-      FactoryBot.create("lecture", "with_teacher_by_id", { teacher_id: this.teacher.id });
+      FactoryBot.create("lecture", { teacher_id: this.teacher.id });
     });
 
     cy.i18n("admin.annotation.your_annotations").as("yourAnnotations");

--- a/spec/cypress/e2e/lectures_spec.cy.js
+++ b/spec/cypress/e2e/lectures_spec.cy.js
@@ -3,7 +3,7 @@ import FactoryBot from "../support/factorybot";
 describe("Lecture edit page", () => {
   it("shows content tab button", function () {
     cy.createUserAndLogin("teacher").then((teacher) => {
-      FactoryBot.create("lecture", "with_teacher_by_id",
+      FactoryBot.create("lecture",
         { teacher_id: teacher.id }).as("lecture");
     });
 

--- a/spec/factories/lectures.rb
+++ b/spec/factories/lectures.rb
@@ -62,13 +62,6 @@ FactoryBot.define do
       course { association :course, title: title }
     end
 
-    trait :with_teacher_by_id do
-      transient do
-        teacher_id { nil }
-      end
-      teacher { User.find(teacher_id) }
-    end
-
     # NOTE: that you can give the chapter_count here as parameter as well
     factory :lecture_with_toc, traits: [:with_toc]
 


### PR DESCRIPTION
Thanks to @fosterfarrell9 for pointing out that the trait `with_teacher_by_id` is actually not needed in FactoryBot. I removed it in this PR.