### PR TITLE
Hotfix: Set retry option to false for UserCleanerJob

### DIFF
--- a/app/workers/user_cleaner_job.rb
+++ b/app/workers/user_cleaner_job.rb
@@ -1,5 +1,6 @@
 class UserCleanerJob
   include Sidekiq::Worker
+  sidekiq_options retry: false # job will be discarded if it fails
 
   def perform
     # Only run this job in production, not for mampf-experimental or mampf-dev.


### PR DESCRIPTION
In production we encountered some failing UserCleanerJobs that were then repeatedly retried according to Sidekiq's error handling schedule, which result in some users getting several emails in a short period of time. As it is currently unclear why these jobs fail, this hotfix configures the UserCleanerJob in a way that failing jobs will not be retried. 