### PR TITLE
Init dependencies (deps) Just commands

### DIFF
--- a/.config/commands/deps.justfile
+++ b/.config/commands/deps.justfile
@@ -1,0 +1,22 @@
+[private]
+help:
+    @just --list --justfile {{source_file()}}
+
+# Shows the Dependabot alerts on GitHub
+alerts:
+    #!/usr/bin/env bash
+    xdg-open https://github.com/MaMpf-HD/mampf/security/dependabot
+
+# Updates the Bundler package manager itself (NOT the Ruby gems)
+update-bundler:
+    bundle update --bundler
+
+# Updates Ruby gems
+update-gems:
+    bundle update
+
+# Updates Node.js packages
+update-nodejs:
+    # You may have to run this command beforehand:
+    # sudo chown your_user_name -R ./node_modules/
+    yarn upgrade

--- a/.justfile
+++ b/.justfile
@@ -5,13 +5,16 @@
 help:
     @just --list
 
-# Test-related commands
+# Commands to test the MaMpf codebase
 mod test ".config/commands/test.justfile"
 # see https://github.com/casey/just/issues/2216
 # alias t := test 
 
-# Docker-related commands
+# Commands to manage the docker containers
 mod docker ".config/commands/docker.justfile"
+
+# Commands to manage dependencies
+mod deps ".config/commands/deps.justfile"
 
 # Some utils, e.g. ERD-generation etc.
 mod utils ".config/commands/utils.justfile"


### PR DESCRIPTION
We introduce new `just` commands to ease updating of dependencies, which we want to do regularly with every release.