### PR TITLE
Fix Playwright global beforeEach hook

### DIFF
--- a/e2e/_support/fixtures.ts
+++ b/e2e/_support/fixtures.ts
@@ -27,12 +27,9 @@ export * from "@playwright/test";
 export const test = base.extend<MaMpfFixtures>({
   // https://playwright.dev/docs/test-fixtures#adding-global-beforeeachaftereach-hooks
   _forEachTest: [
-    async ({ browser }, use) => {
+    async ({ request }, use) => {
       // Clean database before every test (brutal, but effective for good test isolation)
-      const browserContext = await browser.newContext();
-      await callBackend(browserContext.request, "database_cleaner", {});
-      await browserContext.close();
-
+      await callBackend(request, "database_cleaner", {});
       await use([]);
     }, { auto: true },
   ],


### PR DESCRIPTION
In CI/CD, Playwright tests were consistently failing. This was due to the database cleaner hook not being called. To fix it, we switch to a Playwright [**auto fixture**](https://playwright.dev/docs/test-fixtures#adding-global-beforeeachaftereach-hooks) that runs for every test.