### PR TITLE
Fix failing `just docker rebuild` script

### DIFF
--- a/.config/commands/docker.justfile
+++ b/.config/commands/docker.justfile
@@ -61,7 +61,7 @@ up-reseed *args:
     docker compose exec mampf bundle exec rails c
 
 # Rebuilds the most essential containers in the dev or test environment
-rebuild env="dev"
+rebuild env="dev":
     #!/usr/bin/env bash
     environment={{ if env == "test" {"test"} else {"development"} }}
     echo "Rebuilding in env: ${environment}"


### PR DESCRIPTION
In #719, I accidentally broke the `just` scripts because I forgot a `:`.

I won't run through the tests here since we only change a `.justfile`.