### PR TITLE
Fix user cleaner for invalid users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -122,8 +122,9 @@
         "selectize",
         "Timecop",
         "turbolinks",
-        "Unsets",
+        "unassigns",
         "uncached",
+        "Unsets",
         "whitespaces"
     ],
     "cSpell.enableFiletypes": [

--- a/app/mailers/user_cleaner_mailer.rb
+++ b/app/mailers/user_cleaner_mailer.rb
@@ -23,4 +23,15 @@ class UserCleanerMailer < ApplicationMailer
     subject = t("mailer.deletion_subject")
     mail(from: sender, to: user_email, subject: subject, priority: "high")
   end
+
+  # Creates an email to inform the MaMpf team that a user could not be destroyed.
+  def destroy_failed_email(user)
+    sender = "UserCleaner <#{DefaultSetting::PROJECT_EMAIL}>"
+    subject = "User #{user.id} could not be destroyed"
+
+    @user = user
+    mail(from: sender, to: DefaultSetting::PROJECT_EMAIL,
+         content_type: "text/plain",
+         subject: subject, priority: "high")
+  end
 end

--- a/app/models/user_cleaner.rb
+++ b/app/models/user_cleaner.rb
@@ -130,6 +130,7 @@ class UserCleaner
         num_deleted_users += 1
       else
         Rails.logger.info("UserCleaner failed to destroy user #{user.id}")
+        UserCleanerMailer.destroy_failed_email(user).deliver_later
       end
     end
 

--- a/app/models/user_cleaner.rb
+++ b/app/models/user_cleaner.rb
@@ -118,16 +118,23 @@ class UserCleaner
   # deletion date in the future, as we only delete generic users.
   def delete_users_according_to_deletion_date!
     num_deleted_users = 0
+    num_intended_to_delete = 0
 
     User.where(deletion_date: ..Date.current).find_each do |user|
       next unless user.generic?
 
       UserCleanerMailer.deletion_email(user.email, user.locale).deliver_later
-      user.destroy
-      num_deleted_users += 1
+      num_intended_to_delete += 1
+
+      if user.destroy
+        num_deleted_users += 1
+      else
+        Rails.logger.info("UserCleaner failed to destroy user #{user.id}")
+      end
     end
 
-    Rails.logger.info("UserCleaner deleted #{num_deleted_users} stale users")
+    Rails.logger.info("UserCleaner deleted #{num_deleted_users} stale users" \
+      + " (intended to delete: #{num_intended_to_delete})")
   end
 
   # Sends additional warning mails to users whose deletion date is near.

--- a/app/views/user_cleaner_mailer/destroy_failed_email.text.erb
+++ b/app/views/user_cleaner_mailer/destroy_failed_email.text.erb
@@ -1,0 +1,8 @@
+UserCleaner failed to destroy the following user:
+
+- id: <%= @user.id %>
+- name: <%= @user.name %>
+- email: <%= @user.email %>
+- current_sign_in_at: <%= @user.current_sign_in_at %>
+- last_sign_in_at: <%= @user.last_sign_in_at %>
+- deletion_date: <%= @user.deletion_date %>

--- a/spec/models/user_cleaner_spec.rb
+++ b/spec/models/user_cleaner_spec.rb
@@ -158,6 +158,22 @@ RSpec.describe(UserCleaner, type: :model) do
       expect(user_inactive2.deletion_date).to eq(deletion_date)
       expect(user_active.deletion_date).to be_nil
     end
+
+    it "unassigns a deletion from a recently active user even if validations fail" do
+      user = FactoryBot.create(:confirmed_user, current_sign_in_at: 2.days.ago,
+                                                deletion_date: Date.current + 5.days)
+      user.name = ""
+      user.save(validate: false)
+      user.reload
+
+      user_invalid = User.find(user.id)
+      expect(user_invalid).not_to be_valid
+
+      UserCleaner.new.unset_deletion_date_for_recently_active_users
+      user_invalid.reload
+
+      expect(user_invalid.deletion_date).to be_nil
+    end
   end
 
   describe("#delete_users") do

--- a/spec/models/user_cleaner_spec.rb
+++ b/spec/models/user_cleaner_spec.rb
@@ -106,6 +106,21 @@ RSpec.describe(UserCleaner, type: :model) do
         users_flagged = User.where(deletion_date: Date.current + 40.days)
         expect(users_flagged.count).to eq(max_deletions)
       end
+
+      it "assigns a deletion date even if validations fail" do
+        user = FactoryBot.create(:confirmed_user, current_sign_in_at: 7.months.ago)
+        user.name = ""
+        user.save(validate: false)
+        user.reload
+
+        user_invalid = User.find(user.id)
+        expect(user_invalid).not_to be_valid
+
+        UserCleaner.new.set_deletion_date_for_inactive_users
+        user_invalid.reload
+
+        expect(user_invalid.deletion_date).to eq(Date.current + 40.days)
+      end
     end
 
     context "when a deletion date is assigned" do


### PR DESCRIPTION
In production, we got some weird errors, where the same users would get the user cleaner deletion mail (40 days) every day. This blog post summarizes well what I did wrong in the user cleaner: [Misuse of update/update! in Ruby on Rails](https://marcgg.com/blog/2020/04/08/rails-update-bang/).

The problem is a seemingly harmless statement:

https://github.com/MaMpf-HD/mampf/blob/412c981ed9058e82b7023c0552674c00acbe71bd/app/models/user_cleaner.rb#L77

But what if the `user` is invalid? Well, then `update` silently fails here. Instead, we want to set the deletion date in any case, so we should rather do

```rb
user.deletion_date = Date.current + 40.days
user.save(validate: false)
```

> [!tip]
> See also this PDF I've created to summarize the bug: [UserCleaner Update Bug.pdf](https://github.com/user-attachments/files/18399909/UserCleaner.Update.Bug.pdf)

I fixed this and additionally identified another place where I've used `update` without checking for the return value. Furthermore, I've added a mail such that we get informed when a user cannot be destroyed (for whatever reasons).

I've also covered the bug with new tests to avoid regressions in the future.
**❗ Please make sure that the tests do actually fail with the previous behavior.**