### PR TITLE
Fix annotation status default value in UI

### DIFF
--- a/app/views/media/_basics.html.erb
+++ b/app/views/media/_basics.html.erb
@@ -183,11 +183,11 @@
         <div class="form-row ml-2">
           <div class="form-check form-check-inline">
             <%= f.radio_button :annotations_status,
-                               '0',
+                               '-1',
                                class: 'form-check-input' %>
             <%= f.label :annotations_status,
                         t('admin.annotation.inherit_from_lecture'),
-                        value: '0',
+                        value: '-1',
                         class: 'form-check-label' %>
           </div>
           <div class="form-check form-check-inline">
@@ -201,11 +201,11 @@
           </div>
           <div class="form-check form-check-inline">
             <%= f.radio_button :annotations_status,
-                               '-1',
+                               '0',
                                class: 'form-check-input' %>
             <%= f.label :annotations_status,
                         t('basics.no_lc'),
-                        value: '-1',
+                        value: '0',
                         class: 'form-check-label' %>
           </div>
         </div>


### PR DESCRIPTION
Fixes #704.

> Currently, if I create a new medium in a lecture where the lecture has "share annotations with teacher" set as true, the default for the new medium is that annotations are not shared. This is contrary to the intended behaviour.

In reality, the default was indeed that the status is inherited from the lecture. You could even open a video and verify that users can create annotations and share them with the teacher.

The problem was that originally, Marlon used the values `-1, 0, 1` to signify:
- `-1`: deactivated
- `0`: inherit
- `1`: activated

and I changed that to the following when I worked on the annotation tool:
- `-1`: inherit
- `0`: deactivated
- `1`: activated

However, I forgot to update the values at this place in the UI and therefore the wrong radio button was highlighted (the frontend got the value `-1` which meant *deactivated* beforehand).

Luckily, this is a simple frontend bug and we don't have to update anything in the backend.