### PR TITLE
Add .ruby-version to .gitignore to ignore Ruby version files from rbenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ node_modules
 # Vite uses dotenv and suggests to ignore local-only env files. See
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
+
+# Ignore ruby version file from rbenv
+.ruby-version


### PR DESCRIPTION
We add `.ruby-version` to `.gitignore`. It  seems to be used locally by `rbenv`. Note that unit tests are failing because of #837.