### PR TITLE
Fix env variables for production

### DIFF
--- a/docker/production/docker.env
+++ b/docker/production/docker.env
@@ -52,12 +52,11 @@ PRODUCTION_DATABASE_PORT=port
 PRODUCTION_DATABASE_URL='postgresql://mampf:supersecret@db:port/mampf'
 
 # Rails configuration
-# change RAILS_ENV to production for a production deployment
 RAILS_ENV=production
 RAILS_MASTER_KEY=secret
 SECRET_KEY_BASE=secret
 URL_HOST=mampf.mathi.uni-heidelberg.de
-URL_HOST_SHORT=http://mampf.media
+MAMPF_PORT=3000
 
 # Fast caching and indexing need further services
 REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
Add the missing `MAMPF_PORT` to the dummy production `docker.env`.