### PR TITLE
Reflect branch rename (dev->next) in GitHub Workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
-      - dev
+      - next
       - experimental
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
+      - next
 
 jobs:
   # For the setup idea using Docker Buildx, see StackOverflow answer [1].


### PR DESCRIPTION
This is just a simple fix to our pipeline since the workflow wasn't triggered anymore on the `next` branch after its renaming from `dev` to `next`.

Also tries to fix #489 via [this solution](https://github.com/orgs/community/discussions/26276#discussioncomment-3251140).