### PR TITLE
Improve code quality of test setup script in Docker container

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,10 +52,12 @@
         "codeLens": true,
         "definition": true
     },
-    "rubyLsp.enableExperimentalFeatures": true,
     //////////////////////////////////////
     // Ruby Test Explorer
     //////////////////////////////////////
+    "rubyLsp.featureFlags": {
+        "fullTestDiscovery": false,
+    },
     "rubyTestExplorer.testFramework": "rspec",
     "rubyTestExplorer.rspecCommand": "python3 ./spec/rspec_inside_docker.py",
     "rubyTestExplorer.rspecDirectory": "./spec/",

--- a/spec/rspec_inside_docker.py
+++ b/spec/rspec_inside_docker.py
@@ -1,11 +1,11 @@
 """
 Script to run RSpec tests inside a Docker container. Works with the Ruby LSP
-VSCode extension [1] and the Ruby LSP RSpec addon [2].
+VSCode extension [1] and the Ruby Test Explorer [2].
 
 For ongoing development, see also [3] and [4].
 
 [1] https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp
-[2] https://github.com/st0012/ruby-lsp-rspec
+[2] https://marketplace.visualstudio.com/items?itemName=connorshea.vscode-ruby-test-adapter
 [3] https://github.com/Shopify/ruby-lsp/issues/3586
 [4] https://github.com/Shopify/ruby-lsp/pull/2919
 """
@@ -21,12 +21,12 @@ DOCKER_COMPOSE_FOLDER = "./docker/test"
 
 def switch_formatter_path():
     """
-    Memory-maps the custom formatter of the Ruby LSP RSpec addon.
+    Memory-maps the custom formatter of the Ruby Test Explorer extension.
 
-    The Ruby LSP RSpec addon uses a custom formatter to get a specific output
-    format for the test runs. The path to the formatter is automatically passed
-    as an argument to the rspec command. We need to replace this path by the
-    path to the memory-mapped formatter in the Docker container.
+    The Ruby Test Explorer extension uses a custom formatter to get a specific
+    output format for the test runs. The path to the formatter is automatically
+    passed as an argument to the rspec command. We need to replace this path by
+    the path to the memory-mapped formatter in the Docker container.
     """
     formatter_argument_index = None
     for i, arg in enumerate(sys.argv):
@@ -35,7 +35,7 @@ def switch_formatter_path():
             break
 
     if formatter_argument_index is None:
-        # the addon should pass this automatically for you
+        # the extension should pass this automatically for you
         print('Please specify "--require path/to/custom/formatter.rb"')
         sys.exit(1)
 
@@ -48,7 +48,7 @@ def switch_formatter_path():
 
 def replace_absolute_paths_by_relative_paths(path):
     """
-    Replaces absolute paths in the given path by relative paths.
+    Replaces absolute paths by relative paths for usage inside the Docker container.
     """
     res = path.split(PROJECT_ROOT_FOLDER_NAME + "/")[1]
     if not res:
@@ -75,16 +75,12 @@ def main():
         f'{DOCKER_SERVICE_NAME} sh -c "{test_command}"'
     )
 
-    print(f"🎈 Running command: {docker_cmd}")
     result = subprocess.run(
         docker_cmd, shell=True, capture_output=True, text=True, check=False
     )
-    print("🎈 Command output:")
     print(result.stdout, end="")
     if result.stderr:
         print(result.stderr, file=sys.stderr, end="")
-
-    print("🎈 Command finished with exit code:", result.returncode)
     sys.exit(result.returncode)
 
 

--- a/spec/rspec_inside_docker.py
+++ b/spec/rspec_inside_docker.py
@@ -1,61 +1,92 @@
+"""
+Script to run RSpec tests inside a Docker container. Works with the Ruby LSP
+VSCode extension [1] and the Ruby LSP RSpec addon [2].
+
+For ongoing development, see also [3] and [4].
+
+[1] https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp
+[2] https://github.com/st0012/ruby-lsp-rspec
+[3] https://github.com/Shopify/ruby-lsp/issues/3586
+[4] https://github.com/Shopify/ruby-lsp/pull/2919
+"""
+
 import sys
 import subprocess
 
-# Path where the custom formatter of the Ruby Test explorer extension is memory-mapped
 FORMATTER_PATH_IN_DOCKER = "/root/tmp/formatter.rb"
 PROJECT_ROOT_FOLDER_NAME = "mampf"
 DOCKER_SERVICE_NAME = "mampf"
+DOCKER_COMPOSE_FOLDER = "./docker/test"
 
 
 def switch_formatter_path():
     """
-    Memory-maps the custom formatter of the Ruby Test explorer extension.
+    Memory-maps the custom formatter of the Ruby LSP RSpec addon.
 
-    The Ruby Test explorer extension uses a custom formatter to get a specific
-    output JSON format. The path to the formatter is automatically passed as an
-    argument to the rspec command by the extension. We need to replace this
-    path by the path to the memory-mapped formatter in the Docker container.
+    The Ruby LSP RSpec addon uses a custom formatter to get a specific output
+    format for the test runs. The path to the formatter is automatically passed
+    as an argument to the rspec command. We need to replace this path by the
+    path to the memory-mapped formatter in the Docker container.
     """
-
     formatter_argument_index = None
     for i, arg in enumerate(sys.argv):
-        if arg == '--require':
+        if arg in ("--require", "-r"):
             formatter_argument_index = i
             break
 
-    if formatter_argument_index == None:
+    if formatter_argument_index is None:
+        # the addon should pass this automatically for you
         print('Please specify "--require path/to/custom/formatter.rb"')
         sys.exit(1)
 
-    # Switch the path to the custom formatter to the memory-mapped path
-    formatter_path_on_host = sys.argv[formatter_argument_index + 1]
+    # Switch the path of the custom formatter to the memory-mapped path
+    path_on_host = sys.argv[formatter_argument_index + 1]
     sys.argv[formatter_argument_index + 1] = FORMATTER_PATH_IN_DOCKER
 
-    return formatter_path_on_host
-
-
-def process_paths():
-    for i, arg in enumerate(sys.argv):
-        if not arg.startswith('./') and "spec" in arg:
-            sys.argv[i] = replace_absolute_paths_by_relative_paths(sys.argv[i])
+    return path_on_host
 
 
 def replace_absolute_paths_by_relative_paths(path):
-    res = path.split(PROJECT_ROOT_FOLDER_NAME + '/')[1]
+    """
+    Replaces absolute paths in the given path by relative paths.
+    """
+    res = path.split(PROJECT_ROOT_FOLDER_NAME + "/")[1]
     if not res:
-        print(f'Path {path}'
-              f' does not contain string "{PROJECT_ROOT_FOLDER_NAME}/"')
+        print(f"Path {path}" f' does not contain string "{PROJECT_ROOT_FOLDER_NAME}/"')
         sys.exit(1)
-    return './' + res  # make path relative
+    return "./" + res
 
 
-if __name__ == '__main__':
+def main():
+    """
+    Main function to run RSpec tests inside a Docker container.
+    """
     formatter_path_on_host = switch_formatter_path()
-    process_paths()
+    for i, arg in enumerate(sys.argv):
+        if not arg.startswith("./") and "spec" in arg:
+            sys.argv[i] = replace_absolute_paths_by_relative_paths(sys.argv[i])
 
-    rspec_args = ' '.join(sys.argv[1:])
-    test_command = f'bundle install && RAILS_ENV=test bundle exec rspec {rspec_args}'
+    rspec_args = " ".join(sys.argv[1:])
+    test_command = f"bundle install && RAILS_ENV=test bundle exec rspec {rspec_args}"
 
-    docker_cmd = f'cd ./docker/test && docker compose run --rm -T --entrypoint="" -v {formatter_path_on_host}:{FORMATTER_PATH_IN_DOCKER} {DOCKER_SERVICE_NAME} sh -c "{test_command}"'
+    docker_cmd = (
+        f'cd {DOCKER_COMPOSE_FOLDER} && docker compose run --rm -T --entrypoint="" '
+        f"-v {formatter_path_on_host}:{FORMATTER_PATH_IN_DOCKER} "
+        f'{DOCKER_SERVICE_NAME} sh -c "{test_command}"'
+    )
 
-    subprocess.call(docker_cmd, shell=True)
+    print(f"🎈 Running command: {docker_cmd}")
+    result = subprocess.run(
+        docker_cmd, shell=True, capture_output=True, text=True, check=False
+    )
+    print("🎈 Command output:")
+    print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+
+    print("🎈 Command finished with exit code:", result.returncode)
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR improves the code quality of our `rspec_inside_docker.py` script according to Python11 standards.

Note that we still use the [`VSCode Test Explorer` extension](https://marketplace.visualstudio.com/items?itemName=connorshea.vscode-ruby-test-adapter) in our setup, while in the meantime, VSCode has its own native [Test explorer](https://code.visualstudio.com/docs/debugtest/testing) that [Ruby LSP can use](https://shopify.github.io/ruby-lsp/test_explorer.html). In the long-term, we should migrate to this approach. However:

- Ruby LSP does not support Docker ("only" VSCode dev containers as seen [here](https://shopify.github.io/ruby-lsp/vscode-extension.html#developing-on-containers) and we don't migrate to DevContainers soon as discussed in #767).
- Ruby LSP also doesn't offer a custom rspec command. While there is a Ruby LSP addon called [`Ruby LSP RSpec`](https://github.com/st0012/ruby-lsp-rspec) that does support passing an [`rspecCommand`](https://github.com/st0012/ruby-lsp-rspec?tab=readme-ov-file#rspeccommand), this doesn't work for us since it uses Ruby LSP internal commands to report back the results. And since Ruby LSP is still running on the host (VSCode) and _not_ inside the Docker Container, this doesn't work for us. 

For these reasons, we stick to the VSCode Test Explorer extension for now, where we return the test results from the docker container as JSON and the extension reads it and reports it in its custom test explorer view.

For more context, see also [**my comment here**](https://github.com/Shopify/ruby-lsp/pull/2919#issuecomment-2973800573).