### PR TITLE
Fix unknown user variable after deletion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -107,6 +107,7 @@
         "factorybot",
         "helpdesk",
         "katex",
-        "turbolinks"
+        "turbolinks",
+        "Unsets"
     ]
 }

--- a/app/mailers/user_cleaner_mailer.rb
+++ b/app/mailers/user_cleaner_mailer.rb
@@ -5,24 +5,22 @@ class UserCleanerMailer < ApplicationMailer
   #
   # @param [Integer] num_days_until_deletion:
   #  The number of days until the account will be deleted.
-  def pending_deletion_email(num_days_until_deletion)
-    user = params[:user]
+  def pending_deletion_email(user_email, user_locale, num_days_until_deletion)
     sender = "#{t("mailer.warning")} <#{DefaultSetting::PROJECT_EMAIL}>"
-    I18n.locale = user.locale
+    I18n.locale = user_locale
 
     @num_days_until_deletion = num_days_until_deletion
     subject = t("mailer.pending_deletion_subject",
                 num_days_until_deletion: @num_days_until_deletion)
-    mail(from: sender, to: user.email, subject: subject, priority: "high")
+    mail(from: sender, to: user_email, subject: subject, priority: "high")
   end
 
   # Creates an email to inform a user that their account has been deleted.
-  def deletion_email
-    user = params[:user]
+  def deletion_email(user_email, user_locale)
     sender = "#{t("mailer.warning")} <#{DefaultSetting::PROJECT_EMAIL}>"
-    I18n.locale = user.locale
+    I18n.locale = user_locale
 
     subject = t("mailer.deletion_subject")
-    mail(from: sender, to: user.email, subject: subject, priority: "high")
+    mail(from: sender, to: user_email, subject: subject, priority: "high")
   end
 end

--- a/app/models/user_cleaner.rb
+++ b/app/models/user_cleaner.rb
@@ -134,9 +134,9 @@ class UserCleaner
       num_days_until_deletion = (user.deletion_date - Date.current).to_i
 
       if [14, 7, 2].include?(num_days_until_deletion)
-        UserCleanerMailer.with(user: user)
-                         .pending_deletion_email(num_days_until_deletion)
-                         .deliver_later
+        UserCleanerMailer
+          .pending_deletion_email(user.email, user.locale, num_days_until_deletion)
+          .deliver_later
       end
     end
   end

--- a/app/models/user_cleaner.rb
+++ b/app/models/user_cleaner.rb
@@ -76,8 +76,9 @@ class UserCleaner
                   .find_each do |user|
       user.update(deletion_date: Date.current + 40.days)
 
-      if user.generic? # rubocop:disable Style/IfUnlessModifier
-        UserCleanerMailer.with(user: user).pending_deletion_email(40).deliver_later
+      if user.generic?
+        UserCleanerMailer.pending_deletion_email(user.email, user.locale, 40)
+                         .deliver_later
       end
     end
   end
@@ -114,7 +115,7 @@ class UserCleaner
     User.where(deletion_date: ..Date.current).find_each do |user|
       next unless user.generic?
 
-      UserCleanerMailer.with(user: user).deletion_email.deliver_later
+      UserCleanerMailer.deletion_email(user.email, user.locale).deliver_later
       user.destroy
       num_deleted_users += 1
     end


### PR DESCRIPTION
In the user cleaner, we delete users that haven't logged in for too long. Before the deletion, we enqueue a last mail to the user to verify that their account was deleted. This mail might be sent *after* we have actually deleted the user. The user object is passed as reference to the mail handler and is therefore not available anymore after the user was deleted. Hence, the delivery of the mail fails. This PR addresses this by passing the respective user email and locale *by value* and not *by reference*.