### PR TITLE
Add 'created at' field to CSV export for questionnaire answers

### DIFF
--- a/app/models/vignettes/csv_handler.rb
+++ b/app/models/vignettes/csv_handler.rb
@@ -19,7 +19,7 @@ module Vignettes
     def self.answer_data(answer)
       data = [
         answer.id,
-        answer.created_at.strftime("%Y-%m-%d"),
+        answer.created_at.strftime("%Y-%m-%d %H:%M"),
         Codename.user_codename(answer.user_answer.user, answer.user_answer.questionnaire.lecture),
         answer.slide.position,
         answer.slide.title,


### PR DESCRIPTION
The persons studying vignettes want to have information on when the vignettes were called in the csv file. I add this info in this PR.