### PR TITLE
Remove obsolete tutorial name search field

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,10 +133,6 @@ class User < ApplicationRecord
   scope :inactive_for, ->(threshold) { where(current_sign_in_at: ...threshold.ago) }
   scope :confirmation_sent_before, ->(threshold) { where(confirmation_sent_at: ...threshold.ago) }
 
-  searchable do
-    text :tutorial_name
-  end
-
   # returns the array of all teachers
   def self.teachers
     User.where(id: Lecture.distinct.select(:teacher_id))


### PR DESCRIPTION
In our `User` model, we have the following `searchable` related to Solr searches:

```ruby
searchable do
  text :tutorial_name
end
```

There is however no longer any Solr based search for users (and has not been for a long time). The search field was introduced in [this commit](https://github.com/MaMpf-HD/mampf/commit/a76b0bf1695560e9b345994ea7d379967618a032), and [at a later time](https://github.com/MaMpf-HD/mampf/commit/b86f203aa17ea78facbfff24488089dbb2c9faed) the search field was changed to `tutorial_name`. However, this was only used in the [users controller](https://github.com/MaMpf-HD/mampf/commit/a76b0bf1695560e9b345994ea7d379967618a032#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6e) in a `list` method which no longer exists. All user based searches have long since been changed to Postgres searches. If you search for `Sunspot.new_search` in our code base, you will see that there are no longer any Solr based searches on the user model. 
Consequently, this PR removes the obsolete searchable field from the `User` model.