### PR TITLE
Explicitly set locale to German in course specs

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -546,6 +546,7 @@ RSpec.describe(Course, type: :model) do
         self_item1 = Item.find_by(sort: "self", medium: @course_medium)
         self_item2 = Item.find_by(sort: "self", medium: @lecture_medium)
         self_item3 = Item.find_by(sort: "self", medium: @lesson_medium)
+        I18n.locale = :de
         expect(@course.media_items_with_inheritance)
           .to match_array([["Bem. 1.2 ", item1.id],
                            ["SS 20, Satz 3.4 ", item2.id],


### PR DESCRIPTION
As we are comparing to an array of values that contain German words like "Satz" or "Bsp.", we explicitly set the language to German here to avoid flaky tests in our pipeline due to the language of the user being chosen randomly.

This was originally discovered in [this GitHub Actions run](https://github.com/MaMpf-HD/mampf/actions/runs/10760063671/job/29837752555?pr=670).