### PR TITLE
Fix nested forms for quizzes

### DIFF
--- a/app/assets/javascripts/questions.coffee
+++ b/app/assets/javascripts/questions.coffee
@@ -11,7 +11,7 @@ class MampfExpression
     @nerd.expand().eq(otherExpression.nerd.expand())
 
   @parse: (content) ->
-    expression = content['question[solution_content[0]]']
+    expression = content['question[solution_content][dynamic][0][content]']
     new MampfExpression(expression)
 
 class MampfMatrix
@@ -34,13 +34,13 @@ class MampfMatrix
     result
 
   @parse: (content) ->
-    rowCount = parseInt(content['question[solution_content[row_count]]'])
-    columnCount = parseInt(content['question[solution_content[column_count]]'])
+    rowCount = parseInt(content['question[solution_content][row_count]'])
+    columnCount = parseInt(content['question[solution_content][column_count]'])
     matrix = ''
     for i in [1..rowCount]
       column = '['
       for j in [1..columnCount]
-        column += content['question[solution_content[' + i + ',' + j + ']]']
+        column += content['question[solution_content][dynamic][' + i + ',' + j + '][content]']
         column += ',' unless j == columnCount
       column += ']'
       matrix += column
@@ -65,7 +65,7 @@ class MampfTuple
     result
 
   @parse: (content) ->
-    coeffs = content['question[solution_content[0]]']
+    coeffs = content['question[solution_content][dynamic][0][content]']
     expression = 'vector(' + coeffs + ')'
     new MampfTuple(expression)
 
@@ -92,7 +92,7 @@ class MampfSet
     result
 
   @parse: (content) ->
-    elements = content['question[solution_content[0]]'].split(',')
+    elements = content['question[solution_content][dynamic][0][content]'].split(',')
     size = elements.length
     nerds = []
     set = []
@@ -164,8 +164,8 @@ cleanSolutionBox = ->
   try
     solutionInput = extractSolution()
   catch err
-    solutionInput = 'Syntax Error'
-  if solutionInput == 'Syntax Error'
+    solutionInput = 'Syntax Error1'
+  if solutionInput == 'Syntax Error1'
     $('#solution_input_tex').val('')
     $('#solution_input_error').val(solutionInput)
     $('#solution_content_nerd').val('')
@@ -283,8 +283,9 @@ $(document).on 'turbolinks:load', ->
     try
       inputSolution = extractSolution()
     catch err
-      inputSolution = 'Syntax Error'
-    if inputSolution == 'Syntax Error'
+      console.log("Error while extracting solution: #{err}")
+      inputSolution = 'Syntax Error2'
+    if inputSolution == 'Syntax Error2'
       $('#solution-tex').empty().append(inputSolution)
       $('#solution_input_tex').val('')
       $('#solution_input_error').val(inputSolution)

--- a/app/assets/javascripts/questions.coffee
+++ b/app/assets/javascripts/questions.coffee
@@ -164,8 +164,8 @@ cleanSolutionBox = ->
   try
     solutionInput = extractSolution()
   catch err
-    solutionInput = 'Syntax Error1'
-  if solutionInput == 'Syntax Error1'
+    solutionInput = 'Syntax Error'
+  if solutionInput == 'Syntax Error'
     $('#solution_input_tex').val('')
     $('#solution_input_error').val(solutionInput)
     $('#solution_content_nerd').val('')
@@ -284,8 +284,8 @@ $(document).on 'turbolinks:load', ->
       inputSolution = extractSolution()
     catch err
       console.log("Error while extracting solution: #{err}")
-      inputSolution = 'Syntax Error2'
-    if inputSolution == 'Syntax Error2'
+      inputSolution = 'Syntax Error'
+    if inputSolution == 'Syntax Error'
       $('#solution-tex').empty().append(inputSolution)
       $('#solution_input_tex').val('')
       $('#solution_input_error').val(inputSolution)

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -104,7 +104,11 @@ class QuestionsController < ApplicationController
                      .permit(:label, :text, :type, :hint, :level,
                              :question_sort, :independent, :vertex_id,
                              :solution_type,
-                             solution_content: {})
+                             solution_content:
+                             [
+                               :row_count, :column_count, :tex, :nerd, :explanation,
+                               { dynamic: [[:content]] }
+                             ])
       if result[:solution_type] && result[:solution_content]
         result[:solution] = Solution.from_hash(result[:solution_type],
                                                result[:solution_content])

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,4 +1,3 @@
-# Quizzes controller
 class QuizzesController < ApplicationController
   skip_before_action :authenticate_user!, only: [:take, :proceed]
   before_action :set_quiz, except: [:new, :update_branching]

--- a/app/views/questions/_solution.html.erb
+++ b/app/views/questions/_solution.html.erb
@@ -88,21 +88,27 @@
       <%= render partial: 'questions/tex_solution',
                  locals: { solution: solution } %>
     </div>
-    <%= f.hidden_field 'solution_content[nerd]',
+
+    <%= f.fields_for :solution_content do |content_fields| %>
+
+    <%= content_fields.hidden_field :nerd,
                        value: solution.content.nerd,
                        id: 'solution_content_nerd' %>
     <div class="row">
       <div class="col-12">
-        <%= f.label 'solution_content[explanation]',
+        <%= content_fields.label :explanation,
                    t('admin.answer.explanation'),
                    class: "form-label" %>
-        <%= f.text_area 'solution_content[explanation]',
+        <%= content_fields.text_area :explanation,
                         class: 'form-control',
                         id: 'tex-area-explanation-s-' +
                               question.answers.first.id.to_s,
                         value: question.answers.first.explanation %>
       </div>
     </div>
+
+    <% end %>
+
     <div class="row">
       <div class="col-8 py-2">
         <span id="tex-preview-explanation-s-<%= question.answers.first.id %>">

--- a/app/views/questions/domains/_expression.html.erb
+++ b/app/views/questions/domains/_expression.html.erb
@@ -6,10 +6,15 @@
       </div>
     </div>
   <% end %>
-  <%= f.text_field "solution_content#{counter}",
+  <%= solution_content_fields.fields_for :dynamic, index: counter do |dynamic_fields| %>
+
+  <%= dynamic_fields.text_field :content,
                    value: value,
                    class: 'form-control',
                    data: { counter: 0 } %>
+
+  <% end %>
+
   <% if type.in?(['MampfTuple', 'MampfSet']) %>
     <div class="input-group-append">
       <div class="input-group-text">

--- a/app/views/questions/domains/_general_form.html.erb
+++ b/app/views/questions/domains/_general_form.html.erb
@@ -1,22 +1,27 @@
-<% if type.in?(['MampfExpression', 'MampfTuple', 'MampfSet']) %>
-  <%= render partial: 'questions/domains/expression',
-             locals: { f: f,
-                       value: content.value,
-                       counter: '[0]',
-                       type: type } %>
-<% elsif type == 'MampfMatrix' %>
-  <%= render partial: 'questions/domains/matrix',
-             locals: { f: f,
-                       content: content } %>
+<%= f.fields_for :solution_content do |solution_content_fields| %>
+  <% if type.in?(['MampfExpression', 'MampfTuple', 'MampfSet']) %>
+    <%= render partial: 'questions/domains/expression',
+              locals: { solution_content_fields: solution_content_fields,
+                        value: content.value,
+                        counter: "0",
+                        type: type } %>
+  <% elsif type == 'MampfMatrix' %>
+    <%= render partial: 'questions/domains/matrix',
+              locals: { solution_content_fields: solution_content_fields,
+                        content: content } %>
+  <% end %>
+  <%= solution_content_fields.hidden_field :tex,
+                    value: content.tex,
+                    id: 'solution_input_tex' %>
 <% end %>
-<%= f.hidden_field 'solution_content[tex]',
-                   value: content.tex,
-                   id: 'solution_input_tex' %>
+
 <%= f.hidden_field 'solution_error',
-                   value: nil,
-                   id: 'solution_input_error' %>
+                  value: nil,
+                  id: 'solution_input_error' %>
+
 <div class="invalid-feedback" id="solution-error">
 </div>
+
 <div class="row mt-2">
   <div class="col-12 text-center">
     <button type="button"

--- a/app/views/questions/domains/_matrix.html.erb
+++ b/app/views/questions/domains/_matrix.html.erb
@@ -6,12 +6,12 @@
   </span>
   <% (1..4).each do |i| %>
     <div class="form-check form-check-inline">
-      <%= f.radio_button 'solution_content[row_count]',
+      <%= solution_content_fields.radio_button :row_count,
                          i,
                          class: 'form-check-input rowCount',
                          checked: content.row_count == i,
                          data: { count: i } %>
-      <%= f.label 'solution_content[row_count]',
+      <%= solution_content_fields.label :row_count,
                   "#{i}",
                   value: i,
                   class: 'form-check-label' %>
@@ -26,18 +26,19 @@
   </span>
   <% (1..4).each do |i| %>
     <div class="form-check form-check-inline">
-      <%= f.radio_button 'solution_content[column_count]',
+      <%= solution_content_fields.radio_button :column_count,
                          i,
                          class: 'form-check-input columnCount',
                          checked: content.column_count == i,
                          data: { count: i } %>
-      <%= f.label 'solution_content[column_count]',
+      <%= solution_content_fields.label :column_count,
                   "#{i}",
                   value: i,
                   class: 'form-check-label' %>
     </div>
   <% end %>
 </div>
+
 <% (1..4).each do |i| %>
   <div class="row mb-2">
     <% (1..4).each do |j| %>
@@ -46,9 +47,9 @@
            data-row="<%= i %>"
            data-column="<%= j %>">
         <%= render partial: 'questions/domains/expression',
-                   locals: { f: f,
+                   locals: { solution_content_fields: solution_content_fields,
                              value: content.entry(i,j),
-                             counter: "[#{i},#{j}]",
+                             counter: "#{i},#{j}",
                              type: 'MampfExpression' } %>
       </div>
     <% end %>

--- a/app/views/quizzes/_free_question_open.html.erb
+++ b/app/views/quizzes/_free_question_open.html.erb
@@ -29,22 +29,19 @@
                  id: 'submit-solution',
                  style: 'display: none;'  %>
   </div>
-  <%= f.hidden_field 'quiz[progress]',
-                     value: quiz_round.progress %>
-  <%= f.hidden_field 'quiz[counter]',
-                     value: quiz_round.counter %>
-  <%= f.hidden_field 'quiz[answer_shuffle]',
-                     value: quiz_round.answer_shuffle.to_json %>
-  <%= f.hidden_field 'quiz[crosses]',
-                     multiple: true,
-                     data: { answer: answers.first.id },
-                     id: 'quiz_question_crosses' %>
-  <%= f.hidden_field 'quiz[solution_input]',
-                     id: 'question_quiz_solution_input' %>
-  <%= f.hidden_field 'quiz[result]',
-                     id: 'question_quiz_result' %>
-  <%= f.hidden_field 'quiz[session_id]',
-                     value: quiz_round.session_id %>
-  <%= f.hidden_field :id,
-                     value: quiz_round.quiz.id %>
+
+  <%= f.fields_for :quiz do |quiz_fields| %>
+    <%= quiz_fields.hidden_field :progress, value: quiz_round.progress %>
+    <%= quiz_fields.hidden_field :counter, value: quiz_round.counter %>
+    <%= quiz_fields.hidden_field :answer_shuffle, value: quiz_round.answer_shuffle.to_json %>
+    <%= quiz_fields.hidden_field :crosses,
+                      multiple: true,
+                      data: { answer: answers.first.id },
+                      id: 'quiz_question_crosses' %>
+    <%= quiz_fields.hidden_field :solution_input, id: 'question_quiz_solution_input' %>
+    <%= quiz_fields.hidden_field :result, id: 'question_quiz_result' %>
+    <%= quiz_fields.hidden_field :session_id, value: quiz_round.session_id %>
+  <% end %>
+
+  <%= f.hidden_field :id, value: quiz_round.quiz.id %>
 <% end %>


### PR DESCRIPTION
> [!important]
> Merge #790 beforehand.

This is a follow-up to #751 and fixes #788 by reworking the nested params for quizzes. Among others, for the solution content, we introduce a new intermediate layer called "dynamic", sued to render the fields of a matrix, of a tuple or an expression. It can look like this:

```
question[solution_content][column_count]: "2"
question[solution_content][dynamic][1,1][content]: "1"
question[solution_content][dynamic][1,2][content]: "2"
question[solution_content][dynamic][1,3][content]: "0"
question[solution_content][dynamic][1,4][content]: "0"
question[solution_content][dynamic][2,1][content]: "3"
question[solution_content][dynamic][2,2][content]: "4"
question[solution_content][dynamic][2,3][content]: "0"
question[solution_content][dynamic][2,4][content]: "0"
question[solution_content][dynamic][3,1][content]: "0"
question[solution_content][dynamic][3,2][content]: "0"
question[solution_content][dynamic][3,3][content]: "0"
question[solution_content][dynamic][3,4][content]: "0"
question[solution_content][dynamic][4,1][content]: "0"
question[solution_content][dynamic][4,2][content]: "0"
question[solution_content][dynamic][4,3][content]: "0"
question[solution_content][dynamic][4,4][content]: "0"
question[solution_content][explanation]: ""
question[solution_content][nerd]: ""
question[solution_content][row_count]: "2"
question[solution_content][tex]: ""
question[solution_error]: "Syntax Error"
question[solution_type]: "MampfMatrix"
```