### PR TITLE
Disable Style/ArrayIntersect on one line

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -286,7 +286,7 @@ class Lesson < ApplicationRecord
   end
 
   def tags_without_section
-    tags.includes(:sections).select { |t| (t.sections & sections).empty? }
+    tags.includes(:sections).select { |t| (t.sections & sections).empty? } # rubocop:disable Style/ArrayIntersect
   end
 
   private


### PR DESCRIPTION
See it [in the Rubocop docs](https://docs.rubocop.org/rubocop/cops_style.html#stylearrayintersect):

> This cop cannot guarantee that array1 and array2 are actually arrays while method intersect? is for arrays only.

Here, we deal with ActiveRecord objects that are not arrays, so we shouldn't use this. That's why I disable the lint here.