### PR TITLE
Update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,8 @@
 # Security Policy
 
-## Supported Versions
+> [!warning]
+> MaMpf is continuously deployed, so users will always get to work with the newest version.<br>That's why we will only release patches for the `main` branch.
 
-We only release patches for the production branch.
-
-## Reporting a Vulnerability
-
-Please report (suspected) security vulnerabilities to
-mampf-security@mathi.uni-heidelberg.de. You will receive a response from us
-within 48 hours. If the issue is confirmed, we will release a patch as soon
-as possible depending on complexity but usually within a few days.
+- We are very grateful for any reports of security vulnerabilities in MaMpf. We take security very seriously and will respond to verified reports as soon as possible.
+- Please don't report vulnerabilities in the public GitHub issue tracker. Instead, [**report them here privately on GitHub**](https://github.com/MaMpf-HD/mampf/security/advisories) and do NOT disclose them publicly until we have had a chance to address them.
+- Note that we don't give out bounties for security vulnerabilities. We are a non-profit project and don't have the resources to pay for security reports. We are grateful for any reports and will acknowledge them in our release notes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,5 +4,5 @@
 > MaMpf is continuously deployed, so users will always get to work with the newest version.<br>That's why we will only release patches for the `main` branch.
 
 - We are very grateful for any reports of security vulnerabilities in MaMpf. We take security very seriously and will respond to verified reports as soon as possible.
-- Please don't report vulnerabilities in the public GitHub issue tracker. Instead, [**report them here privately on GitHub**](https://github.com/MaMpf-HD/mampf/security/advisories) and do NOT disclose them publicly until we have had a chance to address them.
+- Please don't report vulnerabilities in the public GitHub issue tracker. Instead, [**report them here privately on GitHub**](https://github.com/MaMpf-HD/mampf/security) and do NOT disclose them publicly until we have had a chance to address them.
 - Note that we don't give out bounties for security vulnerabilities. We are a non-profit project and don't have the resources to pay for security reports. We are grateful for any reports and will acknowledge them in our release notes.


### PR DESCRIPTION
Update our security policy text. We don't need to mention an email here, instead users can report security vulnerabilities directly to us on GitHub (privately).

I won't run through the tests for this PR, as this doesn't affect any code.