### PR TITLE
Use generic name for local database seed SQL file

### DIFF
--- a/.config/commands/docker.justfile
+++ b/.config/commands/docker.justfile
@@ -49,7 +49,7 @@ up-reseed *args:
     just --yes docker db-tear-down
 
     cd {{justfile_directory()}}/docker/development/
-    export DB_SQL_PRESEED_URL="https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/20220923120841_mampf.sql"
+    export DB_SQL_PRESEED_URL="https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/mampf.sql"
     export UPLOADS_PRESEED_URL="https://github.com/MaMpf-HD/mampf-init-data/raw/main/data/uploads.zip"
     docker compose rm --stop --force mampf && just docker up {{args}}
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,6 @@
+> [!warning]
+> This guide is not up to date, please refer to the [MaMpf Wiki](https://github.com/MaMpf-HD/mampf/wiki/Installation-&-Setup) in addition to this document, until information from here is fully migrated to the Wiki.
+
 ## Installation (with docker compose)
 
 To simply try out mampf you can use `docker compose` (needs [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)). Simply clone the MaMpf repository and run docker compose by executing


### PR DESCRIPTION
In alignment with https://github.com/MaMpf-HD/mampf-init-data/pull/1, where a new database seed is constructed for local development, we remove the timestamp from the `mampf.sql` filename. This makes it possible to update the seed without having to make changes here in the MaMpf repo.