### PR TITLE
Fix nil check in pagy_bootstrap_nav

### DIFF
--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -2,7 +2,7 @@ module PagyHelper
   # Overrides the default pagy_bootstrap_nav to prevent it from rendering
   # when there is only one page.
   def pagy_bootstrap_nav(pagy, **vars)
-    return if pagy.pages <= 1
+    return if pagy.nil? || pagy.pages <= 1
 
     super
   end


### PR DESCRIPTION
This PR makes the `pagy_bootstrap_nav` method more robust. Without this PR, just go to your local development setting and open `/watchlists`. Unless you added something to the watchlist, you will get an exception because the index action of the watchlists controller renders the `show` template in this case, without setting the pagy variable. The change in this PR fixes this.