### PR TITLE
Architecture book: Introduce lecture roster superset principle

### DIFF
--- a/architecture/src/features/02-registration.md
+++ b/architecture/src/features/02-registration.md
@@ -59,20 +59,20 @@ We use a unified system with:
 
 We recommend that users follow one of these patterns:
 
-### Pattern 1: The "Group Track" (almost like MÜSLI)
+### Pattern 1: The "Group Track"
 Use this when your lecture has groups (Tutorials or Talks).
 - **Primary Campaign:** "Group Registration" (Items: All Tutorials/Talks).
 - **Secondary Campaign (Optional):** "Special Groups" (Item: Cohort "Repeaters").
-- **Roster Logic:** The Lecture Roster is the **union** of all Group members and Cohort members.
+- **Roster Logic:** Materialization into groups automatically propagates users to the Lecture Roster.
 
-### Pattern 2: The "Enrollment Track
+### Pattern 2: The "Enrollment Track"
 Use this when your lecture has no groups (e.g., Advanced Lecture).
 - **Primary Campaign:** "Course Enrollment" (Item: The Lecture itself).
-- **Roster Logic:** The Lecture Roster is the list of registered students.
+- **Roster Logic:** The Lecture Roster is populated directly by this campaign.
 
-### Pattern 3: The "Mixed Track" (Discouraged)
-It is possible to have both a "Group Registration" and a "Course Enrollment" campaign active simultaneously.
-- **Implication:** This creates separate rosters. A student might be in a group but fail to register for the lecture.
+> **Note:** These tracks can be combined. Running both creates a Superset Roster where group members are strictly a subset of the lecture enrollment.
+
+
 
 
 ## Registration::Campaign (ActiveRecord Model)

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -172,15 +172,26 @@ Registration — Step 5: Roster Maintenance
 ```
 
 ```admonish example "PR-5.1 — Roster maintenance UI (admin)"
-- Scope: Post-allocation roster management.
+- Scope: Post-allocation roster management for Sub-Groups (Tutorial/Cohort).
 - Controllers: `Roster::MaintenanceController` (move/add/remove actions).
-- Logic: Support `Lecture` and `Cohort` as rosterable types.
-- UI: Roster Overview with candidates panel (unassigned users from completed campaign); Detail view for individual roster with capacity checks; "Enrollment" tab for Lecture roster; "Cohorts" tab if cohorts exist.
+- Logic: Support `Tutorial`, `Talk` and `Cohort` as rosterable types.
+- UI: Roster Overview with detail views for individual groups; candidates panel (unassigned users from campaign); basic capacity enforcement.
 - Refs: [Roster maintenance](03-rosters.md#roster-maintenance)
-- Acceptance: Teachers can move students between rosters; capacity enforced; candidates panel lists unassigned users; manual add/remove actions work; Lecture/Cohort rosters viewable/editable.
+- Acceptance: Teachers can move students between tutorials/talks/cohorts; capacity enforced; candidates panel lists unassigned users; manual add/remove works for groups.
 ```
 
-```admonish example "PR-5.2 — Tutor abilities (read-only roster access)"
+```admonish example "PR-5.2 — Lecture Roster Superset (Enrollment Track)"
+- Scope: Implement Lecture Roster as the superset of all sub-groups.
+- Backend:
+  - Implement `Lecture#ensure_roster_membership!`.
+  - Update `Tutorial/Talk/Cohort#materialize_allocation!` to propagate users to Lecture.
+  - Update `Roster::MaintenanceService` to handle Enrollment/Drop logic (cascading delete).
+- UI: "Enrollment" tab in `RosterOverviewComponent` showing all lecture members; "Unassigned" status calculation.
+- Refs: [Superset Model](03-rosters.md#the-core-concept-lecture-roster-as-superset), [Enrollment Track](03-rosters.md#b-the-enrollment-track)
+- Acceptance: Adding user to tutorial adds them to lecture; Removing from lecture removes from tutorial; Enrollment tab lists all students.
+```
+
+```admonish example "PR-5.3 — Tutor abilities (read-only roster access)"
 - Scope: Tutors can view rosters for their assigned groups.
 - Abilities: Update CanCanCan to allow read-only roster access for tutors.
 - UI: Tutors see Detail view without edit actions.
@@ -188,7 +199,7 @@ Registration — Step 5: Roster Maintenance
 - Acceptance: Tutors can view rosters for their tutorials; cannot edit; exams do not show candidates panel.
 ```
 
-```admonish example "PR-5.3 — Manual add student (from candidates or arbitrary)"
+```admonish example "PR-5.4 — Manual add student (from candidates or arbitrary)"
 - Scope: Add students to rosters manually.
 - Controllers: Extend `Roster::MaintenanceController` with `add_student` action.
 - UI: "Add student" button on Overview; search input for arbitrary student addition.
@@ -196,7 +207,7 @@ Registration — Step 5: Roster Maintenance
 - Acceptance: Teachers can add students from candidates or search; capacity enforced; duplicate prevention.
 ```
 
-```admonish example "PR-5.4 — Integrity job (assigned/allocated reconciliation)"
+```admonish example "PR-5.5 — Integrity job (assigned/allocated reconciliation)"
 - Scope: Background job to verify roster consistency.
 - Job: `AllocatedAssignedMatchJob` compares `Item#assigned_users` with `Registerable#allocated_user_ids`.
 - Monitoring: Logs mismatches for admin review.


### PR DESCRIPTION
In this PR, we are introducing a "Lecture Roster as Superset" principle to simplify how we track student participation.

Essentially, the Lecture Roster acts as the single source of truth for all students involved in a course. Whenever a student is added to any sub-group—like a Tutorial, Cohort, or Talk—they are automatically and immediately added to the main Lecture Roster. Conversely, if a student is removed from a sub-group, they remain on the Lecture Roster as "Unassigned", but removing them from the Lecture Roster cascades down to remove them from all sub-groups. This ensures that Members(Lecture) always contains everyone, regardless of their specific group assignment.

After having worked on 5.1 for a while, this emerged as a good solution.