### PR TITLE
Add Ruby Test explorer to recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "dbaeumer.vscode-eslint",
         "streetsidesoftware.code-spell-checker",
         "streetsidesoftware.code-spell-checker-german",
-        "nefrob.vscode-just-syntax"
+        "nefrob.vscode-just-syntax",
+        "connorshea.vscode-ruby-test-adapter"
     ]
 }


### PR DESCRIPTION
We forgot to add the [Ruby Test explorer extension](https://marketplace.visualstudio.com/items?itemName=connorshea.vscode-ruby-test-adapter) that we're already using to the recommended VSCode extension. Added it now.