### PR TITLE
Fix flaky unit tests

### DIFF
--- a/spec/models/redeemer_spec.rb
+++ b/spec/models/redeemer_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe(Redeemer, type: :model) do
 
     before :each do
       allow(Current).to receive(:user).and_return(user)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(a_string_matching(/mampf-logo\.png$/))
+                                   .and_return("fake-image-data")
     end
 
     shared_examples "common voucher processing" do


### PR DESCRIPTION
In this PR, we fix the failing unit tests of this sort

```
Failure/Error:   expect(mail).to include_in_html_body(I18n.t("mailer.new_speaker",  seminar: talk.lecture.title, title: talk.to_label,            username: cospeaker.tutorial_name, speaker: user.info)   )    

Expected that the HTML body would include:   ... Talk 1. The Monkey's Raincoat 3197...

But got:   ... Talk 1. The Monkey&#39;s Raincoat 3197...
```

The problem arises from HTML entity encoding. Our test generates a plain text string using I18n.t, which might contain characters like an apostrophe. When the Rails mailer renders the HTML view, it escapes such characters to their HTML entity equivalents (e.g., ' becomes &#39;). Because the matcher looks for the literal, unescaped string, it fails to find a match in the escaped HTML source, leading to flaky test.

We rewrote the `include_in_html_body` matcher method to make use of Nokogiris HTML parser and additionally normalize whitespaces before comparison. This should make the method more robust.

Also, note that locally, I had failing specs in `redeemer_spec.rb` with yet another error message:

```
  /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `map'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:116:in `block in run_specs'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/reporter.rb:74:in `report'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:115:in `run_specs'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:89:in `run'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:71:in `run'
    /usr/local/bundle/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:45:in `invoke'
    /usr/local/bundle/gems/rspec-core-3.13.5/exe/rspec:4:in `<top (required)>'
    /usr/local/bundle/bin/rspec:25:in `load'
    /usr/local/bundle/bin/rspec:25:in `<top (required)>'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/cli/exec.rb:59:in `load'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/cli/exec.rb:59:in `kernel_load'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/cli/exec.rb:23:in `run'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/cli.rb:452:in `exec'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/vendor/thor/lib/thor.rb:538:in `dispatch'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/cli.rb:35:in `dispatch'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/cli.rb:29:in `start'
    /usr/local/bundle/gems/bundler-2.7.0/exe/bundle:28:in `block in <top (required)>'
    /usr/local/bundle/gems/bundler-2.7.0/lib/bundler/friendly_errors.rb:118:in `with_friendly_errors'
    /usr/local/bundle/gems/bundler-2.7.0/exe/bundle:20:in `<top (required)>'
    /usr/local/bundle/bin/bundle:25:in `load'
    /usr/local/bundle/bin/bundle:25:in `<main>'

Backtrace:
/usr/src/app/app/helpers/email_helper.rb:3:in `read'
/usr/src/app/app/helpers/email_helper.rb:3:in `read'
/usr/src/app/app/helpers/email_helper.rb:3:in `email_image_tag'
/usr/src/app/app/views/layouts/mailer.html.erb:10:in `_app_views_layouts_mailer_html_erb__3971146045671669165_39600'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:278:in `public_send'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:278:in `_run'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:284:in `block in render'
/usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:212:in `instrument'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:583:in `instrument_render_template'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:272:in `render'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:77:in `block in render_with_layout'
/usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
/usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:75:in `render_with_layout'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:59:in `render_template'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:11:in `render'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:58:in `render_template_to_object'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:31:in `render_to_object'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:136:in `block in _render_template'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:305:in `in_rendering_context'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:135:in `_render_template'
/usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:122:in `render_to_body'
/usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/rendering.rb:28:in `render'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:998:in `block in collect_responses_from_templates'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:995:in `each'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:995:in `each'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:995:in `map'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:995:in `collect_responses_from_templates'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:973:in `collect_responses'
/usr/local/bundle/gems/actionmailer-8.0.2/lib/action_mailer/base.rb:881:in `mail'
/usr/src/app/app/mailers/application_mailer.rb:44:in `mail'
/usr/src/app/app/mailers/lecture_notification_mailer.rb:21:in `new_teacher_email'
/usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:226:in `process_action'
/usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:261:in `block in process_action'
/usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in `block in run_callbacks'
/usr/local/bundle/gems/actiontext-8.0.2/lib/action_text/rendering.rb:25:in `with_renderer'
/usr/local/bundle/gems/actiontext-8.0.2/lib/action_text/engine.rb:71:in `block (4 levels) in <class:Engine>'
```

The problem here is that asset files like images are not precompiled or available in the `public/` directory. The File.read call triggered by the `email_image_tag` therefore fails, raising a `No such file or directory error...` and crashing the test. In order to fix that I stubbed the `File.read` call, therefore intercepting any attempt to read the logo file.
