### PR TITLE
Fix flaky Cypress submission test

### DIFF
--- a/spec/cypress/e2e/profile_spec.cy.js
+++ b/spec/cypress/e2e/profile_spec.cy.js
@@ -77,9 +77,9 @@ describe("Account settings", () => {
       cy.getBySelector("file-permission-accept").click();
       cy.getBySelector("upload-user-submission").click();
 
-      cy.intercept("POST", "/submissions*").as("saveSubmissionsRequest");
+      cy.intercept("POST", "/submissions*").as("saveSubmissionRequest");
       cy.getBySelector("save-submission").click();
-      cy.wait("@saveSubmissionsRequest");
+      cy.wait("@saveSubmissionRequest");
     });
 
     cy.then(() => {

--- a/spec/cypress/e2e/profile_spec.cy.js
+++ b/spec/cypress/e2e/profile_spec.cy.js
@@ -76,7 +76,10 @@ describe("Account settings", () => {
         .selectFile("cypress/fixtures/files/manuscript.pdf", { force: true });
       cy.getBySelector("file-permission-accept").click();
       cy.getBySelector("upload-user-submission").click();
+
+      cy.intercept("POST", "/submissions*").as("saveSubmissionsRequest");
       cy.getBySelector("save-submission").click();
+      cy.wait("@saveSubmissionsRequest");
     });
 
     cy.then(() => {


### PR DESCRIPTION
In #945, one Cypress test was failing (but only once). I couldn't reproduce the issue locally. With this PR, we intercept the submissions POST request and wait for it to be finished before logging the user out. This should hopefully prevent the flakiness in the future.