### PR TITLE
Remove remnants of food routes cleanup

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -160,7 +160,7 @@ class Medium < ApplicationRecord
     end
   end
 
-  # these are all the sorts of food(=projects) we currently serve
+  # these are all the sorts of projects we currently serve
   def self.sort_enum
     ["LessonMaterial", "WorkedExample", "Quiz", "Repetition", "Erdbeere",
      "Exercise", "Script", "Question", "Remark", "Miscellaneous", "RandomQuiz"]

--- a/app/views/layouts/vignettes_navbar.html.erb
+++ b/app/views/layouts/vignettes_navbar.html.erb
@@ -39,10 +39,10 @@
             </a>
 
             <!-- Information -->
-            <% project_name = 'reste' %>
+            <% project_name = 'miscellaneous' %>
             <% active_class = get_class_for_project(project_name) %>
-            <% is_disabled = !lecture || !lecture.reste?(current_user) %>
-            <a href="<%= lecture_food_path(lecture, params: { project: project_name }) %>" 
+            <% is_disabled = !lecture || !lecture.miscellaneous?(current_user) %>
+            <a href="<%= lecture_material_path(lecture, params: { project: project_name }) %>" 
                aria-current="<%= active_class.present? ? 'page' : '' %>"
                class="nav-link <%= active_class.present? ? 'active' : '' %>
                       <%= is_disabled ? 'disabled' : '' %>"


### PR DESCRIPTION
- We forgot to replace the food routes (see #754) in the Vignettes-related code.
- @fosterfarrell9 post-cleanup of food routes, e.g. in comments etc.