### PR TITLE
Apply RootPathnameMethods linting suggestion

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ require "support/database_cleaner"
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Rails.root.glob("spec/support/**/*.rb").each { |f| require f }
 
 RSpec.configure do |config|
   # Include Factory Girl syntax to simplify calls to factories


### PR DESCRIPTION
Linting failed due to [Rails/RootPathnameMethods](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpathnamemethods), this PR fixes it.

> Safety: This cop is unsafe for autocorrection because Dir's children, each_child, entries, and glob methods return string element, but these methods of Pathname return Pathname element.

Apparently, `require` probably also works on `Pathname`. At least, the tests still work for me locally. I haven't checked the API for `require` though. This file is only used for tests anyways and as they still work I think it's not a big deal.