### PR TITLE
Fix architecture build (mdbook admonish assets)

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install mdBook (and deps)
         run: . "$HOME/.cargo/env" && cargo binstall mdbook mdbook-mermaid mdbook-admonish mdbook-pagetoc --no-confirm --force
 
+      - name: Install mdbook-admonish assets
+        working-directory: ./architecture/
+        run: . "$HOME/.cargo/env" && mdbook-admonish install
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
The mdbook admonish assets were missing for the architecture book build.