### PR TITLE
Remove/Update year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2024 Denis Vogel & Contributors
+Copyright (c) 2017-2025 Denis Vogel & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -78,7 +78,7 @@ de:
       Deiner Profilseite Zugriff erhalten.
   footer:
     text_html: >
-      &copy; MaMpf Team 2024. MaMpf ist auf %{github}.
+      &copy; MaMpf Team. MaMpf ist auf %{github}.
       Powered by %{rails}, %{bootstrap}, %{cytoscape},
       %{nerdamer}, %{katex}, %{thredded}, %{docker}, %{basecamp}.
       Bugs meldest Du am besten %{bugs}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
       You may get access by modifying your account settings.
   footer:
     text_html: >
-      &copy; MaMpf Team 2024. MaMpf is on %{github}.
+      &copy; MaMpf Team. MaMpf is on %{github}.
       Powered by %{rails}, %{bootstrap}, %{cytoscape},
       %{nerdamer}, %{katex}, %{thredded}, %{docker}, %{basecamp}.
       Bugs can be reported %{bugs}.


### PR DESCRIPTION
Fixes #745.

- I've updated the year in our License file.
- For the user-facing year in the MaMpf footer, I don't really see the benefit of having the year included over there. That's why I've removed it such that we don't have to update it there anymore ;)

For this PR, I won't run the tests through since it's just some strings that changed in a trivial way.