### PR TITLE
Autocorrect or disable new RuboCop cops

### DIFF
--- a/.config/.rubocop.yml
+++ b/.config/.rubocop.yml
@@ -68,7 +68,6 @@ Performance:
 Performance/FlatMap:
   Severity: warning # an error in CI/CD
 
-
 #############################################
 # Rails
 #############################################
@@ -78,6 +77,25 @@ Rails/HasManyOrHasOneDependent:
 
 Rails/SkipsModelValidations:
   AllowedMethods: ["touch", "touch_all"]
+
+# TODO RuboCop
+Rails/InverseOf:
+  Enabled: false
+
+# TODO RuboCop
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+# TODO RuboCop
+Rails/UniqueValidationWithoutIndex:
+  Enabled: false
+
+#############################################
+# Naming
+#############################################
+
+Naming/PredicateMethod:
+  Enabled: false
 
 #############################################
 # Style

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
         "editor.formatOnSave": false // TODO: activate once HTML formatter installed
     },
     //////////////////////////////////////
-    // Ruby (Rubocop)
+    // Ruby (RuboCop)
     //////////////////////////////////////
     "[ruby]": {
         "editor.defaultFormatter": "Shopify.ruby-lsp",
@@ -103,6 +103,8 @@
     // Spell Checker
     //////////////////////////////////////
     "cSpell.enabled": true,
+    "cSpell.diagnosticLevel": "Hint",
+    "cSpell.maxNumberOfProblems": 10000,
     "cSpell.ignorePaths": [
         "node_modules",
         ".git"
@@ -140,7 +142,8 @@
         "preselection",
         "psql",
         "realpath",
-        "Rubo",
+        "rubocop",
+        "RuboCop",
         "selectize",
         "Timecop",
         "trix",
@@ -150,9 +153,4 @@
         "webpacker",
         "whitespaces"
     ],
-    "cSpell.enableFiletypes": [
-        "ruby"
-        // Other filetypes are handled by the default spell checker
-    ],
-    "cSpell.maxNumberOfProblems": 10000
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -140,6 +140,7 @@
         "preselection",
         "psql",
         "realpath",
+        "Rubo",
         "selectize",
         "Timecop",
         "trix",

--- a/app/controllers/vignettes/info_slides_controller.rb
+++ b/app/controllers/vignettes/info_slides_controller.rb
@@ -14,6 +14,10 @@ module Vignettes
              locals: { slide: @info_slide }
     end
 
+    def edit
+      render partial: "vignettes/info_slides/form" if request.xhr?
+    end
+
     def create
       @info_slide = @questionnaire.info_slides.new(info_slide_params)
       if @info_slide.save
@@ -22,10 +26,6 @@ module Vignettes
       else
         render :new
       end
-    end
-
-    def edit
-      render partial: "vignettes/info_slides/form" if request.xhr?
     end
 
     def update

--- a/app/controllers/vignettes/questionnaires_controller.rb
+++ b/app/controllers/vignettes/questionnaires_controller.rb
@@ -161,6 +161,12 @@ module Vignettes
       @questionnaire = Questionnaire.new
     end
 
+    def edit
+      @slides = @questionnaire.slides.order(:position)
+
+      render layout: "administration"
+    end
+
     def create
       @questionnaire = Questionnaire.new(questionnaire_params)
       if @questionnaire.save
@@ -169,12 +175,6 @@ module Vignettes
       else
         render :new, status: :unprocessable_entity
       end
-    end
-
-    def edit
-      @slides = @questionnaire.slides.order(:position)
-
-      render layout: "administration"
     end
 
     def destroy

--- a/app/helpers/vertices_helper.rb
+++ b/app/helpers/vertices_helper.rb
@@ -10,6 +10,6 @@ module VerticesHelper
   end
 
   def crosses_id(crosses)
-    crosses.keys.collect { |k| [k, crosses[k].to_s.first] }.flatten.join
+    crosses.keys.collect { |k| [k, crosses[k].to_s.first] }.join
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -5,9 +5,7 @@ class Assignment < ApplicationRecord
 
   before_destroy :check_destructibility, prepend: true
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :title, uniqueness: { scope: [:lecture_id] }, presence: true
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
   validates :deadline, presence: true
   validates :deletion_date, presence: true
   validate :deletion_date_cannot_be_in_the_past

--- a/app/models/clicker.rb
+++ b/app/models/clicker.rb
@@ -5,9 +5,7 @@ class Clicker < ApplicationRecord
 
   before_create :set_basics
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :title, uniqueness: { scope: [:editor_id] }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
   validates :title, presence: true
 
   has_many :votes, dependent: :destroy, class_name: "ClickerVote"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -37,12 +37,8 @@ class Course < ApplicationRecord
   has_many :division_course_joins, dependent: :destroy
   has_many :divisions, through: :division_course_joins
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :title, presence: true, uniqueness: true
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :short_title, presence: true, uniqueness: true
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   # some information about media and lectures are cached
   # to find out whether the cache is out of date, always touch'em after saving

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -2,7 +2,5 @@ class Import < ApplicationRecord
   belongs_to :medium
   belongs_to :teachable, polymorphic: true
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :medium, uniqueness: { scope: [:teachable] }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
 end

--- a/app/models/item_self_join.rb
+++ b/app/models/item_self_join.rb
@@ -7,11 +7,9 @@ class ItemSelfJoin < ApplicationRecord
   belongs_to :item
   belongs_to :related_item, class_name: "Item"
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :related_item, uniqueness: { scope: :item }
   before_destroy :touch_item
   after_destroy :destroy_inverses, if: :inverse?
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
   after_save :create_inverse, unless: :inverse?
   after_save :destroy, if: :self_inverse?
   after_save :touch_item

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -90,9 +90,7 @@ class Lecture < ApplicationRecord
 
   # we do not allow that a teacher gives a certain lecture in a given term
   # of the same sort twice
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :course, uniqueness: { scope: [:teacher_id, :term_id, :sort] }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   validates :content_mode, inclusion: { in: ["video", "manuscript"] }
 

--- a/app/models/manuscript.rb
+++ b/app/models/manuscript.rb
@@ -207,7 +207,7 @@ class Manuscript
         pdf_destination: c["destination"],
         section_id: @sections.find do |s|
                       c["section"] == s["section"]
-                    end ["mampf_section"]&.id,
+                    end["mampf_section"]&.id,
         sort: Item.internal_sort(c["sort"]),
         page: c["page"].to_i,
         description: c["description"],

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1243,7 +1243,7 @@ class Medium < ApplicationRecord
       return false unless type == "Question"
 
       question = becomes(Question)
-      return false unless question.answers.count.in?((2..6))
+      return false unless question.answers.count.in?(2..6)
 
       question.answers.pluck(:value).count(true) == 1
     end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -115,7 +115,7 @@ class Term < ApplicationRecord
   end
 
   def self.previous_by_date(date)
-    season = date.month.in?((4..9)) ? "SS" : "WS"
+    season = date.month.in?(4..9) ? "SS" : "WS"
     year = date.year
     previous_year = season == "WS" ? year : year - 1
     previous_season = season == "WS" ? "SS" : "WS"

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -3,9 +3,7 @@ class Watchlist < ApplicationRecord
   has_many :watchlist_entries, dependent: :destroy
   has_many :media, through: :watchlist_entries
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :name, presence: true, uniqueness: { scope: :user_id }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   def owned_by?(other_user)
     user == other_user

--- a/app/models/watchlist_entry.rb
+++ b/app/models/watchlist_entry.rb
@@ -4,7 +4,5 @@ class WatchlistEntry < ApplicationRecord
   belongs_to :medium
   acts_as_list scope: :watchlist, top_of_list: 0, column: :medium_position
 
-  # rubocop:todo Rails/UniqueValidationWithoutIndex
   validates :medium_id, uniqueness: { scope: :watchlist_id }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
 end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -15,8 +15,7 @@ elsif Rails.env.production?
   submission_path = ENV["SUBMISSION_PATH"] || "/private/submissions"
   Shrine.storages = {
     cache: Shrine::Storage::FileSystem.new("/caches", prefix: "medien_uploads", clean: false),
-    store: Shrine::Storage::FileSystem.new((ENV["MEDIA_PATH"] || "/private/media"),
-                                           prefix: "/"),
+    store: Shrine::Storage::FileSystem.new(ENV["MEDIA_PATH"] || "/private/media", prefix: "/"),
     submission_cache: Shrine::Storage::FileSystem.new(submission_path, prefix: "cache"),
     submission_store: Shrine::Storage::FileSystem.new(submission_path, prefix: "store")
   }


### PR DESCRIPTION
As usual, a new RuboCop update also comes with new cops. Here, I only addressed trivial ones. I've disabled more complex ones in `.rubocop.yml`, e.g. `Rails/InverseOf` as this would require manual testing afterwards. Those I flagged with a TODO note and we should revisit them in the future, see #794.

Off-topic: updates a CSpell VSCode configuration.