### PR TITLE
Prevent showing invites for inactive assignments

### DIFF
--- a/app/models/submission_invite.rb
+++ b/app/models/submission_invite.rb
@@ -8,7 +8,7 @@ class SubmissionInvite
   # created it, or an empty array if no submissions are found.
   def invites_for(assignment)
     return [] unless @user && assignment
-    return [] unless assignment.active?
+    return [] unless assignment.semiactive?
 
     submissions = Submission.where(assignment: assignment)
                             .where("? = ANY(invited_user_ids)", @user.id)

--- a/app/models/submission_invite.rb
+++ b/app/models/submission_invite.rb
@@ -8,6 +8,7 @@ class SubmissionInvite
   # created it, or an empty array if no submissions are found.
   def invites_for(assignment)
     return [] unless @user && assignment
+    return [] unless assignment.active?
 
     submissions = Submission.where(assignment: assignment)
                             .where("? = ANY(invited_user_ids)", @user.id)

--- a/spec/cypress/e2e/submissions_spec.cy.js
+++ b/spec/cypress/e2e/submissions_spec.cy.js
@@ -17,7 +17,7 @@ describe("Submissions Joining", () => {
 
     FactoryBot.create("lecture", "released_for_all").as("lecture");
     cy.then(() => {
-      FactoryBot.create("tutorial", "with_tutors", { lecture_id: this.lecture.id }).as("tutorial");
+      FactoryBot.create("tutorial", "with_tutors", { lecture_id: this.lecture.id });
       FactoryBot.create("assignment", { lecture_id: this.lecture.id }).as("assignment");
     });
   });
@@ -104,7 +104,7 @@ describe("Submissions Joining", () => {
       // (since this user has previously handed in a submission together
       // with the inviter, see above)
       cy.login(this.joiner).then(() => {
-        cy.visit(`/lectures/${this.tutorial.lecture_id}/submissions`);
+        cy.visit(`/lectures/${this.lecture.id}/submissions`);
         cy.getBySelector("submission-join").click();
         cy.getBySelector("accept-invite-0").click();
         cy.getBySelector("submission-team").should("contain", this.inviter.name_in_tutorials);
@@ -155,7 +155,7 @@ describe("Submissions Joining", () => {
       // 🐰 "Joiner" should not be able to join via an invite now
       // as the assignment is overdue (deadline is in the past).
       cy.login(this.joiner).then(() => {
-        cy.visit(`/lectures/${this.tutorial.lecture_id}/submissions`);
+        cy.visit(`/lectures/${this.lecture.id}/submissions`);
         cy.contains(this.assignment.title).should("be.visible");
         cy.getBySelector("accept-invite-0").should("not.exist");
         cy.getBySelector("accept-invite-1").should("not.exist");

--- a/spec/cypress/e2e/submissions_spec.cy.js
+++ b/spec/cypress/e2e/submissions_spec.cy.js
@@ -150,8 +150,6 @@ describe("Submissions Joining", () => {
     });
 
     Timecop.moveAheadDays(2000).then(() => {
-      console.log("Assignment has title:", this.assignment.title);
-
       // 🐰 "Joiner" should not be able to join via an invite now
       // as the assignment is overdue (deadline is in the past).
       cy.login(this.joiner).then(() => {

--- a/spec/cypress/support/timecop.js
+++ b/spec/cypress/support/timecop.js
@@ -39,7 +39,8 @@ class Timecop {
   }
 
   /**
-   * Moves the time ahead by the given number of days.
+   * Moves the time ahead by the given number of days starting from the
+   * current time (that is never shifted).
    */
   moveAheadDays(days) {
     const now = new Date();
@@ -52,7 +53,7 @@ class Timecop {
   }
 
   /**
-   * Resets the time in the backend to the current time.
+   * Resets the time in the backend to the current time (that is never shifted).
    */
   reset() {
     return BackendCaller.callCypressRoute("timecop/reset", "Timecop.reset()");


### PR DESCRIPTION
Fixes #798 by not showing invite links on inactive assignments anymore. The button didn't work because our backend correctly handled the case and prevented joining an inactive assignment, but we shouldn't show the button in the first place. Follow-up to #785.

I've added a Cypress test such that this doesn't happen again.

<img width="904" alt="image" src="https://github.com/user-attachments/assets/a6c038c8-2a4d-4c40-a4eb-e044d0aa1366" />
