### PR TITLE
Update Interactions Schema to Rails 8

### DIFF
--- a/db/interactions_schema.rb
+++ b/db/interactions_schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2020_06_13_112557) do
+ActiveRecord::Schema[8.0].define(version: 2020_06_13_112557) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "consumptions", force: :cascade do |t|
     t.integer "medium_id"


### PR DESCRIPTION
This PR updates the interactions schema to Rails 8: it updates the ActiveRecord schema version and corrects the extension name for the interactions schema.