### PR TITLE
Fix flaky postComment Playwright test

### DIFF
--- a/e2e/page-objects/comments_page.ts
+++ b/e2e/page-objects/comments_page.ts
@@ -14,8 +14,12 @@ export class MediumCommentsPage {
   }
 
   async postComment(comment: string) {
+    const newCommentPromise = this.page.waitForResponse(response =>
+      response.url().includes("comments/new"),
+    );
     await this.page.getByRole("button", { name: "new comment" }).click();
-    await this.page.waitForResponse(response => response.url().includes("comments/new"));
+    await newCommentPromise;
+
     const textarea = this.page.getByTestId("comment-new-textarea");
     await textarea.waitFor({ state: "visible" });
     await textarea.fill(comment);


### PR DESCRIPTION
This PR fixes a flaky test by explicitly waiting for the correct response to arrive, see also [the docs](https://playwright.dev/docs/api/class-page#page-wait-for-response).