### PR TITLE
Fix rubocop errors in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "bootstrap_form", "~> 5.4"
 gem "cancancan", "~> 3.6"
 gem "coffee-rails", "~> 5.0"
 gem "commontator", "~> 7.0.1"
+gem "connection_pool ", "< 3.0" # ActiveSupport currently breaks with connection_pool 3.x
 gem "coveralls", "~> 0.7", require: false
 gem "csv", "~> 3.3", require: false
 gem "dalli", "~> 3.2" # caching to memcached in production
@@ -64,7 +65,6 @@ gem "trix-rails", "~> 2.4", require: "trix"
 gem "turbo-rails", "~> 2.0"
 gem "view_component", "~> 4.0"
 gem "vite_rails", "~> 3.0", ">= 3.0.17"
-gem 'connection_pool', '< 3.0' # ActiveSupport currently breaks with connection_pool 3.x
 
 group :development do
   gem "listen", "~> 3.9"


### PR DESCRIPTION
RuboCop only runs on `.rb` files in the CI. #963 introduced a linting violation in the Gemfile that therefore went unnoticed. This fixed it.

(@f-buerckel you should get automatic squiggly underlines in VSCode via Ruby LSP, hope this works)