### PR TITLE
Init support for entity-relationship diagram creation (Ruby ERD)

### DIFF
--- a/.config/commands/utils.justfile
+++ b/.config/commands/utils.justfile
@@ -1,0 +1,71 @@
+# Prints this help message
+[private]
+help:
+    @just --list --justfile {{source_file()}}
+
+# Generates entity-relationship diagrams (ERD) of the database
+erd:
+    #!/usr/bin/env bash
+
+    # Make sure the mampf dev container is running
+    cd {{justfile_directory()}}/docker/development/
+    if [ -z "$(docker compose ps --services --filter 'status=running' | grep mampf)" ]; then
+        echo "The mampf dev container is not running. Please start it first (use 'just docker')."
+        exit 1
+    fi
+
+    mkdir -p {{justfile_directory()}}/tmp/erd/
+
+    # ▶ Generate ERDs
+    # Customize it with options from here: https://voormedia.github.io/rails-erd/customise.html
+    # Also see the output from: 'bundle exec erd --help' (inside the dev container)
+
+    # Ignore some tables
+    ignored_thredded="Thredded::Post,Thredded::UserPostNotification,Thredded::PrivateUser,Thredded::UserPrivateTopicReadState,Thredded::PrivateTopic,Thredded::MessageboardUser,Thredded::PrivatePost,Thredded:UserDetail,Thredded::MessageboardGroup,Thredded::Messageboard,Thredded::Category,Thredded::TopicCategory,Thredded::Topic,Thredded::UserTopicReadState,Thredded::UserTopicFollow,Thredded::NotificationsForFollowedTopics,Thredded::MessageboardNotificationsForFollowedTopics,Thredded::UserPreference,Thredded::UserMessageboardPreference,Thredded::NotificationsForPrivateTopics,Thredded::PostModerationRecord,Thredded::UserDetail"
+    ignored_translation="Mobility::Backends::ActiveRecord::Table::Translation,Subject::Translation,Program::Translation,Division::Translation"
+    ignored_commontator="Commontable,Votable,Subscriber,Creator"
+    other_ignored="ActionMailbox::Record,ActionText::Record,ActiveStorage::Record,Sluggable,FriendlyId::Slug,ApplicationRecord,InteractionsRecord"
+    exclude_default="${ignored_thredded},${ignored_translation},${ignored_commontator},${other_ignored}"
+
+    # 🌟 Overview with attributes (warnings will be printed only here)
+    docker compose exec -it mampf rake erd \
+        title=false filename=/usr/src/app/tmp/erd/mampf-erd-overview-with-attributes \
+        inheritance=false polymorphism=true indirect=false attributes=content \
+        exclude="${exclude_default}"
+
+    # 🌟 Generic Overview
+    docker compose exec -it mampf rake erd warn=false \
+        title=false filename=/usr/src/app/tmp/erd/mampf-erd-overview \
+        inheritance=false polymorphism=true indirect=false attributes=false \
+        exclude="${exclude_default}"
+
+    # 🌟 Vouchers
+    docker compose exec -it mampf rake erd warn=false \
+        title="Vouchers" filename=/usr/src/app/tmp/erd/mampf-erd-vouchers \
+        inheritance=true polymorphism=true indirect=true attributes=content \
+        exclude="${exclude_default},Teachable,Editable" \
+        only="User,Claim,Voucher,Redemption,Lecture,Tutorial,Talk"
+
+    # 🌟 Tutorials
+    docker compose exec -it mampf rake erd warn=false \
+        title="Tutorials" filename=/usr/src/app/tmp/erd/mampf-erd-tutorials \
+        inheritance=true polymorphism=true indirect=true attributes=content \
+        exclude="${exclude_default},Claimable,Editable,Teachable" \
+        only="User,Lecture,Tutorial,Submission,Assignment,TutorTutorialJoin,UserSubmissionJoin"
+
+    # 🌟 Courses
+    docker compose exec -it mampf rake erd warn=false \
+        title="Courses" filename=/usr/src/app/tmp/erd/mampf-erd-courses \
+        inheritance=true polymorphism=true indirect=true attributes=content \
+        exclude="${exclude_default},Claimable,Editable" \
+        only="Subject,Program,Division,DivisionCourseJoin,Course,Lecture,CourseSelfJoin,Lesson"
+
+    # 🌟 Lectures
+    docker compose exec -it mampf rake erd warn=false \
+        title="Lectures" filename=/usr/src/app/tmp/erd/mampf-erd-lectures \
+        inheritance=true polymorphism=true indirect=true attributes=content \
+        exclude="${exclude_default},Claimable,Editable,Teachable" \
+        only="Lecture,Lesson,Chapter,Section,Item,LessonSectionJoin,Term"
+
+    echo "📂 Diagrams are ready for you in the folder {{justfile_directory()}}/tmp/erd/"
+    echo "🔀 For the meanings of the arrows, refer to https://voormedia.github.io/rails-erd/gallery.html#notations"

--- a/.justfile
+++ b/.justfile
@@ -13,6 +13,9 @@ mod test ".config/commands/test.justfile"
 # Docker-related commands
 mod docker ".config/commands/docker.justfile"
 
+# Some utils, e.g. ERD-generation etc.
+mod utils ".config/commands/utils.justfile"
+
 # Opens the MaMpf wiki in the default browser
 wiki:
     #!/usr/bin/env bash

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -53,7 +53,7 @@ RUN yarn set version "${YARN_VERSION}"
 RUN apt update && \
     apt-get install -y --no-install-recommends \
         ffmpeg imagemagick pdftk ghostscript shared-mime-info \
-        libarchive-tools postgresql-client-13 wget wait-for-it
+        libarchive-tools postgresql-client-13 wget wait-for-it graphviz
 
 # Setup ImageMagick
 RUN sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
Entity-relationship diagrams (ERD) have long been a very powerful tool for gaining insights and an overview of how the tables in a database are structured and associated to each other.

[`Rails ERD`](https://voormedia.github.io/rails-erd/) generates such diagrams based on runtime-informations using reflection (instead of static analysis). We have already specified this dependency in our Gemfile, but not used it so far.

> [!tip]
> In order to generate the PDF files locally, see the new Wiki entry [here](https://github.com/MaMpf-HD/mampf/wiki/Database#entity-relationship-diagrams-erd).


### For reviewers
- Merge the voucher PR #671 into this branch locally to be able to create the voucher-related ERDs. Otherwise you will encounter errors like `raise NameError.new(message, name)`.
- Please make sure to rebuild at least the `mampf` dev docker container, as `graphviz` was added as dependency. This is a visualization library that Rails ERD uses to generate the actual PDF out of `.dot` files. We need to make sure it is available in the dev docker container.
- I've created some diagrams that I think could be useful as a good starting point. We can easily add more later on if needed. But feel free to add more diagrams directly in this pull request ;)


### Sample output

![image](https://github.com/user-attachments/assets/ad8ec2c8-5ed3-41ea-b56c-0e622090dc3f)
