### PR TITLE
Convert 20 CoffeeScript files to JS/JS.erb

### DIFF
--- a/app/frontend/js/file_upload.coffee
+++ b/app/frontend/js/file_upload.coffee
@@ -1,4 +1,0 @@
-$(document).on 'change', '.custom-file-input', ->
-  fileName = $(this).val().split('\\').pop()
-  $(this).siblings('.custom-file-label').addClass('selected').html fileName
-  return

--- a/app/frontend/js/file_upload.js
+++ b/app/frontend/js/file_upload.js
@@ -1,0 +1,4 @@
+$(document).on('change', '.custom-file-input', function() {
+  var fileName = $(this).val().split('\\').pop();
+  $(this).siblings('.custom-file-label').addClass('selected').html(fileName);
+});

--- a/app/views/answers/destroy.coffee
+++ b/app/views/answers/destroy.coffee
@@ -1,5 +1,0 @@
-<% if @success %>
-$('#answer-card-<%= @id %>').remove()
-<% else %>
-alert('<%= I18n.t("admin.answer.delete_error") %>')
-<% end %>

--- a/app/views/answers/destroy.js.erb
+++ b/app/views/answers/destroy.js.erb
@@ -1,0 +1,5 @@
+<% if @success %>
+$('#answer-card-<%= @id %>').remove();
+<% else %>
+alert('<%= I18n.t("admin.answer.delete_error") %>');
+<% end %>

--- a/app/views/answers/new.coffee
+++ b/app/views/answers/new.coffee
@@ -1,5 +1,0 @@
-$('#new-answer').hide()
-$('#new-answer-field')
-  .append '<%= j render partial: "answers/new",
-                        locals: { answer: @answer,
-                                  question_id: params[:question_id].to_i } %>'

--- a/app/views/answers/new.js.erb
+++ b/app/views/answers/new.js.erb
@@ -1,0 +1,3 @@
+$('#new-answer').hide();
+$('#new-answer-field')
+  .append('<%= j render partial: "answers/new", locals: { answer: @answer, question_id: params[:question_id].to_i } %>');

--- a/app/views/assignments/cancel_new.coffee
+++ b/app/views/assignments/cancel_new.coffee
@@ -1,5 +1,0 @@
-$('.assignmentRow[data-id="0"]').remove()
-<% if @none_left %>
-$('#assignmentListHeader').hide()
-<% end %>
-$('#newAssignmentButton').show()

--- a/app/views/assignments/cancel_new.js.erb
+++ b/app/views/assignments/cancel_new.js.erb
@@ -1,0 +1,5 @@
+$('.assignmentRow[data-id="0"]').remove();
+<% if @none_left %>
+$('#assignmentListHeader').hide();
+<% end %>
+$('#newAssignmentButton').show();

--- a/app/views/divisions/edit.coffee
+++ b/app/views/divisions/edit.coffee
@@ -1,5 +1,0 @@
-$('#genericModalLabel').empty().append('<h5><%= t("admin.division.edit") %></h5>')
-$('#generic-modal-content').empty()
-	.append('<%= j render partial: "divisions/edit/edit",
-												locals: { division: @division } %>')
-$('#genericModal').modal('show')

--- a/app/views/divisions/edit.js.erb
+++ b/app/views/divisions/edit.js.erb
@@ -1,0 +1,4 @@
+$('#genericModalLabel').empty().append('<h5><%= t("admin.division.edit") %></h5>');
+$('#generic-modal-content').empty()
+  .append('<%= j render partial: "divisions/edit/edit", locals: { division: @division } %>');
+$('#genericModal').modal('show');

--- a/app/views/divisions/new.coffee
+++ b/app/views/divisions/new.coffee
@@ -1,5 +1,0 @@
-$('#genericModalLabel').empty().append('<h5><%= t("admin.division.new") %></h5>')
-$('#generic-modal-content').empty()
-	.append('<%= j render partial: "divisions/edit/edit",
-												locals: { division: @division } %>')
-$('#genericModal').modal('show')

--- a/app/views/divisions/new.js.erb
+++ b/app/views/divisions/new.js.erb
@@ -1,0 +1,4 @@
+$('#genericModalLabel').empty().append('<h5><%= t("admin.division.new") %></h5>');
+$('#generic-modal-content').empty()
+  .append('<%= j render partial: "divisions/edit/edit", locals: { division: @division } %>');
+$('#genericModal').modal('show');

--- a/app/views/media/destination_warning.coffee
+++ b/app/views/media/destination_warning.coffee
@@ -1,5 +1,0 @@
-$('#quarantineDestinations')
-  .empty().append('<%= j render partial: "media/added_to_quarantine",
-                        locals: { destinations: @quarantine_added } %>')
-# display destination warning modal
-$('#destinationWarningModal').modal('show')

--- a/app/views/media/destination_warning.js.erb
+++ b/app/views/media/destination_warning.js.erb
@@ -1,0 +1,4 @@
+$('#quarantineDestinations')
+  .empty().append('<%= j render partial: "media/added_to_quarantine", locals: { destinations: @quarantine_added } %>');
+// display destination warning modal
+$('#destinationWarningModal').modal('show');

--- a/app/views/media/remove_screenshot.coffee
+++ b/app/views/media/remove_screenshot.coffee
@@ -1,4 +1,0 @@
-# clean up
-$('#screenshot-area').empty()
-$('#remove-screenshot').hide()
-$('#export-screenshot').hide()

--- a/app/views/media/remove_screenshot.js.erb
+++ b/app/views/media/remove_screenshot.js.erb
@@ -1,0 +1,4 @@
+// clean up
+$('#screenshot-area').empty();
+$('#remove-screenshot').hide();
+$('#export-screenshot').hide();

--- a/app/views/media/update_tags.coffee
+++ b/app/views/media/update_tags.coffee
@@ -1,5 +1,0 @@
-$('#edit_tag_form').hide()
-$('#mediumActions').show()
-$('.mediumTags[data-medium="<%= @medium.id %>"]')
-  .empty().append('<%= j render partial: "tags/short_list",
-                                locals: { tags: @medium.tags } %>')

--- a/app/views/media/update_tags.js.erb
+++ b/app/views/media/update_tags.js.erb
@@ -1,0 +1,4 @@
+$('#edit_tag_form').hide();
+$('#mediumActions').show();
+$('.mediumTags[data-medium="<%= @medium.id %>"]')
+  .empty().append('<%= j render partial: "tags/short_list", locals: { tags: @medium.tags } %>');

--- a/app/views/programs/edit.coffee
+++ b/app/views/programs/edit.coffee
@@ -1,5 +1,0 @@
-$('#genericModalLabel').empty().append('<h5><%= t("admin.program.edit") %></h5>')
-$('#generic-modal-content').empty()
-	.append('<%= j render partial: "programs/edit/edit",
-												locals: { program: @program } %>')
-$('#genericModal').modal('show')

--- a/app/views/programs/edit.js.erb
+++ b/app/views/programs/edit.js.erb
@@ -1,0 +1,4 @@
+$('#genericModalLabel').empty().append('<h5><%= t("admin.program.edit") %></h5>');
+$('#generic-modal-content').empty()
+  .append('<%= j render partial: "programs/edit/edit", locals: { program: @program } %>');
+$('#genericModal').modal('show');

--- a/app/views/programs/new.coffee
+++ b/app/views/programs/new.coffee
@@ -1,5 +1,0 @@
-$('#genericModalLabel').empty().append('<h5><%= t("admin.program.new") %></h5>')
-$('#generic-modal-content').empty()
-	.append('<%= j render partial: "programs/edit/edit",
-												locals: { program: @program } %>')
-$('#genericModal').modal('show')

--- a/app/views/programs/new.js.erb
+++ b/app/views/programs/new.js.erb
@@ -1,0 +1,4 @@
+$('#genericModalLabel').empty().append('<h5><%= t("admin.program.new") %></h5>');
+$('#generic-modal-content').empty()
+  .append('<%= j render partial: "programs/edit/edit", locals: { program: @program } %>');
+$('#genericModal').modal('show');

--- a/app/views/quiz_certificates/claim.coffee
+++ b/app/views/quiz_certificates/claim.coffee
@@ -1,4 +1,0 @@
-$('#quizCertificateArea').empty()
-  .append('<%= j render partial: "quiz_certificates/claim",
-                        locals: { certificate: @certificate } %>')
-initBootstrapPopovers()

--- a/app/views/quiz_certificates/claim.js.erb
+++ b/app/views/quiz_certificates/claim.js.erb
@@ -1,0 +1,3 @@
+$('#quizCertificateArea').empty()
+  .append('<%= j render partial: "quiz_certificates/claim", locals: { certificate: @certificate } %>');
+initBootstrapPopovers();

--- a/app/views/readers/update_all.coffee
+++ b/app/views/readers/update_all.coffee
@@ -1,5 +1,0 @@
-$('.readerItem').remove()
-$('.mediaCommentsDecoration').remove()
-$('#mediaCommentsSize').empty().append('(0)').data('size', 0)
-$('#commentsIcon').removeClass('new-comment')
-$('#noCommentsAlert').show()

--- a/app/views/readers/update_all.js.erb
+++ b/app/views/readers/update_all.js.erb
@@ -1,0 +1,5 @@
+$('.readerItem').remove();
+$('.mediaCommentsDecoration').remove();
+$('#mediaCommentsSize').empty().append('(0)').data('size', 0);
+$('#commentsIcon').removeClass('new-comment');
+$('#noCommentsAlert').show();

--- a/app/views/subjects/edit.coffee
+++ b/app/views/subjects/edit.coffee
@@ -1,5 +1,0 @@
-$('#genericModalLabel').empty().append('<h5><%= t("admin.subject.edit") %></h5>')
-$('#generic-modal-content').empty()
-	.append('<%= j render partial: "subjects/edit/edit",
-												locals: { subject: @subject } %>')
-$('#genericModal').modal('show')

--- a/app/views/subjects/edit.js.erb
+++ b/app/views/subjects/edit.js.erb
@@ -1,0 +1,4 @@
+$('#genericModalLabel').empty().append('<h5><%= t("admin.subject.edit") %></h5>');
+$('#generic-modal-content').empty()
+  .append('<%= j render partial: "subjects/edit/edit", locals: { subject: @subject } %>');
+$('#genericModal').modal('show');

--- a/app/views/subjects/new.coffee
+++ b/app/views/subjects/new.coffee
@@ -1,5 +1,0 @@
-$('#genericModalLabel').empty().append('<h5><%= t("admin.subject.new") %></h5>')
-$('#generic-modal-content').empty()
-	.append('<%= j render partial: "subjects/edit/edit",
-												locals: { subject: @subject } %>')
-$('#genericModal').modal('show')

--- a/app/views/subjects/new.js.erb
+++ b/app/views/subjects/new.js.erb
@@ -1,0 +1,4 @@
+$('#genericModalLabel').empty().append('<h5><%= t("admin.subject.new") %></h5>');
+$('#generic-modal-content').empty()
+  .append('<%= j render partial: "subjects/edit/edit", locals: { subject: @subject } %>');
+$('#genericModal').modal('show');

--- a/app/views/submissions/enter_code.coffee
+++ b/app/views/submissions/enter_code.coffee
@@ -1,6 +1,0 @@
-$('.submissionMain[data-id="<%= @assignment.id %>"]').empty()
-  .append('<%= j render partial: "submissions/join",
-                        locals: { assignment: @assignment } %>')
-$('.submissionFooter[data-id!="<%= @assignment.id %>"] .btn')
-  .prop('disabled', true).removeClass('btn-outline-primary')
-  .removeClass('btn-outline-danger').addClass('btn-outline-secondary')

--- a/app/views/submissions/enter_code.js.erb
+++ b/app/views/submissions/enter_code.js.erb
@@ -1,0 +1,5 @@
+$('.submissionMain[data-id="<%= @assignment.id %>"]').empty()
+  .append('<%= j render partial: "submissions/join", locals: { assignment: @assignment } %>');
+$('.submissionFooter[data-id!="<%= @assignment.id %>"] .btn')
+  .prop('disabled', true).removeClass('btn-outline-primary')
+  .removeClass('btn-outline-danger').addClass('btn-outline-secondary');

--- a/app/views/tutorials/cancel_new.coffee
+++ b/app/views/tutorials/cancel_new.coffee
@@ -1,5 +1,0 @@
-$('.tutorialRow[data-id="0"]').remove()
-<% if @none_left %>
-$('#tutorialListHeader').hide()
-<% end %>
-$('#newTutorialButton').show()

--- a/app/views/tutorials/cancel_new.js.erb
+++ b/app/views/tutorials/cancel_new.js.erb
@@ -1,0 +1,5 @@
+$('.tutorialRow[data-id="0"]').remove();
+<% if @none_left %>
+$('#tutorialListHeader').hide();
+<% end %>
+$('#newTutorialButton').show();

--- a/app/views/tutorials/edit.coffee
+++ b/app/views/tutorials/edit.coffee
@@ -1,5 +1,0 @@
-$('.tutorialRow[data-id="<%= @tutorial.id %>"')
-  .replaceWith('<%= j render partial: "tutorials/form",
-                      locals: { tutorial: @tutorial } %>')
-
-fillOptionsByAjax($('#tutorial_tutor_ids_<%= @tutorial.id %>'))

--- a/app/views/tutorials/edit.js.erb
+++ b/app/views/tutorials/edit.js.erb
@@ -1,0 +1,4 @@
+$('.tutorialRow[data-id="<%= @tutorial.id %>"')
+  .replaceWith('<%= j render partial: "tutorials/form", locals: { tutorial: @tutorial } %>');
+
+fillOptionsByAjax($('#tutorial_tutor_ids_<%= @tutorial.id %>'));

--- a/app/views/tutorials/new.coffee
+++ b/app/views/tutorials/new.coffee
@@ -1,5 +1,0 @@
-$('#newTutorialButton').hide()
-$('#tutorialListHeader').show()
-  .after('<%= j render partial: "tutorials/form",
-                       locals: { tutorial: @tutorial } %>')
-fillOptionsByAjax($('#tutorial_tutor_ids_'))

--- a/app/views/tutorials/new.js.erb
+++ b/app/views/tutorials/new.js.erb
@@ -1,0 +1,4 @@
+$('#newTutorialButton').hide();
+$('#tutorialListHeader').show()
+  .after('<%= j render partial: "tutorials/form", locals: { tutorial: @tutorial } %>');
+fillOptionsByAjax($('#tutorial_tutor_ids_'));

--- a/app/views/users/elevate.coffee
+++ b/app/views/users/elevate.coffee
@@ -1,4 +1,0 @@
-# clear selection in generic user dropdown after one user has been elevated
-# to admin
-userSelectize = document.getElementById('generic_user_id').tomselect
-userSelectize.clear()

--- a/app/views/users/elevate.js.erb
+++ b/app/views/users/elevate.js.erb
@@ -1,0 +1,4 @@
+// clear selection in generic user dropdown after one user has been elevated
+// to admin
+var userSelectize = document.getElementById('generic_user_id').tomselect;
+userSelectize.clear();

--- a/coffee.TODO
+++ b/coffee.TODO
@@ -70,29 +70,31 @@ D3 ./app/views/lectures/render_sidebar.coffee (not actually used anymore:
     was added 6 years ago, that's why I think it's safe to delete it. The sidebar
     renders correctly without it.)
 
+4 ./app/frontend/js/file_upload.coffee -> ./app/frontend/js/file_upload.js
+4 ./app/views/assignments/cancel_new.coffee -> ./app/views/assignments/cancel_new.js.erb
+4 ./app/views/divisions/edit.coffee -> ./app/views/divisions/edit.js.erb
+4 ./app/views/divisions/new.coffee -> ./app/views/divisions/new.js.erb
+4 ./app/views/media/remove_screenshot.coffee -> ./app/views/media/remove_screenshot.js.erb
+4 ./app/views/media/update_tags.coffee -> ./app/views/media/update_tags.js.erb
+4 ./app/views/programs/edit.coffee -> ./app/views/programs/edit.js.erb
+4 ./app/views/programs/new.coffee -> ./app/views/programs/new.js.erb
+4 ./app/views/quiz_certificates/claim.coffee -> ./app/views/quiz_certificates/claim.js.erb
+4 ./app/views/readers/update_all.coffee -> ./app/views/readers/update_all.js.erb
+
+4 ./app/views/subjects/edit.coffee -> ./app/views/subjects/edit.js.erb
+4 ./app/views/subjects/new.coffee -> ./app/views/subjects/new.js.erb
+4 ./app/views/tutorials/cancel_new.coffee -> ./app/views/tutorials/cancel_new.js.erb
+4 ./app/views/users/elevate.coffee -> ./app/views/users/elevate.js.erb
+
+5 ./app/views/answers/destroy.coffee -> ./app/views/answers/destroy.js.erb
+5 ./app/views/answers/new.coffee -> ./app/views/answers/new.js.erb
+5 ./app/views/media/destination_warning.coffee -> ./app/views/media/destination_warning.js.erb
+5 ./app/views/submissions/enter_code.coffee -> ./app/views/submissions/enter_code.js.erb
+5 ./app/views/tutorials/edit.coffee -> ./app/views/tutorials/edit.js.erb
+5 ./app/views/tutorials/new.coffee -> ./app/views/tutorials/new.js.erb
+
 
 ### 😐 TODO
-4 ./app/assets/javascripts/file_upload.coffee
-4 ./app/views/assignments/cancel_new.coffee
-4 ./app/views/divisions/edit.coffee
-4 ./app/views/divisions/new.coffee
-4 ./app/views/media/remove_screenshot.coffee
-4 ./app/views/media/update_tags.coffee
-4 ./app/views/programs/edit.coffee
-4 ./app/views/programs/new.coffee
-4 ./app/views/quiz_certificates/claim.coffee
-4 ./app/views/readers/update_all.coffee
-4 ./app/views/subjects/edit.coffee
-4 ./app/views/subjects/new.coffee
-4 ./app/views/tutorials/cancel_new.coffee
-4 ./app/views/users/elevate.coffee
-
-5 ./app/views/answers/destroy.coffee
-5 ./app/views/answers/new.coffee
-5 ./app/views/media/destination_warning.coffee
-5 ./app/views/submissions/enter_code.coffee
-5 ./app/views/tutorials/edit.coffee
-5 ./app/views/tutorials/new.coffee
 5 ./app/views/watchlists/new.coffee
 
 6 ./app/views/announcements/create.coffee


### PR DESCRIPTION
Hey! I was bored and checking out MaMpf, and I saw coffee.TODO and noticed there are still a lot of legacy CoffeeScript files. I figured I'd try to help out a bit, so I went ahead and converted 20 of them to JS/JS.erb. I did the ones mentioned in the issue plus the next batch from the list, and updated coffee.TODO to mark them as done.

I'm not part of the team and I don't really expect this to be added immediately, but I thought I'd send it over in case it saves you some time. Let me know if I should change anything!

**Summary of Changes:**

1.     Converted 10 files explicitly requested.
2.     Converted 10 additional files from the coffee.TODO list (priority groups 4 and 5).
3.     Updated coffee.TODO to move the converted files to the DONE section and documented the new file paths.

**List of Converted Files:**

1.     app/frontend/js/file_upload.coffee -> .js
2.     app/views/assignments/cancel_new.coffee -> .js.erb
3.     app/views/divisions/edit.coffee -> .js.erb
4.     app/views/divisions/new.coffee -> .js.erb
5.     app/views/media/remove_screenshot.coffee -> .js.erb
6.     app/views/media/update_tags.coffee -> .js.erb
7.     app/views/programs/edit.coffee -> .js.erb
8.     app/views/programs/new.coffee -> .js.erb
9.     app/views/quiz_certificates/claim.coffee -> .js.erb
10.     app/views/readers/update_all.coffee -> .js.erb
11.     app/views/subjects/edit.coffee -> .js.erb
12.     app/views/subjects/new.coffee -> .js.erb
13.     app/views/tutorials/cancel_new.coffee -> .js.erb
14.     app/views/users/elevate.coffee -> .js.erb
15.     app/views/answers/destroy.coffee -> .js.erb
16.     app/views/answers/new.coffee -> .js.erb
17.     app/views/media/destination_warning.coffee -> .js.erb
18.     app/views/submissions/enter_code.coffee -> .js.erb
19.     app/views/tutorials/edit.coffee -> .js.erb
20.     app/views/tutorials/new.coffee -> .js.erb
