### PR TITLE
Fix flaky user deletion & redemption cypress test

### DIFF
--- a/spec/cypress/e2e/vouchers_redemptions_spec_helpers.js
+++ b/spec/cypress/e2e/vouchers_redemptions_spec_helpers.js
@@ -117,7 +117,7 @@ export function logoutAndLoginAsTeacher(context) {
 
 export function verifyNoTutorialsButUserEligibleAsTutor(context, shouldBeEligible = true) {
   cy.getBySelector("tutorial-row").should("not.exist");
-  cy.getBySelector("new-tutorial-btn").click();
+  cy.getBySelector("new-tutorial-btn").should("be.visible").click();
   cy.then(() => {
     cy.getBySelector("tutorial-form").should("be.visible");
     cy.getBySelector("tutor-select").within(() => {


### PR DESCRIPTION
The Cypress docs on [Actionability](https://docs.cypress.io/app/core-concepts/interacting-with-elements#Actionability) state that `.click()` will wait until the element reaches an "actionable state". This includes a check that the element is not hidden. However, in our tests we see that after visiting a page, a button is deemed "visible" even though it's not visible in the viewport yet.

Here we fix this flaky test. If this kind of behavior occurs more offen, either we use Cypress in a wrong manner or Cypress has a bug. In both cases it might be worth to consider overriding the `.click()` event by a custom method that calls `.should("be.visible").click()` instead, but this is something for a future PR (maybe).