### PR TITLE
Fix undefined method `lecture` for redemption

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,8 @@ class Notification < ApplicationRecord
   def teachable
     return if notifiable.blank?
     return if lecture_or_course?
-    return notifiable.lecture if announcement_or_redemption?
+    return notifiable.lecture if announcement?
+    return notifiable.voucher.lecture if redemption?
 
     # notifiable will be a medium, so return its teachable
     notifiable.teachable
@@ -81,9 +82,5 @@ class Notification < ApplicationRecord
 
     def lecture_or_course?
       notifiable_type.in?(["Lecture", "Course"])
-    end
-
-    def announcement_or_redemption?
-      notifiable_type.in?(["Announcement", "Redemption"])
     end
 end


### PR DESCRIPTION
This bug appears in production and can be reproduced locally as follows:

- Log in as teacher and create a voucher, e.g. for tutorials in Linear Algebra.
- Log in as student3 and redeem the voucher.
- Log in as teacher and try to update anything on your profile page, e.g. the language.

After this fix, this should not yield any error anymore. Please make sure you can reproduce the error beforehand to make sure that this is really a fix.