### PR TITLE
Fix rubocop rails linting

### DIFF
--- a/db/interactions_migrate/20191209143820_create_interactions.rb
+++ b/db/interactions_migrate/20191209143820_create_interactions.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateInteractions < ActiveRecord::Migration[6.0]
   def change
     create_table :interactions do |t|
@@ -6,4 +5,3 @@ class CreateInteractions < ActiveRecord::Migration[6.0]
     end
   end
 end
-# rubocop:enable Rails/

--- a/db/interactions_migrate/20191209165752_add_details_to_interaction.rb
+++ b/db/interactions_migrate/20191209165752_add_details_to_interaction.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddDetailsToInteraction < ActiveRecord::Migration[6.0]
   def change
     add_column :interactions, :controller_name, :text
@@ -6,4 +5,3 @@ class AddDetailsToInteraction < ActiveRecord::Migration[6.0]
     add_column :interactions, :referrer_url, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/interactions_migrate/20191211155453_remove_details_from_interactions.rb
+++ b/db/interactions_migrate/20191211155453_remove_details_from_interactions.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class RemoveDetailsFromInteractions < ActiveRecord::Migration[6.0]
   def change
     remove_column :interactions, :controller_name, :text
     remove_column :interactions, :action_name, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/interactions_migrate/20191218131526_create_probes.rb
+++ b/db/interactions_migrate/20191218131526_create_probes.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateProbes < ActiveRecord::Migration[6.0]
   def change
     create_table :probes do |t|
@@ -11,4 +10,3 @@ class CreateProbes < ActiveRecord::Migration[6.0]
     end
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20170914162323_delete_asset_tag_join.rb
+++ b/db/migrate/20170914162323_delete_asset_tag_join.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class DeleteAssetTagJoin < ActiveRecord::Migration[5.1]
   def change
     drop_table :asset_tag_joins
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20170919123229_add_admin_to_users.rb
+++ b/db/migrate/20170919123229_add_admin_to_users.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddAdminToUsers < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :admin, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20171001204632_drop_asset.rb
+++ b/db/migrate/20171001204632_drop_asset.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class DropAsset < ActiveRecord::Migration[5.1]
   def change
     drop_table :assets
@@ -6,4 +5,3 @@ class DropAsset < ActiveRecord::Migration[5.1]
     drop_table :connections
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20171009142032_add_modules_to_lecture.rb
+++ b/db/migrate/20171009142032_add_modules_to_lecture.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddModulesToLecture < ActiveRecord::Migration[5.1]
   def change
     add_column :lectures, :kaviar, :boolean
@@ -8,4 +7,3 @@ class AddModulesToLecture < ActiveRecord::Migration[5.1]
     add_column :lectures, :erdbeere, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20171011171726_remove_confirmablefrom_devise.rb
+++ b/db/migrate/20171011171726_remove_confirmablefrom_devise.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class RemoveConfirmablefromDevise < ActiveRecord::Migration[5.1]
   def change
     remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20171016171419_add_kiwi_to_lecture.rb
+++ b/db/migrate/20171016171419_add_kiwi_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddKiwiToLecture < ActiveRecord::Migration[5.1]
   def change
     add_column :lectures, :kiwi, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20171021135749_add_extras_to_medium.rb
+++ b/db/migrate/20171021135749_add_extras_to_medium.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class AddExtrasToMedium < ActiveRecord::Migration[5.1]
   def change
     add_column :media, :extras_link, :text
     add_column :media, :extras_description, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180524065013_add_consents_to_user.rb
+++ b/db/migrate/20180524065013_add_consents_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddConsentsToUser < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :consents, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180524103749_remove_trackable_from_user.rb
+++ b/db/migrate/20180524103749_remove_trackable_from_user.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemoveTrackableFromUser < ActiveRecord::Migration[5.1]
   def change
     remove_column :users, :sign_in_count, :integer
@@ -8,4 +7,3 @@ class RemoveTrackableFromUser < ActiveRecord::Migration[5.1]
     remove_column :users, :last_sign_in_ip, :string
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180806092317_add_fields_to_course_user_join.rb
+++ b/db/migrate/20180806092317_add_fields_to_course_user_join.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddFieldsToCourseUserJoin < ActiveRecord::Migration[5.2]
   def change
     add_column :course_user_joins, :sesam, :boolean
@@ -8,4 +7,3 @@ class AddFieldsToCourseUserJoin < ActiveRecord::Migration[5.2]
     add_column :course_user_joins, :reste, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180806100940_add_news_to_course_user_join.rb
+++ b/db/migrate/20180806100940_add_news_to_course_user_join.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddNewsToCourseUserJoin < ActiveRecord::Migration[5.2]
   def change
     add_column :course_user_joins, :news, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180806124930_add_edited_profile_to_user.rb
+++ b/db/migrate/20180806124930_add_edited_profile_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddEditedProfileToUser < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :edited_profile, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180808092444_remove_properties_from_lecture.rb
+++ b/db/migrate/20180808092444_remove_properties_from_lecture.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemovePropertiesFromLecture < ActiveRecord::Migration[5.2]
   def change
     remove_column :lectures, :kaviar, :boolean
@@ -9,4 +8,3 @@ class RemovePropertiesFromLecture < ActiveRecord::Migration[5.2]
     remove_column :lectures, :kiwi, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180816125615_add_teacher_to_user.rb
+++ b/db/migrate/20180816125615_add_teacher_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddTeacherToUser < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :teacher, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180819151835_create_editable_user_join_table.rb
+++ b/db/migrate/20180819151835_create_editable_user_join_table.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateEditableUserJoinTable < ActiveRecord::Migration[5.2]
   def change
     create_table :editable_user_joins do |t|
@@ -12,4 +11,3 @@ class CreateEditableUserJoinTable < ActiveRecord::Migration[5.2]
               name: "polymorphic_editable_idx"
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180820123437_add_editor_and_name_to_user.rb
+++ b/db/migrate/20180820123437_add_editor_and_name_to_user.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class AddEditorAndNameToUser < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :editor, :boolean
     add_column :users, :name, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180820152008_remove_teacher_and_teacher_id_from_user.rb
+++ b/db/migrate/20180820152008_remove_teacher_and_teacher_id_from_user.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class RemoveTeacherAndTeacherIdFromUser < ActiveRecord::Migration[5.2]
   def change
     remove_column :users, :teacher, :boolean
     remove_column :users, :teacher_id, :integer
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180821132727_remove_teacher_fragments.rb
+++ b/db/migrate/20180821132727_remove_teacher_fragments.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class RemoveTeacherFragments < ActiveRecord::Migration[5.2]
   def change
     remove_column :lectures, :teacher_id
     remove_reference :users, :teacher, foreign_key: true, index: true
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180830085749_add_absolute_numbering_to_lecture.rb
+++ b/db/migrate/20180830085749_add_absolute_numbering_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddAbsoluteNumberingToLecture < ActiveRecord::Migration[5.2]
   def change
     add_column :lectures, :absolute_numbering, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180830121324_remove_numbers_from_section.rb
+++ b/db/migrate/20180830121324_remove_numbers_from_section.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class RemoveNumbersFromSection < ActiveRecord::Migration[5.2]
   def change
     remove_column :sections, :number, :integer
     remove_column :sections, :number_alt, :string
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180905085400_add_shrine_columns_to_media.rb
+++ b/db/migrate/20180905085400_add_shrine_columns_to_media.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddShrineColumnsToMedia < ActiveRecord::Migration[5.2]
   def change
     add_column :media, :video_data, :text
@@ -6,4 +5,3 @@ class AddShrineColumnsToMedia < ActiveRecord::Migration[5.2]
     add_column :media, :manuscript_data, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180906122130_remove_a_lot_of_columns_from_medium.rb
+++ b/db/migrate/20180906122130_remove_a_lot_of_columns_from_medium.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemoveALotOfColumnsFromMedium < ActiveRecord::Migration[5.2]
   def change
     remove_column :media, :width, :integer
@@ -13,4 +12,3 @@ class RemoveALotOfColumnsFromMedium < ActiveRecord::Migration[5.2]
     remove_column :media, :video_player, :string
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180908101213_remove_questions_from_medium.rb
+++ b/db/migrate/20180908101213_remove_questions_from_medium.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class RemoveQuestionsFromMedium < ActiveRecord::Migration[5.2]
   def change
     remove_column :media, :question_id, :integer
     remove_column :media, :question_list, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180909152728_create_referrals.rb
+++ b/db/migrate/20180909152728_create_referrals.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateReferrals < ActiveRecord::Migration[5.2]
   def change
     create_table :referrals do |t|
@@ -14,4 +13,3 @@ class CreateReferrals < ActiveRecord::Migration[5.2]
     end
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180913104612_add_link_to_referral.rb
+++ b/db/migrate/20180913104612_add_link_to_referral.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddLinkToReferral < ActiveRecord::Migration[5.2]
   def change
     add_column :referrals, :link, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20180913110737_add_medium_link_to_referral.rb
+++ b/db/migrate/20180913110737_add_medium_link_to_referral.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddMediumLinkToReferral < ActiveRecord::Migration[5.2]
   def change
     add_column :referrals, :medium_link, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20181015141212_remove_booleans_from_referral.rb
+++ b/db/migrate/20181015141212_remove_booleans_from_referral.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemoveBooleansFromReferral < ActiveRecord::Migration[5.2]
   def change
     remove_column :referrals, :video, :boolean
@@ -6,4 +5,3 @@ class RemoveBooleansFromReferral < ActiveRecord::Migration[5.2]
     remove_column :referrals, :medium_link, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20181210173053_remove_activity_notification.rb
+++ b/db/migrate/20181210173053_remove_activity_notification.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class RemoveActivityNotification < ActiveRecord::Migration[5.2]
   def change
     drop_table :notifications
     drop_table :subscriptions
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190106121300_add_no_notifications_to_user.rb
+++ b/db/migrate/20190106121300_add_no_notifications_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddNoNotificationsToUser < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :no_notifications, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190126161457_create_thredded.thredded.rb
+++ b/db/migrate/20190126161457_create_thredded.thredded.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Rails/
-
 # This migration comes from thredded (originally 20160329231848)
 
 require "thredded/base_migration"
@@ -282,5 +280,3 @@ class CreateThredded < Thredded::BaseMigration
                     :thredded_posts, column: :post_id, on_delete: :cascade
   end
 end
-
-# rubocop:enable Rails/

--- a/db/migrate/20190203110121_remove_extras_from_course_user_join.rb
+++ b/db/migrate/20190203110121_remove_extras_from_course_user_join.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemoveExtrasFromCourseUserJoin < ActiveRecord::Migration[5.2]
   def change
     remove_column :course_user_joins, :sesam?, :boolean
@@ -8,4 +7,3 @@ class RemoveExtrasFromCourseUserJoin < ActiveRecord::Migration[5.2]
     remove_column :course_user_joins, :nuesse?, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190204161127_add_organizational_to_lecture.rb
+++ b/db/migrate/20190204161127_add_organizational_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddOrganizationalToLecture < ActiveRecord::Migration[5.2]
   def change
     add_column :lectures, :organizational, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190207092000_add_muesli_to_lecture.rb
+++ b/db/migrate/20190207092000_add_muesli_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddMuesliToLecture < ActiveRecord::Migration[5.2]
   def change
     add_column :lectures, :muesli, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190225103346_add_quarantine_to_item.rb
+++ b/db/migrate/20190225103346_add_quarantine_to_item.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddQuarantineToItem < ActiveRecord::Migration[5.2]
   def change
     add_column :items, :quarantine, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190226102954_add_start_and_end_destination_to_lesson.rb
+++ b/db/migrate/20190226102954_add_start_and_end_destination_to_lesson.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class AddStartAndEndDestinationToLesson < ActiveRecord::Migration[5.2]
   def change
     add_column :lessons, :start_destination, :text
     add_column :lessons, :end_destination, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190227130143_add_hidden_to_chapter.rb
+++ b/db/migrate/20190227130143_add_hidden_to_chapter.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddHiddenToChapter < ActiveRecord::Migration[5.2]
   def change
     add_column :chapters, :hidden, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190227142829_add_hidden_to_section.rb
+++ b/db/migrate/20190227142829_add_hidden_to_section.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddHiddenToSection < ActiveRecord::Migration[5.2]
   def change
     add_column :sections, :hidden, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190227173517_add_hidden_to_item.rb
+++ b/db/migrate/20190227173517_add_hidden_to_item.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddHiddenToItem < ActiveRecord::Migration[5.2]
   def change
     add_column :items, :hidden, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190301121741_add_imported_manuscript_to_medium.rb
+++ b/db/migrate/20190301121741_add_imported_manuscript_to_medium.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddImportedManuscriptToMedium < ActiveRecord::Migration[5.2]
   def change
     add_column :media, :imported_manuscript, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190323142434_create_answers.rb
+++ b/db/migrate/20190323142434_create_answers.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateAnswers < ActiveRecord::Migration[5.2]
   def change
     create_table :answers do |t|
@@ -10,4 +9,3 @@ class CreateAnswers < ActiveRecord::Migration[5.2]
     end
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190401132839_add_quizzable_data_and_type_to_medium.rb
+++ b/db/migrate/20190401132839_add_quizzable_data_and_type_to_medium.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddQuizzableDataAndTypeToMedium < ActiveRecord::Migration[5.2]
   def change
     add_column :media, :hint, :text
@@ -8,4 +7,3 @@ class AddQuizzableDataAndTypeToMedium < ActiveRecord::Migration[5.2]
     add_column :media, :type, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190404132603_add_independent_to_medium.rb
+++ b/db/migrate/20190404132603_add_independent_to_medium.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddIndependentToMedium < ActiveRecord::Migration[5.2]
   def change
     add_column :media, :independent, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190405110252_add_organizational_data_to_course.rb
+++ b/db/migrate/20190405110252_add_organizational_data_to_course.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class AddOrganizationalDataToCourse < ActiveRecord::Migration[5.2]
   def change
     add_column :courses, :organizational, :boolean
     add_column :courses, :organizational_concept, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190501135815_remove_colums_from_medium.rb
+++ b/db/migrate/20190501135815_remove_colums_from_medium.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemoveColumsFromMedium < ActiveRecord::Migration[6.0]
   def change
     remove_column :media, :video_file_link, :text
@@ -14,4 +13,3 @@ class RemoveColumsFromMedium < ActiveRecord::Migration[6.0]
     remove_column :media, :extras_description, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190508131506_add_columns_to_notion.rb
+++ b/db/migrate/20190508131506_add_columns_to_notion.rb
@@ -1,8 +1,6 @@
-# rubocop:disable Rails/
 class AddColumnsToNotion < ActiveRecord::Migration[6.0]
   def change
     add_column :notions, :title, :text
     add_column :notions, :locale, :text
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190518161033_add_email_notifications_to_user.rb
+++ b/db/migrate/20190518161033_add_email_notifications_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddEmailNotificationsToUser < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :email_notifications, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190522110318_add_mail_properties_to_user.rb
+++ b/db/migrate/20190522110318_add_mail_properties_to_user.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddMailPropertiesToUser < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :email_for_medium, :boolean
@@ -7,4 +6,3 @@ class AddMailPropertiesToUser < ActiveRecord::Migration[6.0]
     add_column :users, :email_for_news, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20190808083830_add_open_to_clicker.rb
+++ b/db/migrate/20190808083830_add_open_to_clicker.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddOpenToClicker < ActiveRecord::Migration[6.0]
   def change
     add_column :clickers, :open, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200412104751_acts_as_votable_migration.rb
+++ b/db/migrate/20200412104751_acts_as_votable_migration.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class ActsAsVotableMigration < ActiveRecord::Migration[6.0]
   def self.up
     create_table :votes do |t|
@@ -20,4 +19,3 @@ class ActsAsVotableMigration < ActiveRecord::Migration[6.0]
     drop_table :votes
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200414170119_add_unread_comments_to_user.rb
+++ b/db/migrate/20200414170119_add_unread_comments_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddUnreadCommentsToUser < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :unread_comments, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200510104347_create_item_self_join.rb
+++ b/db/migrate/20200510104347_create_item_self_join.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateItemSelfJoin < ActiveRecord::Migration[6.0]
   def change
     create_table :item_self_joins do |t|
@@ -7,4 +6,3 @@ class CreateItemSelfJoin < ActiveRecord::Migration[6.0]
     end
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200531141619_add_comments_disabled_to_lecture.rb
+++ b/db/migrate/20200531141619_add_comments_disabled_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddCommentsDisabledToLecture < ActiveRecord::Migration[6.0]
   def change
     add_column :lectures, :comments_disabled, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200606133607_add_active_to_term.rb
+++ b/db/migrate/20200606133607_add_active_to_term.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddActiveToTerm < ActiveRecord::Migration[6.0]
   def change
     add_column :terms, :active, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200611130229_add_study_participant_to_user.rb
+++ b/db/migrate/20200611130229_add_study_participant_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddStudyParticipantToUser < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :study_participant, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200613090342_add_text_input_to_medium.rb
+++ b/db/migrate/20200613090342_add_text_input_to_medium.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddTextInputToMedium < ActiveRecord::Migration[6.0]
   def change
     add_column :media, :text_input, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200809123000_add_new_design_to_user.rb
+++ b/db/migrate/20200809123000_add_new_design_to_user.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddNewDesignToUser < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :new_design, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200810162008_add_term_independent_to_course.rb
+++ b/db/migrate/20200810162008_add_term_independent_to_course.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddTermIndependentToCourse < ActiveRecord::Migration[6.0]
   def change
     add_column :courses, :term_independent, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200903152249_add_organizational_on_top_to_lecture.rb
+++ b/db/migrate/20200903152249_add_organizational_on_top_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddOrganizationalOnTopToLecture < ActiveRecord::Migration[6.0]
   def change
     add_column :lectures, :organizational_on_top, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200907113337_add_disable_teacher_display_to_lecture.rb
+++ b/db/migrate/20200907113337_add_disable_teacher_display_to_lecture.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddDisableTeacherDisplayToLecture < ActiveRecord::Migration[6.0]
   def change
     add_column :lectures, :disable_teacher_display, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20200927111435_add_submission_email_flags_to_user.rb
+++ b/db/migrate/20200927111435_add_submission_email_flags_to_user.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddSubmissionEmailFlagsToUser < ActiveRecord::Migration[6.0]
   def up
     add_column :users, :email_for_submission_upload, :boolean
@@ -14,4 +13,3 @@ class AddSubmissionEmailFlagsToUser < ActiveRecord::Migration[6.0]
     remove_column :users, :email_for_submission_leave, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201002095520_set_submission_primary_key_to_uuid.rb
+++ b/db/migrate/20201002095520_set_submission_primary_key_to_uuid.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class SetSubmissionPrimaryKeyToUuid < ActiveRecord::Migration[6.0]
   def up
     rename_column :submissions, :id, :integer_id
@@ -11,4 +10,3 @@ class SetSubmissionPrimaryKeyToUuid < ActiveRecord::Migration[6.0]
     raise ActiveRecord::IrreversibleMigration
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201004141237_add_correction_email_to_user.rb
+++ b/db/migrate/20201004141237_add_correction_email_to_user.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddCorrectionEmailToUser < ActiveRecord::Migration[6.0]
   def up
     add_column :users, :email_for_correction_upload, :boolean
@@ -8,4 +7,3 @@ class AddCorrectionEmailToUser < ActiveRecord::Migration[6.0]
     remove_column :users, :email_for_correction_upload, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201008135825_add_accepted_to_submission.rb
+++ b/db/migrate/20201008135825_add_accepted_to_submission.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddAcceptedToSubmission < ActiveRecord::Migration[6.0]
   def up
     add_column :submissions, :accepted, :boolean
@@ -8,4 +7,3 @@ class AddAcceptedToSubmission < ActiveRecord::Migration[6.0]
     remove_column :submissions, :accepted, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201009154917_add_email_for_submission_decisions_to_user.rb
+++ b/db/migrate/20201009154917_add_email_for_submission_decisions_to_user.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddEmailForSubmissionDecisionsToUser < ActiveRecord::Migration[6.0]
   def up
     add_column :users, :email_for_submission_decision, :boolean
@@ -8,4 +7,3 @@ class AddEmailForSubmissionDecisionsToUser < ActiveRecord::Migration[6.0]
     remove_column :users, :email_for_submission_decision, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201015154231_add_archived_to_user.rb
+++ b/db/migrate/20201015154231_add_archived_to_user.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddArchivedToUser < ActiveRecord::Migration[6.0]
   def up
     add_column :users, :archived, :boolean
@@ -8,4 +7,3 @@ class AddArchivedToUser < ActiveRecord::Migration[6.0]
     remove_column :users, :archived, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201026151550_remove_redundant_columns_for_v13.rb
+++ b/db/migrate/20201026151550_remove_redundant_columns_for_v13.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class RemoveRedundantColumnsForV13 < ActiveRecord::Migration[6.0]
   def up
     remove_column :users, :edited_profile, :boolean
@@ -10,4 +9,3 @@ class RemoveRedundantColumnsForV13 < ActiveRecord::Migration[6.0]
     add_column :tutorial, :tutor_id, :integer
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20201121151659_add_on_main_page_to_announcement.rb
+++ b/db/migrate/20201121151659_add_on_main_page_to_announcement.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddOnMainPageToAnnouncement < ActiveRecord::Migration[6.0]
   def up
     add_column :announcements, :on_main_page, :boolean, default: false
@@ -8,4 +7,3 @@ class AddOnMainPageToAnnouncement < ActiveRecord::Migration[6.0]
     remove_column :announcements, :on_main_page, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20210319102604_add_submission_deletion_columns_to_term.rb
+++ b/db/migrate/20210319102604_add_submission_deletion_columns_to_term.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddSubmissionDeletionColumnsToTerm < ActiveRecord::Migration[6.0]
   def up
     add_column :terms, :submission_deletion_mail, :datetime
@@ -12,4 +11,3 @@ class AddSubmissionDeletionColumnsToTerm < ActiveRecord::Migration[6.0]
     remove_column :terms, :submissions_deleted_at, :datetime
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20210710152036_add_title_and_position_to_talk.rb
+++ b/db/migrate/20210710152036_add_title_and_position_to_talk.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddTitleAndPositionToTalk < ActiveRecord::Migration[6.1]
   def up
     add_column :talks, :title, :text
@@ -10,4 +9,3 @@ class AddTitleAndPositionToTalk < ActiveRecord::Migration[6.1]
     remove_column :talks, :position, :integer
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20210827141317_create_watchlist_entries.rb
+++ b/db/migrate/20210827141317_create_watchlist_entries.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class CreateWatchlistEntries < ActiveRecord::Migration[6.1]
   def up
     create_table :watchlists
@@ -24,4 +23,3 @@ class CreateWatchlistEntries < ActiveRecord::Migration[6.1]
     drop_table :watchlist_entries
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20210909153352_add_display_description_to_talk.rb
+++ b/db/migrate/20210909153352_add_display_description_to_talk.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddDisplayDescriptionToTalk < ActiveRecord::Migration[6.1]
   def up
     add_column :talks, :display_description, :boolean, default: false
@@ -8,4 +7,3 @@ class AddDisplayDescriptionToTalk < ActiveRecord::Migration[6.1]
     remove_column :talks, :display_description, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20210923085744_add_protected_to_assignment.rb
+++ b/db/migrate/20210923085744_add_protected_to_assignment.rb
@@ -1,7 +1,5 @@
-# rubocop:disable Rails/
 class AddProtectedToAssignment < ActiveRecord::Migration[6.1]
   def change
     add_column :assignments, :protected, :boolean, default: false
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20210923113111_add_public_to_watchlists.rb
+++ b/db/migrate/20210923113111_add_public_to_watchlists.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddPublicToWatchlists < ActiveRecord::Migration[6.1]
   def up
     add_column :watchlists, :public, :boolean, default: false
@@ -8,4 +7,3 @@ class AddPublicToWatchlists < ActiveRecord::Migration[6.1]
     remove_column :watchlists, :public, :boolean
   end
 end
-# rubocop:enable Rails/

--- a/db/migrate/20231101100015_add_devise_trackable_columns_to_users.rb
+++ b/db/migrate/20231101100015_add_devise_trackable_columns_to_users.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/
 class AddDeviseTrackableColumnsToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :sign_in_count, :integer, default: 0, null: false
@@ -8,4 +7,3 @@ class AddDeviseTrackableColumnsToUsers < ActiveRecord::Migration[7.0]
     add_column :users, :last_sign_in_ip, :string
   end
 end
-# rubocop:enable Rails/


### PR DESCRIPTION
In #566, I added `# rubocop:disable Rails/` statements to migrations since RuboCop was complaining. Now, with an update of RuboCop in #742, it complains that these statements are unnecessary, so I remove them in this PR.