### PR TITLE
Fix remaining broken links on lecture edit page

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -36,7 +36,7 @@ class AnnouncementsController < ApplicationController
         redirect_to announcements_path
         return
       end
-      redirect_to "#{edit_lecture_path(@announcement.lecture)}#communication"
+      redirect_to "#{edit_lecture_path(@announcement.lecture)}?tab=communication"
       return
     end
     @errors = @announcement.errors[:details].join(", ")

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -177,28 +177,28 @@ class LecturesController < ApplicationController
       forum.save
       @lecture.update(forum_id: forum.id) if forum.valid?
     end
-    redirect_to "#{edit_lecture_path(@lecture)}#communication"
+    redirect_to "#{edit_lecture_path(@lecture)}?tab=communication"
   end
 
   # lock forum for this lecture
   def lock_forum
     @lecture.forum.update(locked: true) if @lecture.forum?
     @lecture.touch
-    redirect_to "#{edit_lecture_path(@lecture)}#communication"
+    redirect_to "#{edit_lecture_path(@lecture)}?tab=communication"
   end
 
   # unlock forum for this lecture
   def unlock_forum
     @lecture.forum.update(locked: false) if @lecture.forum?
     @lecture.touch
-    redirect_to "#{edit_lecture_path(@lecture)}#communication"
+    redirect_to "#{edit_lecture_path(@lecture)}?tab=communication"
   end
 
   # destroy forum for this lecture
   def destroy_forum
     @lecture.forum.destroy if @lecture.forum?
     @lecture.update(forum_id: nil)
-    redirect_to "#{edit_lecture_path(@lecture)}#communication"
+    redirect_to "#{edit_lecture_path(@lecture)}?tab=communication"
   end
 
   # show all announcements for this lecture
@@ -261,13 +261,13 @@ class LecturesController < ApplicationController
       lesson.media.update(annotations_status: -1)
     end
     @lecture.touch
-    redirect_to "#{edit_lecture_path(@lecture)}#communication"
+    redirect_to "#{edit_lecture_path(@lecture)}?tab=communication"
   end
 
   def open_comments
     @lecture.open_comments!(current_user)
     @lecture.touch
-    redirect_to "#{edit_lecture_path(@lecture)}#communication"
+    redirect_to "#{edit_lecture_path(@lecture)}?tab=communication"
   end
 
   def search

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -69,7 +69,7 @@ module TalksHelper
                     }
                   })
     else
-      seminar_edit_people_link = "#{edit_lecture_path(talk.lecture)}#people"
+      seminar_edit_people_link = "#{edit_lecture_path(talk.lecture)}?tab=people"
 
       form.select(:speaker_ids, speakers_preselection(talk), {},
                   class: "selectize",


### PR DESCRIPTION
Follow-up to #860. There, we replaced the anchor links by `?tab=` URL query params and I forgot some occurrences.