### PR TITLE
Muesli: PR 5.8 - Roster superset checker worker

### DIFF
--- a/app/models/rosters/roster_superset_checker.rb
+++ b/app/models/rosters/roster_superset_checker.rb
@@ -1,0 +1,111 @@
+module Rosters
+  class RosterSupersetChecker
+    class RosterSupersetViolationError < StandardError; end
+
+    def check_all_lectures!
+      Rails.logger.info("[RosterSupersetChecker] Starting nightly check")
+
+      total_lectures = 0
+      total_violations = 0
+
+      Lecture.find_each do |lecture|
+        total_lectures += 1
+
+        lecture_ids = lecture_user_ids(lecture)
+        group_ids = propagating_group_user_ids(lecture)
+
+        violations = find_violations(lecture, lecture_ids, group_ids)
+
+        if violations.any?
+          total_violations += violations.size
+          log_violation(lecture, violations)
+        end
+      end
+
+      Rails.logger.info("[RosterSupersetChecker] Completed: " \
+                        "checked #{total_lectures} lectures, " \
+                        "found #{total_violations} violations")
+
+      return unless total_violations.positive?
+
+      raise(RosterSupersetViolationError,
+            "Found #{total_violations} roster superset violations across " \
+            "#{total_lectures} lectures. Check logs for details.")
+    end
+
+    private
+
+      def lecture_user_ids(lecture)
+        lecture.lecture_memberships.pluck(:user_id).uniq
+      end
+
+      def propagating_group_user_ids(lecture)
+        tutorial_ids = TutorialMembership
+                       .joins(:tutorial)
+                       .where(tutorials: { lecture_id: lecture.id })
+                       .pluck(:user_id)
+
+        cohort_ids = CohortMembership
+                     .joins(:cohort)
+                     .where(cohorts: { context_type: "Lecture",
+                                       context_id: lecture.id,
+                                       propagate_to_lecture: true })
+                     .pluck(:user_id)
+
+        (tutorial_ids + cohort_ids).uniq
+      end
+
+      def find_violations(lecture, lecture_ids, group_ids)
+        missing_ids = group_ids - lecture_ids
+        return [] if missing_ids.empty?
+
+        missing_ids.map do |user_id|
+          user = User.find_by(id: user_id)
+          groups = find_user_groups(lecture, user_id)
+
+          {
+            user_id: user_id,
+            user_email: user&.email || "Unknown",
+            found_in_groups: groups
+          }
+        end
+      end
+
+      def find_user_groups(lecture, user_id)
+        groups = lecture.tutorials.joins(:tutorial_memberships)
+                        .where(tutorial_memberships: { user_id: user_id }).map do |t|
+          "Tutorial: #{t.title}"
+        end
+
+        lecture.cohorts.where(propagate_to_lecture: true)
+               .joins(:cohort_memberships)
+               .where(cohort_memberships: { user_id: user_id }).find_each do |c|
+          groups << "Cohort: #{c.title}"
+        end
+
+        groups
+      end
+
+      def log_violation(lecture, violations)
+        return if violations.empty?
+
+        log_data = {
+          timestamp: Time.current.iso8601,
+          lecture_id: lecture.id,
+          lecture_title: lecture.title,
+          violation_count: violations.size,
+          violations: violations
+        }
+
+        Rails.logger.error("[RosterSupersetViolation] #{log_data.to_json}")
+
+        Rails.logger.error("Lecture #{lecture.id} (#{lecture.title}): " \
+                           "#{violations.size} user(s) missing from roster")
+
+        violations.each do |v|
+          Rails.logger.error("  - User #{v[:user_id]} (#{v[:user_email]}): " \
+                             "in #{v[:found_in_groups].join(", ")}")
+        end
+      end
+  end
+end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -58,6 +58,12 @@ class Term < ApplicationRecord
     Term.find_by(year: previous_year, season: previous_season)
   end
 
+  def next
+    next_year = season == "SS" ? year : year + 1
+    next_season = season == "SS" ? "WS" : "SS"
+    Term.find_by(year: next_year, season: next_season)
+  end
+
   def assignments
     Assignment.where(lecture: lectures)
   end

--- a/app/workers/roster_superset_checker_job.rb
+++ b/app/workers/roster_superset_checker_job.rb
@@ -1,0 +1,12 @@
+class RosterSupersetCheckerJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default,
+                  retry: false,
+                  backtrace: true,
+                  dead: true
+
+  def perform
+    Rosters::RosterSupersetChecker.new.check_all_lectures!
+  end
+end

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -246,12 +246,13 @@ Registration — Step 5: Roster Maintenance
 - Acceptance: Students receive emails on add/remove/move; emails queued asynchronously; feature flag gates delivery; teachers can configure notification timing per lecture.
 ```
 
-```admonish example "PR-5.8 — Integrity job (assigned/allocated reconciliation)"
-- Scope: Background job to verify roster consistency.
-- Job: `AllocatedAssignedMatchJob` compares `Item#assigned_users` with `Registerable#allocated_user_ids`.
-- Monitoring: Logs mismatches for admin review.
-- Refs: [Integrity invariants](09-integrity-and-invariants.md#registration-allocation)
-- Acceptance: Job runs nightly; reports mismatches; no auto-fix (manual review required).
+```admonish example "PR-5.8 — Integrity job (lecture roster superset validation)"
+- Scope: Background job to verify lecture roster superset principle.
+- Job: `RosterSupersetCheckJob` validates that `Lecture#roster_user_ids` ⊇ (tutorials + talks + propagating cohorts).roster_user_ids.
+- Detection: Identifies users in sub-groups who are missing from lecture roster.
+- Monitoring: Logs violations for admin review; potential causes include callback failures, race conditions, or manual database edits.
+- Refs: [Superset Model](03-rosters.md#the-core-concept-lecture-roster-as-superset)
+- Acceptance: Job runs nightly; reports missing users; no auto-fix (manual review required); clear log format with lecture ID, user IDs, and affected groups.
 ```
 
 ```admonish example "PR-5.9 — Turbo Stream Orchestrator"

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -248,7 +248,7 @@ Registration — Step 5: Roster Maintenance
 
 ```admonish example "PR-5.8 — Integrity job (lecture roster superset validation)"
 - Scope: Background job to verify lecture roster superset principle.
-- Job: `RosterSupersetCheckJob` validates that `Lecture#roster_user_ids` ⊇ (tutorials + talks + propagating cohorts).roster_user_ids.
+- Job: `RosterSupersetCheckerJob` validates that `Lecture#roster_user_ids` ⊇ (tutorials + talks + propagating cohorts).roster_user_ids.
 - Detection: Identifies users in sub-groups who are missing from lecture roster.
 - Monitoring: Logs violations for admin review; potential causes include callback failures, race conditions, or manual database edits.
 - Refs: [Superset Model](03-rosters.md#the-core-concept-lecture-roster-as-superset)

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -27,6 +27,13 @@ altcha_solutions_cleaner_job:
   class: "AltchaSolutionsCleaner"
   queue: critical
 
+roster_superset_checker:
+  # at 3:00 AM, every day
+  cron: "0 3 * * *"
+  class: "RosterSupersetCheckerJob"
+  queue: default
+  description: "Validates roster superset invariant nightly"
+
 campaign_status_worker:
   cron: "*/1 * * * *"
   class: "CampaignStatusWorker"

--- a/spec/models/rosters/roster_superset_checker_spec.rb
+++ b/spec/models/rosters/roster_superset_checker_spec.rb
@@ -1,0 +1,199 @@
+require "rails_helper"
+
+RSpec.describe(Rosters::RosterSupersetChecker) do
+  subject { described_class.new }
+
+  let(:lecture) { create(:lecture) }
+
+  describe "#check_all_lectures!" do
+    context "when superset invariant holds" do
+      it "logs no violations for users in both tutorial and lecture" do
+        tutorial = create(:tutorial, lecture: lecture)
+        user = create(:user)
+
+        create(:tutorial_membership, tutorial: tutorial, user: user)
+        create(:lecture_membership, lecture: lecture, user: user)
+
+        expect(Rails.logger).not_to receive(:error)
+          .with(/RosterSupersetViolation/)
+
+        subject.check_all_lectures!
+      end
+
+      it "logs no violations for users in both propagating cohort and lecture" do
+        cohort = create(:cohort, context: lecture, propagate_to_lecture: true)
+        user = create(:user)
+
+        create(:cohort_membership, cohort: cohort, user: user)
+        create(:lecture_membership, lecture: lecture, user: user)
+
+        expect(Rails.logger).not_to receive(:error)
+          .with(/RosterSupersetViolation/)
+
+        subject.check_all_lectures!
+      end
+    end
+
+    context "when user missing from lecture roster" do
+      it "logs violation for user in tutorial but not lecture" do
+        tutorial = create(:tutorial, lecture: lecture)
+        user = create(:user)
+
+        create(:tutorial_membership, tutorial: tutorial, user: user)
+
+        expect { subject.check_all_lectures! }
+          .to raise_error(Rosters::RosterSupersetChecker::RosterSupersetViolationError,
+                          /Found 1 roster superset violations/)
+      end
+
+      it "includes user details in violation log" do
+        tutorial = create(:tutorial, lecture: lecture)
+        user = create(:user, email: "test@example.com")
+
+        create(:tutorial_membership, tutorial: tutorial, user: user)
+
+        logs = []
+        original_error = Rails.logger.method(:error)
+        allow(Rails.logger).to receive(:error) do |*args|
+          logs << args.first
+          original_error.call(*args)
+        end
+
+        expect { subject.check_all_lectures! }
+          .to raise_error(Rosters::RosterSupersetChecker::RosterSupersetViolationError)
+
+        combined_log = logs.join(" ")
+        expect(combined_log).to include(user.id.to_s)
+        expect(combined_log).to include("test@example.com")
+        expect(combined_log).to include("Tutorial: #{tutorial.title}")
+      end
+
+      it "logs violation for user in propagating cohort but not lecture" do
+        cohort = create(:cohort, context: lecture, propagate_to_lecture: true)
+        user = create(:user)
+
+        create(:cohort_membership, cohort: cohort, user: user)
+
+        expect { subject.check_all_lectures! }
+          .to raise_error(Rosters::RosterSupersetChecker::RosterSupersetViolationError)
+      end
+
+      it "reports multiple violations in single lecture" do
+        tutorial = create(:tutorial, lecture: lecture)
+        user1 = create(:user)
+        user2 = create(:user)
+
+        create(:tutorial_membership, tutorial: tutorial, user: user1)
+        create(:tutorial_membership, tutorial: tutorial, user: user2)
+
+        expect { subject.check_all_lectures! }
+          .to raise_error(Rosters::RosterSupersetChecker::RosterSupersetViolationError,
+                          /Found 2 roster superset violations/)
+      end
+    end
+
+    context "with non-propagating cohorts" do
+      it "ignores users in non-propagating cohorts" do
+        cohort = create(:cohort, context: lecture, propagate_to_lecture: false)
+        user = create(:user)
+
+        create(:cohort_membership, cohort: cohort, user: user)
+
+        expect(Rails.logger).not_to receive(:error)
+          .with(/RosterSupersetViolation/)
+
+        subject.check_all_lectures!
+      end
+
+      it "correctly identifies planning cohorts as non-propagating" do
+        cohort = create(:cohort, context: lecture, purpose: :planning,
+                                 propagate_to_lecture: false)
+        user = create(:user)
+
+        create(:cohort_membership, cohort: cohort, user: user)
+
+        expect(Rails.logger).not_to receive(:error)
+
+        subject.check_all_lectures!
+      end
+    end
+
+    context "with user in multiple groups" do
+      it "lists all groups where user is found" do
+        tutorial = create(:tutorial, lecture: lecture)
+        cohort = create(:cohort, context: lecture, propagate_to_lecture: true)
+        user = create(:user)
+
+        create(:tutorial_membership, tutorial: tutorial, user: user)
+        create(:cohort_membership, cohort: cohort, user: user)
+
+        logs = []
+        original_error = Rails.logger.method(:error)
+        allow(Rails.logger).to receive(:error) do |*args|
+          logs << args.first
+          original_error.call(*args)
+        end
+
+        expect { subject.check_all_lectures! }
+          .to raise_error(Rosters::RosterSupersetChecker::RosterSupersetViolationError)
+
+        combined_log = logs.join(" ")
+        expect(combined_log).to include("Tutorial: #{tutorial.title}")
+        expect(combined_log).to include("Cohort: #{cohort.title}")
+      end
+    end
+
+    context "with deleted users" do
+      it "handles deleted users gracefully" do
+        tutorial = create(:tutorial, lecture: lecture)
+        user = create(:user)
+
+        create(:tutorial_membership, tutorial: tutorial, user: user)
+
+        allow(User).to receive(:find_by).with(id: user.id).and_return(nil)
+
+        logs = []
+        original_error = Rails.logger.method(:error)
+        allow(Rails.logger).to receive(:error) do |*args|
+          logs << args.first
+          original_error.call(*args)
+        end
+
+        expect { subject.check_all_lectures! }
+          .to raise_error(Rosters::RosterSupersetChecker::RosterSupersetViolationError)
+
+        combined_log = logs.join(" ")
+        expect(combined_log).to include(user.id.to_s)
+        expect(combined_log).to include("Unknown")
+      end
+    end
+
+    context "with multiple lectures" do
+      it "checks all lectures" do
+        create(:lecture)
+        create(:lecture)
+
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info)
+          .with(/checked 2 lectures/)
+
+        subject.check_all_lectures!
+      end
+    end
+
+    context "when no violations exist" do
+      it "logs completion with zero violations" do
+        tutorial = create(:tutorial, lecture: lecture)
+        user = create(:user)
+
+        create(:tutorial_membership, tutorial: tutorial, user: user)
+        create(:lecture_membership, lecture: lecture, user: user)
+
+        expect(Rails.logger).to receive(:info).with(/Starting nightly check/)
+        expect(Rails.logger).to receive(:info).with(/found 0 violations/)
+
+        subject.check_all_lectures!
+      end
+    end
+  end
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -104,4 +104,36 @@ RSpec.describe(Term, type: :model) do
   #     expect(term.to_label_short).to eq('SS 17')
   #   end
   # end
+
+  describe "#next" do
+    context "when term is a summer term" do
+      it "returns the winter term of the same year" do
+        summer = create(:term, season: "SS", year: 2023)
+        winter = create(:term, season: "WS", year: 2023)
+
+        expect(summer.next).to eq(winter)
+      end
+
+      it "returns nil if next term does not exist" do
+        summer = create(:term, season: "SS", year: 2023)
+
+        expect(summer.next).to be_nil
+      end
+    end
+
+    context "when term is a winter term" do
+      it "returns the summer term of the next year" do
+        winter = create(:term, season: "WS", year: 2023)
+        next_summer = create(:term, season: "SS", year: 2024)
+
+        expect(winter.next).to eq(next_summer)
+      end
+
+      it "returns nil if next term does not exist" do
+        winter = create(:term, season: "WS", year: 2023)
+
+        expect(winter.next).to be_nil
+      end
+    end
+  end
 end

--- a/spec/workers/roster_superset_checker_job_spec.rb
+++ b/spec/workers/roster_superset_checker_job_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe(RosterSupersetCheckerJob, type: :worker) do
+  subject { described_class.new }
+
+  describe "#perform" do
+    it "delegates to Rosters::RosterSupersetChecker" do
+      checker = instance_double(Rosters::RosterSupersetChecker)
+      allow(Rosters::RosterSupersetChecker).to receive(:new).and_return(checker)
+      expect(checker).to receive(:check_all_lectures!)
+
+      subject.perform
+    end
+  end
+end


### PR DESCRIPTION
This PR (5.8 from the architecture book) implements a nightly background check for roster data integrity by checking the validity the lecture roster superset rule. It adds a `RosterSupersetChecker` model that does the validation and a `RosterSupersetCheckerJob` worker that runs daily at 3 am. The check is restricted to lectures associated to the current term and the next one. It raises a `RosterSupersetViolationError` in case violations are found.

Note that we don't check the rule for seminars because there are seminars in production in the current term that have talks with speakers but with empty lecture roster (because the lecture roster and the rule didn't exist then). This problem does not occur for tutorials because tutorials in production also don't have member yet.