### PR TITLE
Fix editing of comments that have an annotation timestamp

### DIFF
--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -7,6 +7,8 @@ module Commontator
     before_action :commontator_set_thread_variables,
                   only: [:show, :update, :delete, :undelete]
 
+    helper MediaHelper
+
     # GET /comments/1
     def show
       respond_to do |format|

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -151,7 +151,8 @@ module MediaHelper
   end
 
   def video_link_timed(medium, timestamp)
-    play_medium_path(medium, params: { time: timestamp.total_seconds })
+    Rails.application.routes.url_helpers
+         .play_medium_path(medium, params: { time: timestamp.total_seconds })
   end
 
   def feedback_video_link_timed(medium, timestamp)

--- a/app/views/commontator/comments/_body.html.erb
+++ b/app/views/commontator/comments/_body.html.erb
@@ -1,8 +1,3 @@
-<%#
-  Views that use this partial must provide the following variable:
-  comment
-%>
-
 <%= commontator_simple_format comment.body %>
 
 <!--- Show timestamps in comments that have a linked annotation --->


### PR DESCRIPTION
Comments, which resulted from creating a new annotation on a video and posting it as comment, were not editable anymore

```
NoMethodError (undefined method `video_link_timed' for an instance of #<Class:...>)
```

The reason is the call to `video_linked_timed` in `app/views/commontator/comments/_body.html.erb`. When this is rendered usually, it works fine, but not when rendered via the `app/views/commontator/comments/update.js.erb` file where the `CommentsController` is responsible. And the latter didn't include the `MediaHelper` yet.