### PR TITLE
Fix nested array syntax in answer_params method

### DIFF
--- a/app/controllers/vignettes/questionnaires_controller.rb
+++ b/app/controllers/vignettes/questionnaires_controller.rb
@@ -303,9 +303,9 @@ module Vignettes
           .expect(vignettes_answer: [:slide_id, :text, :likert_scale_value,
                                      { option_ids: [],
                                        slide_statistic_attributes:
-                                     [[:user_id, :time_on_slide, :total_time_on_slide,
+                                     [:user_id, :time_on_slide, :total_time_on_slide,
                                        :time_on_info_slides, :info_slides_access_count,
-                                       :info_slides_first_access_time]] }])
+                                       :info_slides_first_access_time] }])
       end
 
       def user_has_codename?(user, lecture)


### PR DESCRIPTION
This PR fixes a bug related to vignettes statistics in Rails 8. There was a syntax error for answer_params which prevented statistics from being passed through, resulting in an exception when statistics were exported.