### PR TITLE
Fix test database username locally

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       TEST_DATABASE_ADAPTER: postgresql
       TEST_DATABASE_DATABASE: mampf-test
       TEST_DATABASE_INTERACTIONS: interactions-test
-      TEST_DATABASE_USERNAME: mampf
+      TEST_DATABASE_USERNAME: localroot
       TEST_DATABASE_HOST: db
       TEST_DATABASE_PORT: 5432
       MAX_DELETIONS_PER_RUN: 50


### PR DESCRIPTION
Follow-up to #736 where this config was changed. We had the wrong username assigned locally for our test database. @fosterfarrell9 found this out after a complete clean install of the Docker Containers.