### PR TITLE
Setup codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these owners
+# will be requested for review when someone opens a pull request.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection
+*       @fosterfarrell9 @Splines


### PR DESCRIPTION
Here, we set up a new `.github/CODEOWNERS` file as described [in the GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection), such that specific people are required give a review before a PR can be merged.

This is important since now more people have write access to the MaMpf repo and we want to avoid the situation, where they approve each other's PRs, merging them through, without the longer-standing team taking note of it. This is not a trust issue; instead this PR is fully transparent about it. We just want to avoid unintentional merges. Especially on main, this would have the consequence that production rebuilds, which is why we need this security measure.

In principle, this permission can be scoped via regex, e.g. only this folder, only that extension etc. But I don't regard this as necessary for us (and rather for something like the Linux kernel, where companies are owners of their own subfolders).