### PR TITLE
Avoid flaky test when creating multiple chapters

### DIFF
--- a/spec/factories/lectures.rb
+++ b/spec/factories/lectures.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     trait :with_toc do
       after(:build) do |lecture, evaluator|
         lecture.chapters = create_list(:chapter, evaluator.chapter_count,
-                                       :with_sections)
+                                       :with_sections, lecture: lecture)
       end
     end
 
@@ -38,7 +38,7 @@ FactoryBot.define do
     trait :with_sparse_toc do
       after(:build) do |lecture|
         lecture.chapters = create_list(:chapter, 1,
-                                       :with_sections, section_count: 1)
+                                       :with_sections, section_count: 1, lecture: lecture)
       end
     end
 


### PR DESCRIPTION
We got this error in a unit test in the CI:

```rb
Search::Filters::LectureMediaScopeFilter with invalid parameters when lecture is not found returns an empty scope

Failure/Error:
  lecture.chapters = create_list(:chapter, evaluator.chapter_count,
                                 :with_sections)

ActiveRecord::RecordInvalid:
  Gültigkeitsprüfung ist fehlgeschlagen: Season Dieses Semester existiert bereits.
```

The problem is that in the `lectures.rb` Factory, we create a list of chapters, without assigning a specific lecture. Thus, every chapter creates its own lecture, which creates its own term (randomly picks from "WS" or "SS" and a random year). This opens up the possibility for collisions due to a uniqueness validation of the term. Therefore, the test is flaky.
