### PR TITLE
Fix lecture creation

### DIFF
--- a/app/views/courses/_basics.html.erb
+++ b/app/views/courses/_basics.html.erb
@@ -92,7 +92,8 @@
                     class: 'fas fa-plus-circle text-dark',
                     id: 'new-lecture-button',
                     data: { remote: true,
-                            toggle: 'tooltip' },
+                            toggle: 'tooltip',
+                            cy: 'new-lecture-button-admin-index' },
                     title: t('buttons.create_lecture') %>
       <% end %>
     </div>

--- a/app/views/lectures/_new.html.erb
+++ b/app/views/lectures/_new.html.erb
@@ -67,7 +67,7 @@
                      { class: 'form-select'} %>
       </div>
     </div>
-    <div class="row">
+    <div class="row mt-4">
       <div class="col-12 text-center">
         <%= f.submit t('buttons.save'),
               class: 'btn btn-primary',

--- a/app/views/lectures/create.coffee
+++ b/app/views/lectures/create.coffee
@@ -3,6 +3,8 @@ $('#lecture_course_id').removeClass('is-invalid')
 $('#new-lecture-course-error').empty()
 $('#lecture_term_id').removeClass('is-invalid')
 $('#new-lecture-term-error').empty()
+$('#lecture_teacher_id').removeClass('is-invalid')
+$('#lecture-teacher-error').empty()
 
 # display error message
 <% if @errors.present? %>
@@ -15,5 +17,9 @@ $('#lecture_course_id').addClass('is-invalid')
 $('#new-lecture-term-error')
   .append('<%= @errors[:term].join(" ") %>').show()
 $('#lecture_term_id').addClass('is-invalid')
+<% end %>
+<% if @errors[:teacher].present? %>
+$('#lecture-teacher-error')
+  .append('<%= @errors[:teacher].join(" ") %>').show() 
 <% end %>
 <% end %>

--- a/app/views/lectures/new.coffee
+++ b/app/views/lectures/new.coffee
@@ -11,16 +11,6 @@ initBootstrapPopovers()
 # hide all other buttons on admin index page
 $('.admin-index-button').hide()
 
-# make sure that there will always be a teacher selected
-teacherSelector = document.getElementById('lecture_teacher_id')
-if teacherSelector?
-  sel = teacherSelector.tomselect
-  sel.on 'blur', ->
-    value = sel.getValue()
-    if value == ''
-      sel.setValue(teacherSelector.dataset.current)
-   return
-
 # show the modal if the new action was triggered from course edit page
 <% if @from == 'course' %>
 $('#newLectureModal').modal('show')

--- a/app/views/lectures/new.coffee
+++ b/app/views/lectures/new.coffee
@@ -13,12 +13,13 @@ $('.admin-index-button').hide()
 
 # make sure that there will always be a teacher selected
 teacherSelector = document.getElementById('lecture_teacher_id')
-sel = teacherSelector.tomselect
-sel.on 'blur', ->
-  value = sel.getValue()
-  if value == ''
-    sel.setValue(teacherSelector.dataset.current)
-  return
+if teacherSelector?
+  sel = teacherSelector.tomselect
+  sel.on 'blur', ->
+    value = sel.getValue()
+    if value == ''
+      sel.setValue(teacherSelector.dataset.current)
+   return
 
 # show the modal if the new action was triggered from course edit page
 <% if @from == 'course' %>

--- a/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
+++ b/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
@@ -21,11 +21,14 @@ describe("New lecture (as admin)", () => {
   });
 });
 
-describe.only("New lecture as course editor", () => {
+describe.only("New lecture (as course editor)", () => {
   beforeEach(function () {
     cy.createUserAndLogin("course_editor").as("user");
 
-    FactoryBot.create("course").as("course");
+    cy.then(() => {
+      FactoryBot.create("course", "with_editor_by_id", { editor_id: this.user.id }).as("course");
+    });
+
     cy.then(() => {
       FactoryBot.create("term").as("term");
     });

--- a/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
+++ b/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
@@ -1,47 +1,38 @@
 import FactoryBot from "../../support/factorybot";
 
-describe("New lecture (as admin)", () => {
-  beforeEach(function () {
-    cy.createUserAndLogin("admin").as("user");
+describe("New lecture", () => {
+  const roles = ["admin", "course_editor"];
 
-    FactoryBot.create("course").as("course");
-    cy.then(() => {
-      FactoryBot.create("term").as("term");
+  roles.forEach((role) => {
+    context(`as ${role}`, function () {
+      beforeEach(function () {
+        cy.createUserAndLogin(role).as("user");
+
+        cy.then(() => {
+          if (role === "admin") {
+            FactoryBot.create("course").as("course");
+          }
+          else {
+            FactoryBot.create("course", "with_editor_by_id", { editor_id: this.user.id })
+              .as("course");
+          }
+        });
+
+        cy.then(() => {
+          FactoryBot.create("term").as("term");
+        });
+      });
+
+      it("Creates new lecture (via index page)", function () {
+        cy.visit("/administration");
+        testCreateNewLecture(this, false);
+      });
+
+      it("Creates new lecture (via course edit page)", function () {
+        cy.visit(`/courses/${this.course.id}/edit`);
+        testCreateNewLecture(this, true);
+      });
     });
-  });
-
-  it("Creates new lecture (via index page", function () {
-    cy.visit("/administration");
-    testCreateNewLecture(this, false);
-  });
-
-  it("Creates new lecture (via course edit page)", function () {
-    cy.visit(`/courses/${this.course.id}/edit`);
-    testCreateNewLecture(this, true);
-  });
-});
-
-describe.only("New lecture (as course editor)", () => {
-  beforeEach(function () {
-    cy.createUserAndLogin("course_editor").as("user");
-
-    cy.then(() => {
-      FactoryBot.create("course", "with_editor_by_id", { editor_id: this.user.id }).as("course");
-    });
-
-    cy.then(() => {
-      FactoryBot.create("term").as("term");
-    });
-  });
-
-  it("Creates new lecture (via index page)", function () {
-    cy.visit("/administration");
-    testCreateNewLecture(this, false);
-  });
-
-  it("Creates new lecture (via course edit page)", function () {
-    cy.visit(`/courses/${this.course.id}/edit`);
-    testCreateNewLecture(this, true);
   });
 });
 

--- a/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
+++ b/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
@@ -1,6 +1,6 @@
 import FactoryBot from "../../support/factorybot";
 
-describe("New lecture (via admin index page)", () => {
+describe("New lecture", () => {
   beforeEach(function () {
     cy.createUserAndLogin("admin").as("admin");
 
@@ -10,20 +10,32 @@ describe("New lecture (via admin index page)", () => {
     });
   });
 
-  it("Creates new lecture", function () {
+  it("Creates new lecture (via index page", function () {
     cy.visit("/administration");
-    cy.getBySelector("new-lecture-button-admin-index").click();
+    testCreateNewLecture(this, false);
+  });
 
-    cy.getBySelector("new-lecture-course-select-div").then(($wrapperDiv) => {
-      cy.wrap($wrapperDiv).selectTom(this.course.title);
-    });
-    cy.getBySelector("new-lecture-submit").click();
-
-    const successMessage = this.admin.locale === "de" ? "erfolgreich" : "successfully";
-    cy.get("div.alert")
-      .should("contain", this.course.title)
-      .should("contain", this.term.season)
-      .should("contain", this.admin.name)
-      .should("contain", successMessage);
+  it("Creates new lecture (via course edit page)", function () {
+    cy.visit(`/courses/${this.course.id}/edit`);
+    testCreateNewLecture(this, true);
   });
 });
+
+function testCreateNewLecture(context, isCoursePrefilled) {
+  cy.getBySelector("new-lecture-button-admin-index").click();
+
+  if (!isCoursePrefilled) {
+    cy.getBySelector("new-lecture-course-select-div").then(($wrapperDiv) => {
+      cy.wrap($wrapperDiv).selectTom(context.course.title);
+    });
+  }
+
+  cy.getBySelector("new-lecture-submit").click();
+
+  const successMessage = context.admin.locale === "de" ? "erfolgreich" : "successfully";
+  cy.get("div.alert")
+    .should("contain", context.course.title)
+    .should("contain", context.term.season)
+    .should("contain", context.admin.name)
+    .should("contain", successMessage);
+}

--- a/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
+++ b/spec/cypress/e2e/lecture/new_lecture_specs.cy.js
@@ -1,8 +1,8 @@
 import FactoryBot from "../../support/factorybot";
 
-describe("New lecture", () => {
+describe("New lecture (as admin)", () => {
   beforeEach(function () {
-    cy.createUserAndLogin("admin").as("admin");
+    cy.createUserAndLogin("admin").as("user");
 
     FactoryBot.create("course").as("course");
     cy.then(() => {
@@ -11,6 +11,27 @@ describe("New lecture", () => {
   });
 
   it("Creates new lecture (via index page", function () {
+    cy.visit("/administration");
+    testCreateNewLecture(this, false);
+  });
+
+  it("Creates new lecture (via course edit page)", function () {
+    cy.visit(`/courses/${this.course.id}/edit`);
+    testCreateNewLecture(this, true);
+  });
+});
+
+describe.only("New lecture as course editor", () => {
+  beforeEach(function () {
+    cy.createUserAndLogin("course_editor").as("user");
+
+    FactoryBot.create("course").as("course");
+    cy.then(() => {
+      FactoryBot.create("term").as("term");
+    });
+  });
+
+  it("Creates new lecture (via index page)", function () {
     cy.visit("/administration");
     testCreateNewLecture(this, false);
   });
@@ -32,10 +53,10 @@ function testCreateNewLecture(context, isCoursePrefilled) {
 
   cy.getBySelector("new-lecture-submit").click();
 
-  const successMessage = context.admin.locale === "de" ? "erfolgreich" : "successfully";
+  const successMessage = context.user.locale === "de" ? "erfolgreich" : "successfully";
   cy.get("div.alert")
     .should("contain", context.course.title)
     .should("contain", context.term.season)
-    .should("contain", context.admin.name)
+    .should("contain", context.user.name)
     .should("contain", successMessage);
 }

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -114,9 +114,6 @@ beforeEach(() => {
 });
 
 Cypress.Commands.add("createUser", (role) => {
-  if (!["admin", "editor", "teacher", "generic", "tutor"].includes(role)) {
-    throw new Error(`Invalid role: ${role}`);
-  }
   return BackendCaller.callCypressRoute("user_creator", "cy.createUser()", { role: role });
 });
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -60,5 +60,15 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_editor_by_id do
+      transient do
+        editor_id { nil }
+      end
+
+      after(:build) do |course, evaluator|
+        course.editors << User.find(evaluator.editor_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes #739. Turns out it was just a conditional that was forgotten in the restructuring of access rights in #671: Since there does no longer appear a form where you can select the teacher (unless you are admin), the javascript produced by `lectures/new.coffee` crashes. This has no consequence on `/administration` (where the exception also occurs), but on `courses/:id/edit` this prevents the modal from popping up.

I guess, some cypress tests should still be written for that.

UPDATE: After I had introduced the missing conditional in [this commit](https://github.com/MaMpf-HD/mampf/pull/752/commits/4f109ab510d61db5b436e369bcbff5d7b47929be) I decided it might be better just to let the backend do the job, so i just removed the corresponding js.