### PR TITLE
Müsli PR: Only Ruby files (but no spec files)

### DIFF
--- a/app/abilities/cohort_ability.rb
+++ b/app/abilities/cohort_ability.rb
@@ -1,0 +1,14 @@
+class CohortAbility
+  include CanCan::Ability
+
+  def initialize(user)
+    clear_aliased_actions
+
+    can [:new, :create, :edit, :update, :destroy], Cohort do |cohort|
+      context = cohort.context
+      next false unless context
+
+      user.can_edit?(context)
+    end
+  end
+end

--- a/app/abilities/registration_campaign_ability.rb
+++ b/app/abilities/registration_campaign_ability.rb
@@ -1,0 +1,13 @@
+class RegistrationCampaignAbility
+  include CanCan::Ability
+
+  def initialize(user)
+    clear_aliased_actions
+
+    can [:index, :new, :create, :show, :edit, :update, :destroy, :open, :close,
+         :reopen, :check_unlimited_items, :finalize, :allocate, :view_allocation],
+        Registration::Campaign do |campaign|
+      user.can_edit?(campaign.campaignable)
+    end
+  end
+end

--- a/app/abilities/registration_item_ability.rb
+++ b/app/abilities/registration_item_ability.rb
@@ -1,0 +1,11 @@
+class RegistrationItemAbility
+  include CanCan::Ability
+
+  def initialize(user)
+    clear_aliased_actions
+
+    can [:create, :update, :destroy], Registration::Item do |item|
+      user.can_edit?(item.registration_campaign.campaignable)
+    end
+  end
+end

--- a/app/abilities/registration_policy_ability.rb
+++ b/app/abilities/registration_policy_ability.rb
@@ -1,0 +1,12 @@
+class RegistrationPolicyAbility
+  include CanCan::Ability
+
+  def initialize(user)
+    clear_aliased_actions
+
+    can [:new, :create, :edit, :update, :destroy, :move_up, :move_down],
+        Registration::Policy do |policy|
+      user.can_edit?(policy.registration_campaign.campaignable)
+    end
+  end
+end

--- a/app/abilities/registration_user_registration_ability.rb
+++ b/app/abilities/registration_user_registration_ability.rb
@@ -1,0 +1,11 @@
+class RegistrationUserRegistrationAbility
+  include CanCan::Ability
+
+  def initialize(user)
+    clear_aliased_actions
+
+    can :destroy, Registration::UserRegistration do |registration|
+      user.can_edit?(registration.registration_campaign.campaignable)
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,6 +72,18 @@ class ApplicationController < ActionController::Base
     response.headers["Expires"] = "Mon, 01 Jan 1990 00:00:00 GMT"
   end
 
+  # Helper to refresh the campaigns tab content via Turbo Stream
+  # NOTE: This should be moved to a better place once we refactor the
+  # whole streaming logic for campaigns and rosters (e.g. the StreamOrchestrator,
+  # see the docs).
+  def refresh_campaigns_index_stream(lecture)
+    return nil unless lecture
+
+    turbo_stream.update("campaigns_container",
+                        partial: "registration/campaigns/card_body_index",
+                        locals: { lecture: lecture })
+  end
+
   protected
 
     def configure_permitted_parameters

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -1,0 +1,189 @@
+class CohortsController < ApplicationController
+  helper RosterHelper
+
+  before_action :set_lecture, only: [:new, :create]
+  before_action :set_cohort, only: [:edit, :update, :destroy]
+  authorize_resource except: [:new, :create]
+
+  def current_ability
+    @current_ability ||= CohortAbility.new(current_user)
+  end
+
+  def new
+    @cohort = Cohort.new(context: @lecture)
+    @cohort.assign_attributes(cohort_params) if params[:cohort].present?
+    authorize! :new, @cohort
+    set_cohort_locale
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "modal-container",
+          partial: "cohorts/modal",
+          locals: { cohort: @cohort }
+        )
+      end
+    end
+  end
+
+  def edit
+    set_cohort_locale
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "modal-container",
+          partial: "cohorts/modal",
+          locals: { cohort: @cohort }
+        )
+      end
+    end
+  end
+
+  def create
+    cohort_attributes = cohort_params
+    cohort_attributes = parse_special_purpose_checkbox(cohort_attributes)
+
+    @cohort = Cohort.new(cohort_attributes)
+    @cohort.context = @lecture
+    authorize! :create, @cohort
+    set_cohort_locale
+
+    if @cohort.save
+      flash.now[:notice] = t("controllers.cohorts.created")
+    else
+      @errors = @cohort.errors
+    end
+
+    respond_to do |format|
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = create_turbo_streams(group_type)
+        render turbo_stream: streams, status: @cohort.persisted? ? :ok : :unprocessable_content
+      end
+    end
+  end
+
+  def update
+    set_cohort_locale
+    updated_attributes = cohort_params
+    updated_attributes = parse_special_purpose_checkbox(updated_attributes)
+
+    if @cohort.update(updated_attributes)
+      flash.now[:notice] = t("controllers.cohorts.updated")
+    else
+      @errors = @cohort.errors
+    end
+
+    respond_to do |format|
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = []
+
+        if @cohort.errors.empty?
+          streams.concat(Rosters::StreamService.new(@lecture, view_context)
+          .item_updated(@cohort,
+                        group_type: group_type, flash: flash))
+          streams << refresh_campaigns_index_stream(@cohort.lecture)
+          streams << turbo_stream.update("modal-container", "")
+        else
+          streams << turbo_stream.replace(view_context.dom_id(@cohort, "form"),
+                                          partial: "cohorts/modal_form",
+                                          locals: { cohort: @cohort })
+        end
+
+        render turbo_stream: streams, status: @cohort.errors.empty? ? :ok : :unprocessable_content
+      end
+    end
+  end
+
+  def destroy
+    set_cohort_locale
+    if @cohort.destroy
+      flash.now[:notice] = t("controllers.cohorts.destroyed")
+    else
+      flash.now[:alert] = t("controllers.cohorts.destruction_failed")
+    end
+
+    respond_to do |format|
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = Rosters::StreamService.new(@lecture, view_context).roster_changed(
+          group_type: group_type, flash: flash
+        )
+        streams << refresh_campaigns_index_stream(@cohort.lecture)
+        render turbo_stream: streams
+      end
+    end
+  end
+
+  private
+
+    def set_lecture
+      lecture_id = params[:lecture_id] || params.dig(:cohort, :lecture_id)
+      @lecture = Lecture.find_by(id: lecture_id)
+      if @lecture
+        set_cohort_locale
+      else
+        redirect_to :root, alert: I18n.t("controllers.no_lecture")
+      end
+    end
+
+    def set_cohort
+      @cohort = Cohort.find_by(id: params[:id])
+      if @cohort
+        @lecture = @cohort.lecture
+      else
+        redirect_to :root, alert: I18n.t("controllers.no_cohort")
+      end
+    end
+
+    def set_cohort_locale
+      I18n.locale = @lecture&.locale_with_inheritance || current_user.locale ||
+                    I18n.default_locale
+    end
+
+    def cohort_params
+      permitted = [:title, :capacity, :description, :purpose]
+      permitted << :propagate_to_lecture unless @cohort&.persisted?
+      params.expect(cohort: permitted)
+    end
+
+    def parse_special_purpose_checkbox(attributes)
+      propagate_value = if @cohort&.persisted?
+        @cohort.propagate_to_lecture?
+      else
+        attributes[:propagate_to_lecture] == "true"
+      end
+
+      attributes[:purpose] = if params[:has_special_purpose] == "1"
+        propagate_value ? :enrollment : :planning
+      else
+        :general
+      end
+
+      attributes
+    end
+
+    def create_turbo_streams(group_type)
+      streams = []
+      service = Rosters::StreamService.new(@lecture, view_context)
+
+      if @cohort.persisted?
+        streams.concat(service.roster_changed(group_type: group_type, flash: flash))
+        streams << refresh_campaigns_index_stream(@lecture)
+      else
+        streams << turbo_stream.replace(view_context.dom_id(@cohort, "form"),
+                                        partial: "cohorts/modal_form",
+                                        locals: { cohort: @cohort })
+      end
+      streams
+    end
+
+    def parse_group_type
+      if params[:group_type].is_a?(Array)
+        params[:group_type].map(&:to_sym)
+      else
+        params[:group_type].presence&.to_sym || :cohorts
+      end
+    end
+end

--- a/app/controllers/cypress/feature_flags_controller.rb
+++ b/app/controllers/cypress/feature_flags_controller.rb
@@ -1,0 +1,13 @@
+module Cypress
+  class FeatureFlagsController < CypressController
+    def enable
+      Flipper.enable(params[:name].to_sym)
+      render json: { name: params[:name], enabled: true }, status: :created
+    end
+
+    def disable
+      Flipper.disable(params[:name].to_sym)
+      render json: { name: params[:name], enabled: false }, status: :created
+    end
+  end
+end

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -73,12 +73,13 @@ class LecturesController < ApplicationController
   end
 
   def edit
-    if stale?(etag: @lecture,
-              last_modified: [current_user.updated_at, @lecture.updated_at,
-                              Time.zone.parse(ENV.fetch("RAILS_CACHE_ID", nil))].max)
-      eager_load_stuff
-      render template: "lectures/edit/edit"
+    eager_load_stuff
+    if params[:campaign_id]
+      @campaign = @lecture.registration_campaigns.find_by(id: params[:campaign_id])
+    elsif params[:new_campaign]
+      @new_campaign = @lecture.registration_campaigns.build
     end
+    render template: "lectures/edit/edit"
   end
 
   def create

--- a/app/controllers/registration/allocations_controller.rb
+++ b/app/controllers/registration/allocations_controller.rb
@@ -1,0 +1,112 @@
+module Registration
+  class AllocationsController < ApplicationController
+    before_action :set_campaign
+    before_action :set_locale
+
+    def current_ability
+      @current_ability ||= RegistrationCampaignAbility.new(current_user)
+    end
+
+    def show
+      authorize! :view_allocation, @campaign
+      @dashboard = Registration::AllocationDashboard.new(@campaign)
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.update("campaigns_container",
+                                                   partial: "registration/allocations/dashboard")
+        end
+      end
+    end
+
+    def create
+      authorize! :allocate, @campaign
+      if @campaign.closed? || @campaign.processing?
+        Registration::AllocationService.new(@campaign).allocate!
+        @dashboard = Registration::AllocationDashboard.new(@campaign)
+
+        respond_to do |format|
+          format.html do
+            redirect_to registration_campaign_allocation_path(@campaign),
+                        notice: t("registration.allocation.started")
+          end
+          format.turbo_stream do
+            flash.now[:notice] = t("registration.allocation.started")
+            render turbo_stream: [
+              turbo_stream.update("campaigns_container",
+                                  partial: "registration/allocations/dashboard"),
+              stream_flash
+            ]
+          end
+        end
+      else
+        respond_with_error(t("registration.allocation.errors.wrong_status"))
+      end
+    end
+
+    def finalize
+      authorize! :finalize, @campaign
+
+      guard = Registration::FinalizationGuard.new(@campaign)
+      # Allow skipping policies if 'force' param is present
+      result = guard.check(ignore_policies: params[:force] == "true")
+
+      unless result.success?
+        # Redirect to dashboard to show errors
+        redirect_to registration_campaign_allocation_path(@campaign),
+                    alert: t("registration.allocation.errors.#{result.error_code}")
+        return
+      end
+
+      if @campaign.finalize!
+        respond_with_success(t("registration.campaign.finalized"))
+      else
+        respond_with_error(@campaign.errors.full_messages.join(", "))
+      end
+    end
+
+    private
+
+      def set_campaign
+        @campaign = Registration::Campaign.find_by(id: params[:registration_campaign_id])
+        return if @campaign
+
+        respond_with_error(t("registration.campaign.not_found"), redirect_path: root_path)
+      end
+
+      def set_locale
+        I18n.locale = @campaign&.locale_with_inheritance || I18n.locale
+      end
+
+      def respond_with_success(message)
+        respond_to do |format|
+          format.html do
+            redirect_to registration_campaign_path(@campaign), notice: message
+          end
+          format.turbo_stream do
+            flash.now[:notice] = message
+            render turbo_stream: [
+              turbo_stream.update("campaigns_container",
+                                  partial: "registration/campaigns/card_body_show",
+                                  locals: { campaign: @campaign }),
+              stream_flash
+            ]
+          end
+        end
+      end
+
+      def respond_with_error(message, redirect_path: nil)
+        respond_to do |format|
+          format.html do
+            path = redirect_path || registration_campaign_path(@campaign)
+            redirect_to path, alert: message
+          end
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render turbo_stream: stream_flash
+          end
+        end
+      end
+  end
+end

--- a/app/controllers/registration/campaigns_controller.rb
+++ b/app/controllers/registration/campaigns_controller.rb
@@ -1,0 +1,257 @@
+module Registration
+  class CampaignsController < ApplicationController
+    before_action :set_lecture, only: [:index, :new, :create]
+    before_action :set_campaign, except: [:index, :new, :create]
+    before_action :set_locale
+    authorize_resource class: "Registration::Campaign", except: [:index, :new, :create]
+
+    def current_ability
+      @current_ability ||= begin
+        ability = RegistrationCampaignAbility.new(current_user)
+        # We need to merge TutorialAbility and TalkAbility because the view renders
+        # registration items which delegate permission checks to their registerables
+        # (Tutorials/Talks). Without this, can?(:destroy, item.registerable) fails.
+        ability.merge(TutorialAbility.new(current_user))
+        ability.merge(TalkAbility.new(current_user))
+        ability
+      end
+    end
+
+    def index
+      authorize! :index, Registration::Campaign.new(campaignable: @lecture)
+      @campaigns = @lecture.registration_campaigns.includes(:registration_items)
+                           .order(created_at: :desc)
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream do
+          render_card_body("registration/campaigns/card_body_index", lecture: @lecture)
+        end
+      end
+    end
+
+    def show
+      respond_to do |format|
+        format.html
+        format.turbo_stream do
+          render_card_body("registration/campaigns/card_body_show", campaign: @campaign)
+        end
+      end
+    end
+
+    def new
+      @campaign = @lecture.registration_campaigns.build
+      authorize! :new, @campaign
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream do
+          render_card_body("registration/campaigns/card_body_form",
+                           campaign: @campaign, lecture: @lecture)
+        end
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+        format.turbo_stream do
+          render_card_body("registration/campaigns/card_body_form",
+                           campaign: @campaign, lecture: @campaign.campaignable)
+        end
+      end
+    end
+
+    def create
+      @campaign = @lecture.registration_campaigns.build(campaign_params)
+      authorize! :create, @campaign
+
+      if @campaign.save
+        respond_with_success(t("registration.campaign.created"), tab: "items")
+      else
+        respond_with_form_error(t("registration.campaign.create_failed"), :new)
+      end
+    end
+
+    def update
+      if @campaign.update(campaign_params)
+        respond_with_success(t("registration.campaign.updated"))
+      else
+        respond_with_form_error(t("registration.campaign.update_failed"), :edit)
+      end
+    end
+
+    def destroy
+      unless @campaign.can_be_deleted?
+        respond_with_error(t("registration.campaign.cannot_delete"))
+        return
+      end
+
+      lecture = @campaign.campaignable
+
+      if @campaign.destroy
+        respond_with_destroy_success(lecture)
+      else
+        respond_with_error(@campaign.errors.full_messages.join(", "))
+      end
+    end
+
+    def open
+      update_status(:open, t("registration.campaign.opened"))
+    end
+
+    def close
+      attributes = { status: :closed }
+      if @campaign.registration_deadline > Time.current
+        attributes[:registration_deadline] = Time.current
+      end
+
+      if @campaign.update(attributes)
+        respond_with_success(t("registration.campaign.closed"))
+      else
+        respond_with_error(@campaign.errors.full_messages.join(", "))
+      end
+    end
+
+    def reopen
+      if @campaign.processing? || @campaign.completed?
+        respond_with_error(t("registration.campaign.cannot_reopen_allocated"))
+        return
+      end
+
+      update_status(:open, t("registration.campaign.reopened"))
+    end
+
+    def check_unlimited_items
+      has_unlimited = @campaign.registration_items.any? { |i| i.capacity.nil? }
+
+      respond_to do |format|
+        format.json { render json: { has_unlimited_items: has_unlimited } }
+      end
+    end
+
+    private
+
+      def set_lecture
+        @lecture = Lecture.find_by(id: params[:lecture_id])
+        return if @lecture
+
+        respond_with_error(t("registration.campaign.lecture_not_found"),
+                           redirect_path: root_path)
+      end
+
+      def set_campaign
+        @campaign = Registration::Campaign.find_by(id: params[:id])
+        return if @campaign
+
+        respond_with_error(t("registration.campaign.not_found"),
+                           redirect_path: root_path)
+      end
+
+      def set_locale
+        I18n.locale = @campaign&.locale_with_inheritance ||
+                      @lecture&.locale_with_inheritance ||
+                      I18n.locale
+      end
+
+      def campaign_params
+        params.expect(
+          registration_campaign: [:description, :allocation_mode,
+                                  :registration_deadline]
+        )
+      end
+
+      def update_status(status, success_message)
+        if @campaign.update(status: status)
+          respond_with_success(success_message)
+        else
+          respond_with_error(@campaign.errors.full_messages.join(", "))
+        end
+      end
+
+      def render_card_body(partial, locals)
+        render turbo_stream: turbo_stream.update("campaigns_container",
+                                                 partial: partial,
+                                                 locals: locals)
+      end
+
+      def render_turbo_update(partial, locals)
+        lecture = locals[:lecture] || @lecture || @campaign&.campaignable
+        streams = [
+          turbo_stream.update("campaigns_container", partial: partial, locals: locals),
+          stream_flash
+        ]
+        streams += refresh_roster_streams(lecture)
+        render turbo_stream: streams.compact
+      end
+
+      def refresh_roster_streams(lecture)
+        return [] unless lecture
+
+        group_type = view_context.roster_group_types(lecture)
+        frame_id = view_context.roster_maintenance_frame_id(group_type)
+
+        [
+          turbo_stream.replace(frame_id,
+                               view_context.turbo_frame_tag(frame_id,
+                                                            src: view_context.lecture_roster_path(
+                                                              lecture, group_type: group_type
+                                                            ),
+                                                            loading: "lazy"))
+        ]
+      end
+
+      def respond_with_success(message, tab: nil)
+        respond_to do |format|
+          format.html do
+            redirect_to registration_campaign_path(@campaign, tab: tab), notice: message
+          end
+          format.turbo_stream do
+            flash.now[:notice] = message
+            render_turbo_update("registration/campaigns/card_body_show",
+                                campaign: @campaign, tab: tab)
+          end
+        end
+      end
+
+      def respond_with_destroy_success(lecture)
+        message = t("registration.campaign.destroyed")
+        respond_to do |format|
+          format.html do
+            redirect_to lecture_registration_campaigns_path(lecture),
+                        notice: message
+          end
+          format.turbo_stream do
+            flash.now[:notice] = message
+            render_turbo_update("registration/campaigns/card_body_index",
+                                lecture: lecture)
+          end
+        end
+      end
+
+      def respond_with_form_error(message, action)
+        respond_to do |format|
+          format.html { render action, status: :unprocessable_content }
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render_turbo_update("registration/campaigns/card_body_form",
+                                campaign: @campaign,
+                                lecture: @campaign.campaignable)
+          end
+        end
+      end
+
+      def respond_with_error(message, redirect_path: nil)
+        respond_to do |format|
+          format.html do
+            path = redirect_path || registration_campaign_path(@campaign)
+            redirect_to path, alert: message
+          end
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render turbo_stream: stream_flash
+          end
+        end
+      end
+  end
+end

--- a/app/controllers/registration/items_controller.rb
+++ b/app/controllers/registration/items_controller.rb
@@ -1,0 +1,192 @@
+module Registration
+  class ItemsController < ApplicationController
+    helper RosterHelper
+    before_action :set_campaign
+    before_action :set_locale
+    before_action :set_item, only: [:destroy, :update]
+    authorize_resource class: "Registration::Item", except: [:create]
+
+    def current_ability
+      @current_ability ||= begin
+        ability = RegistrationItemAbility.new(current_user)
+        # We need to merge TutorialAbility and TalkAbility because the view renders
+        # registration items which delegate permission checks to their registerables
+        # (Tutorials/Talks). Without this, can?(:destroy, item.registerable) fails.
+        ability.merge(TutorialAbility.new(current_user))
+        ability.merge(TalkAbility.new(current_user))
+        ability.merge(CohortAbility.new(current_user))
+        ability
+      end
+    end
+
+    def create
+      create_existing_item
+    end
+
+    def update
+      if @item.update(capacity_params)
+        respond_to do |format|
+          format.html do
+            redirect_to after_action_path,
+                        notice: t("registration.item.updated")
+          end
+          format.turbo_stream do
+            flash.now[:notice] = t("registration.item.updated")
+            streams = [
+              turbo_stream.replace(@item, partial: "registration/items/item",
+                                          locals: { item: @item }),
+              stream_flash
+            ]
+            if @campaign.campaignable.is_a?(Lecture)
+              streams.concat(Rosters::StreamService.new(@campaign.campaignable,
+                                                        view_context).roster_changed(flash: nil))
+            end
+            render turbo_stream: streams
+          end
+        end
+      else
+        messages = @item.errors.full_messages
+        messages += @item.registerable.errors.full_messages if @item.registerable&.errors&.any?
+        respond_with_error(messages.uniq.to_sentence)
+      end
+    end
+
+    def destroy
+      unless @campaign.draft?
+        respond_with_error(t("activerecord.errors.models.registration/item.attributes.base.frozen"))
+        return
+      end
+
+      if params[:cascade] == "true"
+        destroy_cascading
+      else
+        destroy_item_only
+      end
+    end
+
+    private
+
+      def destroy_item_only
+        @item.destroy
+        respond_with_success(t("registration.item.destroyed"))
+      end
+
+      def destroy_cascading
+        registerable = @item.registerable
+        authorize! :destroy, registerable
+
+        if perform_cascading_destroy(registerable)
+          message = t("registration.item.registerable_destroyed",
+                      type: t("registration.item.types.#{registerable.class.name.underscore}"))
+          respond_with_success(message)
+        else
+          respond_with_error(registerable.errors.full_messages.to_sentence)
+        end
+      end
+
+      def perform_cascading_destroy(registerable)
+        success = false
+        ActiveRecord::Base.transaction do
+          @item.destroy
+          raise(ActiveRecord::Rollback) unless registerable.destroy
+
+          success = true
+        end
+        success
+      end
+
+      def create_existing_item
+        @item = @campaign.registration_items.build(item_params)
+        authorize! :create, @item
+
+        if @item.save
+          respond_with_success(t("registration.item.created"))
+        else
+          respond_with_error(@item.errors.full_messages.to_sentence)
+        end
+      end
+
+      def respond_with_success(message)
+        @campaign.reload
+        respond_to do |format|
+          format.html do
+            redirect_to after_action_path, notice: message
+          end
+          format.turbo_stream do
+            flash.now[:notice] = message
+            streams = [
+              turbo_stream.update("campaigns_container",
+                                  partial: "registration/campaigns/card_body_show",
+                                  locals: { campaign: @campaign, tab: "items" }),
+              stream_flash
+            ]
+            if @campaign.campaignable.is_a?(Lecture)
+              streams.concat(Rosters::StreamService.new(@campaign.campaignable,
+                                                        view_context).roster_changed(flash: nil))
+            end
+            render turbo_stream: streams
+          end
+        end
+      end
+
+      def respond_with_error(message, redirect_path: nil)
+        respond_to do |format|
+          format.html do
+            path = redirect_path || after_action_path
+            redirect_to path, alert: message
+          end
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render turbo_stream: stream_flash
+          end
+        end
+      end
+
+      def set_campaign
+        @campaign = Registration::Campaign.find_by(id: params[:registration_campaign_id])
+        return if @campaign
+
+        respond_with_error(t("registration.campaign.not_found"), redirect_path: root_path)
+      end
+
+      def set_locale
+        I18n.locale = @campaign&.locale_with_inheritance || I18n.locale
+      end
+
+      def set_item
+        @item = @campaign.registration_items.find_by(id: params[:id])
+        return if @item
+
+        respond_with_error(t("registration.item.not_found"))
+      end
+
+      def item_params
+        params.expect(registration_item: [:registerable_id, :registerable_type])
+      end
+
+      def capacity_params
+        params.expect(registration_item: [:capacity])
+      end
+
+      def after_action_path
+        if @campaign.campaignable.is_a?(Lecture)
+          edit_lecture_path(@campaign.campaignable, tab: "campaigns")
+        else
+          registration_campaign_path(@campaign, tab: "items")
+        end
+      end
+
+      def refresh_roster_groups_list_stream(lecture, group_type = :all)
+        return nil unless lecture
+
+        component = RosterOverviewComponent.new(lecture: lecture,
+                                                group_type: group_type)
+        turbo_stream.update("roster_groups_list",
+                            partial: "roster/components/groups_tab",
+                            locals: {
+                              group_type: group_type,
+                              component: component
+                            })
+      end
+  end
+end

--- a/app/controllers/registration/policies_controller.rb
+++ b/app/controllers/registration/policies_controller.rb
@@ -1,0 +1,120 @@
+module Registration
+  class PoliciesController < ApplicationController
+    before_action :set_campaign
+    before_action :set_locale
+    before_action :set_policy, only: [:edit, :update, :destroy, :move_up, :move_down]
+    authorize_resource class: "Registration::Policy", except: [:new, :create]
+
+    def current_ability
+      @current_ability ||= RegistrationPolicyAbility.new(current_user)
+    end
+
+    def new
+      @policy = @campaign.registration_policies.build
+      authorize! :new, @policy
+    end
+
+    def edit
+    end
+
+    def create
+      @policy = @campaign.registration_policies.build(policy_params)
+      authorize! :create, @policy
+
+      if @policy.save
+        respond_with_success(t("registration.policy.created"))
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def update
+      if @policy.update(policy_params)
+        respond_with_success(t("registration.policy.updated"))
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      if @policy.destroy
+        respond_with_success(t("registration.policy.destroyed"))
+      else
+        respond_with_error(@policy.errors.full_messages.join(", "))
+      end
+    end
+
+    def move_up
+      move(:higher)
+    end
+
+    def move_down
+      move(:lower)
+    end
+
+    private
+
+      def set_campaign
+        @campaign = Registration::Campaign.find_by(id: params[:registration_campaign_id])
+        return if @campaign
+
+        respond_with_error(t("registration.campaign.not_found"),
+                           redirect_path: root_path)
+      end
+
+      def set_policy
+        @policy = @campaign.registration_policies.find_by(id: params[:id])
+        return if @policy
+
+        respond_with_error(t("registration.policy.not_found"),
+                           redirect_path: registration_campaign_path(@campaign,
+                                                                     anchor: "policies-tab"))
+      end
+
+      def set_locale
+        I18n.locale = @campaign&.locale_with_inheritance || I18n.locale
+      end
+
+      def policy_params
+        params.expect(registration_policy: [:kind, :phase, :allowed_domains,
+                                            :prerequisite_campaign_id])
+      end
+
+      def move(direction)
+        @policy.public_send("move_#{direction}")
+        respond_with_success(nil)
+      end
+
+      def respond_with_success(message)
+        respond_to do |format|
+          format.html do
+            redirect_to registration_campaign_path(@campaign, anchor: "policies-tab"),
+                        notice: message
+          end
+          format.turbo_stream do
+            flash.now[:notice] = message if message
+            render turbo_stream: [
+              turbo_stream.update("campaigns_container",
+                                  partial: "registration/campaigns/card_body_show",
+                                  locals: { campaign: @campaign, tab: "policies" }),
+              stream_flash
+            ].compact
+          end
+        end
+      end
+
+      def respond_with_error(message, redirect_path: nil)
+        respond_to do |format|
+          format.html do
+            path = redirect_path || registration_campaign_path(@campaign,
+                                                               anchor: "policies-tab")
+            redirect_to path, alert: message
+          end
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render turbo_stream: stream_flash
+          end
+        end
+      end
+  end
+end

--- a/app/controllers/roster/maintenance_controller.rb
+++ b/app/controllers/roster/maintenance_controller.rb
@@ -1,0 +1,411 @@
+module Roster
+  # Manages group allocations through a lecture-level overview and a polymorphic
+  # item dashboard. Handles student membership visualization and maintenance actions.
+  class MaintenanceController < ApplicationController
+    class RosterLockedError < StandardError; end
+    class UserNotFoundError < StandardError; end
+
+    before_action :set_lecture, only: [:index, :enroll]
+    before_action :set_rosterable,
+                  only: [:show, :update, :add_member, :remove_member, :move_member,
+                         :update_self_materialization]
+    before_action :authorize_lecture
+    before_action :use_lecture_locale
+
+    rescue_from "Rosters::UserAlreadyInBundleError" do |e|
+      respond_with_error(t("roster.errors.user_already_in_bundle",
+                           group: e.conflicting_group.title))
+    end
+
+    rescue_from "Rosters::MaintenanceService::CapacityExceededError" do
+      respond_with_error(t("roster.errors.capacity_exceeded"))
+    end
+
+    rescue_from RosterLockedError do
+      respond_with_error(t("roster.errors.item_locked"))
+    end
+
+    rescue_from UserNotFoundError do
+      respond_with_error(t("roster.errors.user_not_found"))
+    end
+
+    rescue_from CanCan::AccessDenied do |exception|
+      redirect_to main_app.root_url, alert: exception.message
+    end
+
+    def current_ability
+      @current_ability ||= LectureAbility.new(current_user)
+    end
+
+    # GET /lectures/:lecture_id/roster
+    def index
+      @group_type = if params[:group_type].is_a?(Array)
+        params[:group_type].map(&:to_sym)
+      else
+        params[:group_type]&.to_sym || :all
+      end
+      @active_tab = params[:tab]&.to_sym || :groups
+
+      setup_participants
+    end
+
+    def enroll
+      set_rosterable_from_composite_id
+      return unless @rosterable
+
+      ensure_rosterable_unlocked!
+
+      user = find_user
+      Rosters::MaintenanceService.new.add_user!(user, @rosterable, force: true)
+
+      flash.now[:notice] = t("roster.messages.user_added_to", group: @rosterable.title)
+      flash.now[:alert] = t("roster.warnings.capacity_exceeded") if @rosterable.over_capacity?
+
+      render_roster_update(tab: :enrollment)
+    end
+
+    def show
+      @active_tab = params[:tab] || "roster"
+      setup_participants
+    end
+
+    def update
+      if @rosterable.update(rosterable_params)
+        flash.now[:notice] = t("roster.messages.updated")
+        render_roster_update(rosterable: nil)
+      else
+        redirect_to lecture_roster_path(@lecture),
+                    alert: @rosterable.errors.full_messages.join(", ")
+      end
+    end
+
+    def add_member
+      ensure_rosterable_unlocked!
+
+      user = find_user
+      Rosters::MaintenanceService.new.add_user!(user, @rosterable, force: true)
+
+      flash.now[:notice] = t("roster.messages.user_added")
+      flash.now[:alert] = t("roster.warnings.capacity_exceeded") if @rosterable.over_capacity?
+
+      render_roster_update(tab: params[:active_tab])
+    end
+
+    def remove_member
+      ensure_rosterable_unlocked!
+
+      user = find_user
+      Rosters::MaintenanceService.new.remove_user!(user, @rosterable)
+
+      flash.now[:notice] = t("roster.messages.user_removed")
+      render_roster_update(tab: params[:active_tab])
+    end
+
+    def move_member
+      ensure_rosterable_unlocked!
+
+      user = find_user
+      target = find_target_rosterable(params[:target_id])
+
+      if target.nil?
+        respond_with_error(t("roster.errors.target_not_found"))
+        return
+      end
+
+      if target.locked?
+        respond_with_error(t("roster.errors.target_locked"))
+        return
+      end
+
+      Rosters::MaintenanceService.new.move_user!(user, @rosterable, target, force: true)
+
+      flash.now[:notice] = t("roster.messages.user_moved", target: target.title)
+      flash.now[:alert] = t("roster.warnings.capacity_exceeded") if target.over_capacity?
+
+      render_roster_update(tab: params[:active_tab])
+    end
+
+    def update_self_materialization
+      mode = params[:self_materialization_mode]
+
+      component = RosterOverviewComponent.new(lecture: @lecture)
+      campaign = component.active_campaign_for(@rosterable)
+
+      group_type = if params[:group_type].is_a?(Array)
+        params[:group_type].map(&:to_sym)
+      else
+        params[:group_type]&.to_sym || @rosterable.roster_group_type
+      end
+
+      ActiveRecord::Base.transaction do
+        if @rosterable.update(self_materialization_mode: mode)
+          flash.now[:notice] = t("roster.messages.updated")
+        else
+          flash.now[:alert] = @rosterable.errors.full_messages.to_sentence
+          @rosterable.reload
+        end
+      end
+
+      render turbo_stream: [
+        turbo_stream.replace(
+          view_context.dom_id(@rosterable, :actions),
+          partial: "roster/components/groups_tab/item_actions",
+          locals: { item: @rosterable, component: component, campaign: campaign,
+                    group_type: group_type }
+        ),
+        turbo_stream.replace(
+          view_context.dom_id(@rosterable, :status),
+          partial: "roster/components/groups_tab/status_cell",
+          locals: { item: @rosterable, campaign: campaign, component: component }
+        ),
+        stream_flash
+      ]
+    end
+
+    private
+
+      def setup_participants
+        query = Rosters::ParticipantQuery.new(@lecture, params).call
+
+        @participants_filter = query.filter_mode
+        @total_participants_count = query.total_count
+        @unassigned_participants_count = query.unassigned_count
+
+        @pagy, @participants = pagy(query.scope)
+      end
+
+      def authorize_lecture
+        authorize! :edit, @lecture
+      end
+
+      def render_roster_update(tab: nil, rosterable: @rosterable)
+        @lecture = eager_load_lecture(@lecture.id)
+        rosterable = reload_rosterable_from_lecture(rosterable)
+        setup_participants
+
+        active_tab = tab&.to_sym || params[:active_tab]&.to_sym || :groups
+        target_rosterable = determine_target_rosterable(active_tab, rosterable)
+        group_type = normalize_group_type
+        frame_id = resolve_frame_id(group_type)
+        component_counts = build_component_counts
+
+        respond_to do |format|
+          format.turbo_stream do
+            streams = [
+              turbo_stream.update(
+                frame_id,
+                RosterOverviewComponent.new(lecture: @lecture,
+                                            group_type: group_type,
+                                            active_tab: active_tab,
+                                            rosterable: target_rosterable,
+                                            participants: @participants,
+                                            pagy: @pagy,
+                                            filter_mode: @participants_filter,
+                                            counts: component_counts)
+              ),
+              refresh_campaigns_index_stream(@lecture)
+            ]
+            streams << stream_flash if flash.present?
+            render turbo_stream: streams
+          end
+          format.html do
+            redirect_back_or_to fallback_path, notice: flash.now[:notice], alert: flash.now[:alert]
+          end
+        end
+      end
+
+      def reload_rosterable_from_lecture(rosterable)
+        return rosterable if rosterable.nil? || rosterable.is_a?(Lecture)
+
+        collection = case rosterable
+                     when Tutorial then @lecture.tutorials
+                     when Talk then @lecture.talks
+                     when Cohort then @lecture.cohorts
+        end
+        collection&.find { |r| r.id == rosterable.id } || rosterable
+      end
+
+      def determine_target_rosterable(active_tab, rosterable)
+        return nil if active_tab == :enrollment
+        return nil if active_tab == :participants
+        return nil if rosterable.is_a?(Lecture)
+
+        rosterable
+      end
+
+      def normalize_group_type
+        group_type = if params[:group_type].is_a?(Array)
+          params[:group_type].map(&:to_sym)
+        else
+          fallback = if @rosterable.is_a?(Lecture)
+            :all
+          else
+            @rosterable&.roster_group_type || :all
+          end
+          params[:group_type]&.to_sym || fallback
+        end
+
+        group_type.is_a?(Array) ? group_type : group_type&.to_sym
+      end
+
+      def resolve_frame_id(group_type)
+        expected_frame_id = view_context.roster_maintenance_frame_id(group_type)
+        allowed_frame_ids = allowed_roster_frame_ids
+
+        allowed_frame_ids.include?(expected_frame_id) ? expected_frame_id : allowed_frame_ids.first
+      end
+
+      def build_component_counts
+        {
+          total: @total_participants_count,
+          unassigned: @unassigned_participants_count
+        }
+      end
+
+      def allowed_roster_frame_ids
+        group_types = [
+          :all,
+          *RosterOverviewComponent::SUPPORTED_TYPES.keys,
+          view_context.roster_group_types(@lecture)
+        ].uniq
+
+        frame_ids = group_types.map { |t| view_context.roster_maintenance_frame_id(t) }
+        raise("No valid roster frame IDs generated") if frame_ids.empty?
+
+        frame_ids
+      end
+
+      def find_user
+        user = if params[:user_id]
+          User.find_by(id: params[:user_id])
+        else
+          User.find_by(email: params[:email])
+        end
+        raise(UserNotFoundError) unless user
+
+        user
+      end
+
+      def ensure_rosterable_unlocked!
+        raise(RosterLockedError) if @rosterable.locked?
+      end
+
+      def set_rosterable_from_composite_id
+        type, id = params[:rosterable_id].split("-")
+
+        unless Rosters::Rosterable::TYPES.include?(type)
+          respond_with_error(t("roster.errors.invalid_type"))
+          return
+        end
+
+        klass = type.constantize
+        @rosterable = if klass == Cohort
+          klass.find_by(id: id, context: @lecture)
+        else
+          klass.find_by(id: id, lecture: @lecture)
+        end
+
+        return if @rosterable
+
+        respond_with_error(t("roster.errors.rosterable_not_found"))
+        nil
+      end
+
+      def fallback_path
+        lecture_roster_path(@lecture, group_type: @rosterable&.roster_group_type || :all)
+      end
+
+      def find_target_rosterable(id)
+        target_type = params[:target_type]
+
+        return nil if target_type.present? && Rosters::Rosterable::TYPES.exclude?(target_type)
+
+        target_type ||= @rosterable.class.name
+        klass = target_type.constantize
+
+        # Scope the search to the same type as the current group to avoid ID collisions
+        # between Tutorials and Talks.
+        if klass == Cohort
+          klass.find_by(id: id, context: @lecture)
+        else
+          klass.find_by(id: id, lecture: @lecture)
+        end
+      end
+
+      def rosterable_params
+        params.expect(rosterable: [:skip_campaigns])
+      end
+
+      def set_lecture
+        @lecture = eager_load_lecture(params[:lecture_id])
+        return if @lecture
+
+        redirect_to root_path, alert: t("roster.errors.lecture_not_found")
+      end
+
+      def set_rosterable
+        unless Rosters::Rosterable::TYPES.include?(params[:type])
+          redirect_to root_path, alert: t("roster.errors.invalid_type")
+          return
+        end
+
+        klass = params[:type].constantize
+        param_key = "#{params[:type].underscore}_id"
+        id = params[param_key] || params[:id]
+        rosterable = klass.find_by(id: id)
+
+        if rosterable&.lecture
+          @lecture = eager_load_lecture(rosterable.lecture.id)
+
+          if @lecture
+            if rosterable.is_a?(Lecture)
+              @rosterable = @lecture
+            else
+              collection = case rosterable
+                           when Tutorial then @lecture.tutorials
+                           when Talk then @lecture.talks
+                           when Cohort then @lecture.cohorts
+              end
+              @rosterable = collection&.find { |r| r.id == rosterable.id } || rosterable
+            end
+          else
+            @rosterable = rosterable
+          end
+        else
+          @rosterable = rosterable
+        end
+
+        return if @rosterable && @lecture
+
+        redirect_to root_path, alert: t("roster.errors.rosterable_not_found")
+      end
+
+      def respond_with_error(message)
+        respond_to do |format|
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render turbo_stream: stream_flash
+          end
+          format.html { redirect_back_or_to fallback_path, alert: message }
+        end
+      end
+
+      def eager_load_lecture(id)
+        Lecture.includes(
+          { registration_campaigns: [:user_registrations, :registration_items,
+                                     :registration_policies] },
+          tutorials: [:tutors, :tutorial_memberships,
+                      { registration_items: { registration_campaign: :registration_policies } }],
+          cohorts: [:cohort_memberships,
+                    { registration_items: { registration_campaign: :registration_policies } }],
+          talks: [:speakers, :speaker_talk_joins,
+                  { registration_items: { registration_campaign: :registration_policies } }]
+        ).find_by(id: id)
+      end
+
+      def use_lecture_locale
+        locale = @lecture&.locale_with_inheritance || I18n.default_locale
+        I18n.locale = locale
+      end
+  end
+end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -19,9 +19,33 @@ class TalksController < ApplicationController
     authorize! :new, @talk
     I18n.locale = @talk.lecture.locale_with_inheritance ||
                   current_user.locale || I18n.default_locale
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TalksController#new")
+      end
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "modal-container",
+          partial: "talks/roster_modal",
+          locals: { talk: @talk }
+        )
+      end
+    end
   end
 
   def edit
+    respond_to do |format|
+      format.html
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "modal-container",
+          partial: "talks/roster_modal",
+          locals: { talk: @talk }
+        )
+      end
+    end
   end
 
   def create
@@ -34,21 +58,37 @@ class TalksController < ApplicationController
     I18n.locale = @talk&.lecture&.locale_with_inheritance ||
                   current_user.locale || I18n.default_locale
     position = params[:talk][:predecessor]
-    # place the chapter in the correct position
-    if position.present?
+
+    saved = if position.present?
       @talk.insert_at(position.to_i + 1)
+      @talk.valid?
     else
       @talk.save
     end
-    redirect_to edit_lecture_path(@talk.lecture) if @talk.valid?
-    @errors = @talk.errors
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TalksController#create")
+        if saved
+          redirect_to edit_lecture_path(@talk.lecture)
+        else
+          @errors = @talk.errors
+          render :create
+        end
+      end
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = create_turbo_streams(group_type, saved)
+        render turbo_stream: streams, status: saved ? :ok : :unprocessable_content
+      end
+    end
   end
 
   def update
     I18n.locale = @talk.lecture.locale_with_inheritance ||
                   current_user.locale || I18n.default_locale
-    @talk.update(talk_params)
-    if @talk.valid?
+    if @talk.update(talk_params) && @talk.valid?
       dates = parse_talk_dates(params[:talk][:dates])
       @talk.update(dates: dates)
 
@@ -59,16 +99,60 @@ class TalksController < ApplicationController
         position -= 1 if position > @talk.position
         @talk.insert_at(position + 1)
       end
-      redirect_to edit_talk_path(@talk)
+
+      flash.now[:notice] = t("controllers.talks.updated")
+
+      respond_to do |format|
+        format.html { redirect_to edit_talk_path(@talk) }
+        format.turbo_stream do
+          group_type = parse_group_type
+          streams = Rosters::StreamService.new(@talk.lecture, view_context).roster_changed(
+            group_type: group_type, flash: flash
+          )
+          streams << refresh_campaigns_index_stream(@talk.lecture)
+          streams << turbo_stream.update("modal-container", "")
+          render turbo_stream: streams
+        end
+      end
       return
     end
+
     @errors = @talk.errors
+    respond_to do |format|
+      format.html { render :edit }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          dom_id(@talk, "form"),
+          partial: "talks/roster_modal_form",
+          locals: { talk: @talk }
+        ), status: :unprocessable_content
+      end
+    end
   end
 
   def destroy
     lecture = @talk.lecture
-    @talk.destroy
-    redirect_to edit_lecture_path(lecture)
+    if @talk.destroy
+      flash.now[:notice] = t("controllers.talks.destroyed")
+    else
+      flash.now[:alert] = t("controllers.talks.destruction_failed")
+    end
+
+    respond_to do |format|
+      format.html do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy HTML format accessed in " \
+                          "TalksController#destroy")
+        redirect_to edit_lecture_path(lecture)
+      end
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = Rosters::StreamService.new(@talk.lecture, view_context).roster_changed(
+          group_type: group_type, flash: flash
+        )
+        streams << refresh_campaigns_index_stream(lecture)
+        render turbo_stream: streams
+      end
+    end
   end
 
   def assemble
@@ -92,7 +176,7 @@ class TalksController < ApplicationController
     end
 
     def talk_params
-      attributes = [:title, :lecture_id, :details, :description,
+      attributes = [:title, :lecture_id, :details, :description, :capacity,
                     :display_description, { speaker_ids: [], tag_ids: [] }]
       if @talk && !current_user.in?(@talk.speakers) &&
          !@talk.display_description
@@ -115,5 +199,38 @@ class TalksController < ApplicationController
       return [] unless dates_param
 
       dates_param.values.filter_map { |d| d[:date] }.compact_blank
+    end
+
+    def parse_group_type
+      if params[:group_type].is_a?(Array)
+        params[:group_type].map(&:to_sym)
+      else
+        params[:group_type].presence&.to_sym || :talks
+      end
+    end
+
+    def create_turbo_streams(group_type, saved)
+      streams = []
+      service = Rosters::StreamService.new(@talk.lecture, view_context)
+
+      if saved
+        flash.now[:notice] = t("controllers.talks.created")
+        streams.concat(service.roster_changed(group_type: group_type, flash: flash))
+        streams << refresh_campaigns_index_stream(@talk.lecture)
+        streams << turbo_stream.update("modal-container", "")
+      else
+        streams << turbo_stream.replace(view_context.dom_id(@talk, "form"),
+                                        partial: "talks/roster_modal_form",
+                                        locals: { talk: @talk })
+        streams << stream_flash if flash.present?
+      end
+
+      streams
+    end
+
+    def refresh_campaigns_index_stream(lecture)
+      turbo_stream.replace("campaigns_container",
+                           partial: "registration/campaigns/index",
+                           locals: { lecture: lecture })
     end
 end

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,5 +1,7 @@
 # TutorialsController
 class TutorialsController < ApplicationController
+  helper RosterHelper
+
   before_action :set_tutorial, only: [:edit, :destroy, :update, :cancel_edit,
                                       :bulk_download_submissions,
                                       :bulk_download_corrections,
@@ -55,9 +57,38 @@ class TutorialsController < ApplicationController
     set_tutorial_locale
     @tutorial.lecture = @lecture
     authorize! :new, @tutorial
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TutorialsController#new")
+      end
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "modal-container",
+          partial: "tutorials/modal",
+          locals: { tutorial: @tutorial }
+        )
+      end
+    end
   end
 
   def edit
+    authorize! :edit, @tutorial
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TutorialsController#edit")
+      end
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update(
+          "modal-container",
+          partial: "tutorials/modal",
+          locals: { tutorial: @tutorial }
+        )
+      end
+    end
   end
 
   def create
@@ -65,18 +96,79 @@ class TutorialsController < ApplicationController
     authorize! :create, @tutorial
     @lecture = @tutorial.lecture
     set_tutorial_locale
-    @tutorial.save
+    flash.now[:notice] = t("controllers.tutorials.created") if @tutorial.save
     @errors = @tutorial.errors
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TutorialsController#create")
+      end
+      format.turbo_stream do
+        group_type = parse_group_type
+
+        streams = create_turbo_streams(group_type)
+        render turbo_stream: streams, status: @tutorial.persisted? ? :ok : :unprocessable_content
+      end
+    end
   end
 
   def update
-    @tutorial.update(tutorial_params)
-    @errors = @tutorial.errors
-    nil if @errors.present?
+    authorize! :update, @tutorial
+
+    if @tutorial.update(tutorial_params)
+      flash.now[:notice] = t("controllers.tutorials.updated")
+    else
+      @errors = @tutorial.errors
+    end
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TutorialsController#update")
+      end
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = []
+
+        if @tutorial.errors.empty?
+          streams.concat(Rosters::StreamService.new(@lecture, view_context)
+          .item_updated(@tutorial, group_type: group_type, flash: flash))
+          streams << refresh_campaigns_index_stream(@tutorial.lecture)
+        else
+          streams << turbo_stream.replace(view_context.dom_id(@tutorial, "form"),
+                                          partial: "tutorials/modal_form",
+                                          locals: { tutorial: @tutorial })
+          streams << stream_flash if flash.present?
+        end
+
+        render turbo_stream: streams, status: @tutorial.errors.empty? ? :ok : :unprocessable_content
+      end
+    end
   end
 
   def destroy
-    @tutorial.destroy
+    if @tutorial.destroy
+      flash.now[:notice] = t("controllers.tutorials.destroyed")
+    else
+      flash.now[:alert] = t("controllers.tutorials.destruction_failed")
+    end
+
+    respond_to do |format|
+      format.js do
+        Rails.logger.warn("[MUESLI-DEPRECATION] Legacy JS format accessed in " \
+                          "TutorialsController#destroy")
+      end
+      format.turbo_stream do
+        group_type = parse_group_type
+        streams = Rosters::StreamService.new(@lecture, view_context).roster_changed(
+          group_type: group_type, flash: flash
+        )
+        streams << refresh_campaigns_index_stream(@tutorial.lecture)
+
+        render turbo_stream: streams
+      end
+    end
   end
 
   def cancel_edit
@@ -169,7 +261,7 @@ class TutorialsController < ApplicationController
     end
 
     def tutorial_params
-      params.expect(tutorial: [:title, :lecture_id, { tutor_ids: [] }])
+      params.expect(tutorial: [:title, :lecture_id, :capacity, { tutor_ids: [] }])
     end
 
     def bulk_params
@@ -202,5 +294,31 @@ class TutorialsController < ApplicationController
                             .correction_upload_email.deliver_later
         end
       end
+    end
+
+    def parse_group_type
+      if params[:group_type].is_a?(Array)
+        params[:group_type].map(&:to_sym)
+      else
+        params[:group_type].presence&.to_sym || :tutorials
+      end
+    end
+
+    def create_turbo_streams(group_type)
+      streams = []
+      service = Rosters::StreamService.new(@lecture, view_context)
+
+      if @tutorial.persisted?
+        streams.concat(service.roster_changed(group_type: group_type, flash: flash))
+        streams << refresh_campaigns_index_stream(@lecture)
+        streams << turbo_stream.update("modal-container", "")
+      else
+        streams << turbo_stream.replace(view_context.dom_id(@tutorial, "form"),
+                                        partial: "tutorials/modal_form",
+                                        locals: { tutorial: @tutorial })
+        streams << stream_flash if flash.present?
+      end
+
+      streams
     end
 end

--- a/app/frontend/roster/components/roster_candidates_component.rb
+++ b/app/frontend/roster/components/roster_candidates_component.rb
@@ -1,0 +1,125 @@
+# Renders campaign registrations for a given group type.
+# Shows students who registered in campaigns but haven't been allocated.
+# Assigning them will enroll them in the lecture.
+class RosterCandidatesComponent < ViewComponent::Base
+  include RosterTransferable
+
+  def initialize(lecture:, group_type:)
+    super()
+    @lecture = lecture
+    @group_type = group_type
+  end
+
+  def render?
+    registerable_class_names.present?
+  end
+
+  def candidates
+    @candidates ||= fetch_all_candidates
+  end
+
+  def fetch_all_candidates
+    return [] unless render?
+
+    # Get all completed campaigns for this lecture
+    campaigns = Registration::Campaign.completed.where(campaignable: @lecture)
+
+    # Get lecture roster to exclude already-enrolled students
+    lecture_roster_ids = @lecture.allocated_user_ids
+
+    # Aggregate fresh candidates from all campaigns
+    # Only include users who are NOT on lecture roster (truly fresh)
+    candidate_ids = campaigns.flat_map do |c|
+      c.unassigned_users
+       .where.not(id: lecture_roster_ids)
+       .joins(:user_registrations)
+       .where(user_registrations: {
+                registration_campaign_id: c.id,
+                materialized_at: nil
+              })
+       .pluck(:id)
+    end.uniq
+
+    # Preload registrations to display preferences and source campaign
+    User.where(id: candidate_ids)
+        .includes(user_registrations: [:registration_campaign,
+                                       { registration_item: :registerable }])
+        .order(:name, :email)
+  end
+
+  def available_groups
+    return [] unless render?
+
+    @available_groups ||= begin
+      groups = []
+      Array(@group_type).each do |type|
+        next unless @lecture.respond_to?(type)
+
+        groups.concat(@lecture.public_send(type).reject(&:locked?))
+      end
+      groups.sort_by(&:title)
+    end
+  end
+
+  def add_member_path(group, user)
+    case group
+    when Tutorial
+      helpers.add_member_tutorial_path(
+        group, user_id: user.id, tab: "enrollment", active_tab: "enrollment",
+               group_type: @group_type,
+               frame_id: helpers.roster_maintenance_frame_id(@group_type)
+      )
+    when Talk
+      helpers.add_member_talk_path(
+        group, user_id: user.id, tab: "enrollment", active_tab: "enrollment",
+               group_type: @group_type,
+               frame_id: helpers.roster_maintenance_frame_id(@group_type)
+      )
+    when Cohort
+      helpers.add_member_cohort_path(
+        group, user_id: user.id, tab: "enrollment", active_tab: "enrollment",
+               group_type: @group_type,
+               frame_id: helpers.roster_maintenance_frame_id(@group_type)
+      )
+    end
+  end
+
+  def candidate_info(user)
+    # Group by campaign to show source
+    relevant_registrations(user).group_by(&:registration_campaign)
+                                .map do |campaign, campaign_regs|
+      {
+        campaign_title: campaign.description.presence || "Campaign ##{campaign.id}",
+        wishes: format_wishes(campaign_regs)
+      }
+    end
+  end
+
+  private
+
+    def registerable_class_names
+      types = Array(@group_type)
+      classes = []
+      classes << "Tutorial" if types.include?(:tutorials)
+      classes << "Talk" if types.include?(:talks)
+      classes << "Cohort" if types.include?(:cohorts)
+      classes
+    end
+
+    def relevant_registrations(user)
+      # Filter in memory because we eager loaded them in fetch_candidates
+      user.user_registrations.select do |r|
+        r.registration_campaign.campaignable_id == @lecture.id &&
+          registerable_class_names.include?(r.registration_item&.registerable_type)
+      end
+    end
+
+    def format_wishes(registrations)
+      # Sort by preference rank (if present)
+      sorted = registrations.sort_by { |r| r.preference_rank || 999 }
+
+      sorted.map do |r|
+        r.registration_item.registerable.title
+      end.join(", ")
+    end
+end

--- a/app/frontend/roster/components/roster_detail_component.rb
+++ b/app/frontend/roster/components/roster_detail_component.rb
@@ -1,0 +1,90 @@
+# Displays the student membership list for a specific group, providing controls
+# to add, remove, or move participants. It dynamically aggregates compatible
+# transfer targets across different group types to facilitate flexible student
+# reassignment.
+class RosterDetailComponent < ViewComponent::Base
+  include RosterTransferable
+
+  def initialize(rosterable:, group_type: nil)
+    super()
+    @rosterable = rosterable
+    @lecture = rosterable.lecture
+    @group_type = group_type
+  end
+
+  delegate :title, :locked?, :roster_group_type, to: :@rosterable
+
+  def students
+    @students ||=
+      User.where(id: @rosterable.roster_entries.map do |e|
+        e.public_send(@rosterable.roster_user_id_column)
+      end)
+          .order(:name)
+          .to_a
+  end
+
+  def back_path
+    helpers.lecture_roster_path(@lecture, group_type: group_type)
+  end
+
+  def group_type
+    @group_type || roster_group_type
+  end
+
+  def add_member_path
+    route_helper("add_member",
+                 group_type: group_type,
+                 active_tab: "groups",
+                 frame_id: "roster_maintenance_#{group_type}")
+  end
+
+  def remove_member_path(user)
+    route_helper("remove_member", user,
+                 group_type: group_type,
+                 active_tab: "groups",
+                 frame_id: "roster_maintenance_#{group_type}")
+  end
+
+  def move_member_path(user)
+    route_helper("move_member", user,
+                 group_type: group_type,
+                 active_tab: "groups",
+                 frame_id: "roster_maintenance_#{group_type}")
+  end
+
+  def available_groups
+    # Lectures don't transfer to other Lectures
+    return [] if @rosterable.is_a?(Lecture)
+
+    # Dynamically fetch the collection (e.g. @lecture.tutorials) based on the type
+    # Memoize to avoid re-fetching for every student row in the view if accessed multiple times
+    @available_groups ||= begin
+      groups = @lecture.public_send(roster_group_type).to_a
+
+      if @rosterable.is_a?(Cohort)
+        groups.concat(@lecture.tutorials.to_a) if @lecture.respond_to?(:tutorials)
+        groups.concat(@lecture.talks.to_a) if @lecture.respond_to?(:talks)
+      elsif @lecture.respond_to?(:cohorts)
+        groups.concat(@lecture.cohorts.to_a)
+      end
+
+      groups.uniq!
+      groups.reject! { |g| g.id == @rosterable.id && g.instance_of?(@rosterable.class) }
+      groups.reject!(&:locked?)
+      groups.sort_by(&:title)
+    end
+  end
+
+  def overbooked?(group = @rosterable)
+    super
+  end
+
+  private
+
+    def route_helper(prefix, *)
+      # Dynamically call the correct helper, e.g. add_member_tutorial_path(@rosterable)
+      # This relies on the route helpers following the convention: {action}_{model}_path
+      method_name = "#{prefix}_#{@rosterable.model_name.singular_route_key}_path"
+      helpers.public_send(method_name, @rosterable, *)
+    end
+end

--- a/app/frontend/roster/components/roster_overview_component.rb
+++ b/app/frontend/roster/components/roster_overview_component.rb
@@ -1,0 +1,481 @@
+# Renders a list of groups (tutorials, exams, etc.) for a lecture.
+# Can be filtered by group_type (:tutorials, :exams, :all).
+class RosterOverviewComponent < ViewComponent::Base
+  # Maximum number of policy names to display before truncating with "..."
+  MAX_DISPLAYED_POLICIES = 3
+
+  # Central configuration for supported types.
+  # Maps the group_type symbol to the model class name string and roster association.
+  SUPPORTED_TYPES = {
+    tutorials: { model: "Tutorial", association: :tutorial_memberships, includes: :tutors },
+    talks: { model: "Talk", association: :speaker_talk_joins, includes: :speakers },
+    cohorts: { model: "Cohort", association: :cohort_memberships, includes: [] }
+  }.freeze
+
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(lecture:, group_type: :all, active_tab: :groups, rosterable: nil,
+                 participants: nil, pagy: nil, filter_mode: "all", counts: {})
+    super()
+    @lecture = lecture
+    @group_type = group_type
+    @active_tab = active_tab
+    @rosterable = rosterable
+    @participants = participants
+    @pagy = pagy
+    @filter_mode = filter_mode
+    @counts = counts
+    @last_campaign_cache = {}
+    @campaign_policies_cache = {}
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  attr_reader :lecture, :active_tab, :rosterable, :group_type, :participants, :pagy, :filter_mode,
+              :counts
+
+  def sections
+    # Fetch all items across all requested types
+    all_items = target_types.flat_map do |type|
+      build_group_items(type)
+    end.compact
+
+    # Bucket 1: The official roster (propagate_to_lecture = true)
+    on_roster = all_items.select do |item|
+      !item.is_a?(Cohort) || item.propagate_to_lecture?
+    end
+
+    # Bucket 2: Sidecars / Waitlists (propagate_to_lecture = false)
+    off_roster = all_items.select do |item|
+      item.is_a?(Cohort) && !item.propagate_to_lecture?
+    end
+
+    result = []
+
+    # 1. Main Roster Section
+    if on_roster.any? || primary_type_enabled?
+      result << {
+        title: primary_section_title,
+        items: sort_mixed_items(on_roster),
+        actions: build_roster_actions
+      }
+    end
+
+    # 2. Isolated Section
+    if off_roster.any? || cohorts_enabled?
+      result << {
+        title: I18n.t("roster.cohorts.without_lecture_enrollment_title"),
+        help: I18n.t("roster.cohorts.without_lecture_enrollment_help"),
+        items: off_roster,
+        actions: build_isolated_actions
+      }
+    end
+
+    result
+  end
+
+  def group_type_title
+    if @group_type.is_a?(Array) || @group_type == :all
+      I18n.t("roster.tabs.group_maintenance")
+    elsif SUPPORTED_TYPES.key?(@group_type)
+      I18n.t("roster.tabs.#{@group_type.to_s.singularize}_maintenance")
+    else
+      I18n.t("roster.dashboard.title")
+    end
+  end
+
+  # Helper to generate the correct polymorphic path
+  def group_path(item)
+    method_name = "#{item.model_name.singular_route_key}_roster_path"
+    Rails.application.routes.url_helpers.public_send(method_name, item)
+  end
+
+  def active_campaign_for(item)
+    # Check loaded association first to avoid N+1 and direct DB hits
+    items = if item.association(:registration_items).loaded?
+      item.registration_items
+    else
+      item.registration_items.includes(:registration_campaign)
+    end
+    items.map(&:registration_campaign).find { |c| !c.completed? }
+  end
+
+  def show_skip_campaigns_switch?(item)
+    (item.skip_campaigns? && item.can_unskip_campaigns?) ||
+      (!item.skip_campaigns? && item.can_skip_campaigns?)
+  end
+
+  def toggle_skip_campaigns_path(item)
+    method_name = "#{item.class.name.underscore}_roster_path"
+    Rails.application.routes.url_helpers.public_send(method_name, item)
+  end
+
+  def update_self_materialization_path(item, mode, group_type_param = nil)
+    method_name = "#{item.class.name.underscore}_update_self_materialization_path"
+    group_type_param ||= @group_type
+    Rails.application.routes.url_helpers.public_send(
+      method_name,
+      item,
+      self_materialization_mode: mode,
+      group_type: group_type_param
+    )
+  end
+
+  def subtables_for(group)
+    [{ title: nil, items: group[:items] }]
+  end
+
+  def primary_status(item, campaign)
+    if campaign
+      I18n.t("roster.status_texts.campaign_#{campaign.status}")
+    elsif item.in_campaign?
+      status = I18n.t("roster.status_texts.post_campaign")
+      unless item.self_materialization_mode_disabled?
+        status += " (#{I18n.t("roster.status_texts.self_enrollment")})"
+        if bypasses_campaign_policy?(item, item.self_materialization_mode)
+          status += " ⚠️ #{I18n.t("roster.status_texts.no_policy_enforcement")}"
+        end
+      end
+      status
+    elsif item.skip_campaigns?
+      status = I18n.t("roster.status_texts.direct_management")
+      unless item.self_materialization_mode_disabled?
+        status += " (#{I18n.t("roster.status_texts.self_enrollment")})"
+      end
+      status
+    else
+      I18n.t("roster.status_texts.awaiting_setup")
+    end
+  end
+
+  def bypasses_campaign_policy?(item, target_mode)
+    return false if target_mode.to_s == "disabled"
+    return false if target_mode.to_s == "remove_only"
+    return false unless item.in_campaign?
+
+    last_campaign = last_completed_campaign_for(item)
+    return false unless last_campaign
+
+    campaign_has_policies?(last_campaign)
+  end
+
+  def policy_bypass_warning_data(item, target_mode)
+    return nil unless bypasses_campaign_policy?(item, target_mode)
+
+    last_campaign = last_completed_campaign_for(item)
+    policies = last_campaign.registration_policies.active
+    kinds = policies.limit(MAX_DISPLAYED_POLICIES).pluck(:kind)
+    policy_names = kinds.map { |k| I18n.t("registration.policy.kinds.#{k}") }.join(", ")
+    policy_names += "..." if policies.count > MAX_DISPLAYED_POLICIES
+
+    {
+      policy_name: policy_names.presence || I18n.t("roster.unknown_policy"),
+      campaign_name: last_campaign.description.presence || I18n.t("roster.completed_campaign")
+    }
+  end
+
+  def campaign_has_policies?(campaign)
+    return false unless campaign
+
+    if campaign.association(:registration_policies).loaded?
+      campaign.registration_policies.any?
+    else
+      campaign.registration_policies.exists?
+    end
+  end
+
+  def policy_shield_tooltip(item, campaign)
+    # Check active campaign first
+    target_campaign = campaign
+
+    # If no active campaign, check for completed campaign with policies
+    target_campaign = last_completed_campaign_for(item) if target_campaign.nil? && item.in_campaign?
+
+    return nil unless campaign_has_policies?(target_campaign)
+
+    policies = target_campaign.registration_policies.active
+
+    policy_kinds = if policies.loaded?
+      policies.first(MAX_DISPLAYED_POLICIES).map do |p|
+        I18n.t("registration.policy.kinds.#{p.kind}")
+      end.join(", ")
+    else
+      kinds = policies.limit(MAX_DISPLAYED_POLICIES).pluck(:kind)
+      kinds.map { |k| I18n.t("registration.policy.kinds.#{k}") }.join(", ")
+    end
+
+    count = policies.loaded? ? policies.size : policies.count
+    policy_kinds += "..." if count > MAX_DISPLAYED_POLICIES
+
+    # Use past tense for completed campaigns, present tense for active ones
+    key = campaign.present? ? "gated_by_policies" : "enforced_policies"
+    I18n.t("roster.status_texts.#{key}", policies: policy_kinds)
+  end
+
+  def status_badge_data(item, campaign)
+    if campaign
+      campaign_badge_data(campaign)
+    elsif item.in_campaign?
+      tooltip_text = I18n.t("roster.status_texts.post_campaign")
+      has_policies = campaign_has_policies_for_item?(item)
+
+      if has_policies
+        policy_tooltip = policy_shield_tooltip(item, nil)
+        tooltip_text += " • #{policy_tooltip}" if policy_tooltip
+      end
+
+      {
+        icon: "bi-calendar-check-fill",
+        text: I18n.t("roster.status_texts.post_campaign_short") + (has_policies ? " 🛡️" : ""),
+        css_class: "bg-light text-secondary border border-secondary",
+        tooltip: tooltip_text,
+        self_enrollment: !item.self_materialization_mode_disabled?,
+        has_policies: has_policies
+      }
+    elsif item.skip_campaigns?
+      {
+        icon: "bi-gear-fill",
+        text: I18n.t("roster.status_texts.direct_management_short"),
+        css_class: "bg-light text-primary border border-primary",
+        tooltip: I18n.t("roster.status_texts.direct_management"),
+        self_enrollment: !item.self_materialization_mode_disabled?,
+        has_policies: false
+      }
+    else
+      {
+        icon: "bi-hourglass",
+        text: I18n.t("roster.status_texts.awaiting_setup_short"),
+        css_class: "bg-light text-muted border border-secondary",
+        tooltip: I18n.t("roster.status_texts.awaiting_setup"),
+        self_enrollment: false,
+        has_policies: false
+      }
+    end
+  end
+
+  def campaign_badge_data(campaign)
+    icon, css_class = case campaign.status
+                      when "open"
+                        ["bi-calendar-check", "bg-light text-success border border-success"]
+                      when "closed"
+                        ["bi-calendar-x", "bg-light text-warning border border-warning"]
+                      when "processing"
+                        ["bi-arrow-repeat", "bg-light text-primary border border-primary"]
+                      when "completed"
+                        ["bi-calendar-check-fill",
+                         "bg-light text-secondary border border-secondary"]
+                      else
+                        ["bi-calendar", "bg-light text-secondary border border-secondary"]
+    end
+
+    {
+      icon: icon,
+      text: I18n.t("roster.status_texts.campaign_#{campaign.status}_short"),
+      css_class: css_class,
+      tooltip: I18n.t("roster.status_texts.campaign_#{campaign.status}"),
+      self_enrollment: false
+    }
+  end
+
+  def self_enrollment_badge_data(item)
+    mode = item.self_materialization_mode
+    icon = "bi-person-fill"
+    text = case mode
+           when "add_only"
+             "+"
+           when "remove_only"
+             "−"
+           when "add_and_remove"
+             "±"
+           else
+             ""
+    end
+
+    has_warning = bypasses_campaign_policy?(item, mode)
+    tooltip_text = I18n.t("roster.self_materialization.modes.#{mode}")
+
+    tooltip_text += " ⚠️ #{I18n.t("roster.status_texts.no_policy_enforcement")}" if has_warning
+
+    {
+      icon: icon,
+      text: text,
+      css_class: "bg-light text-success border border-success",
+      tooltip: tooltip_text,
+      has_warning: has_warning
+    }
+  end
+
+  def campaign_has_policies_for_item?(item)
+    return false unless item.in_campaign?
+
+    last_campaign = last_completed_campaign_for(item)
+    return false unless last_campaign
+
+    campaign_has_policies?(last_campaign)
+  end
+
+  def all_groups_empty?
+    @lecture.tutorials.empty? && @lecture.talks.empty? && @lecture.cohorts.empty?
+  end
+
+  private
+
+    # Cached lookup for the last completed campaign of an item
+    # Prevents N+1 queries by memoizing per item
+    def last_completed_campaign_for(item)
+      cache_key = "#{item.class.name}-#{item.id}"
+      return @last_campaign_cache[cache_key] if @last_campaign_cache.key?(cache_key)
+
+      @last_campaign_cache[cache_key] = item.registration_items
+                                            .joins(:registration_campaign)
+                                            .merge(::Registration::Campaign.completed)
+                                            .order("registration_campaigns.updated_at DESC")
+                                            .first&.registration_campaign
+    end
+
+    def build_roster_actions
+      actions = []
+
+      # 1. Tutorial / Talk Action
+      if primary_type_enabled?
+        label = @lecture.seminar? ? Talk.model_name.human : Tutorial.model_name.human
+        url = if @lecture.seminar?
+          Rails.application.routes.url_helpers.new_talk_path(lecture_id: @lecture.id,
+                                                             group_type: @group_type,
+                                                             format: :turbo_stream)
+        else
+          Rails.application.routes.url_helpers.new_tutorial_path(lecture_id: @lecture.id,
+                                                                 group_type: @group_type,
+                                                                 format: :turbo_stream)
+        end
+        actions << { text: label, path: url }
+      end
+
+      # 2. Cohort (Enrolled) Actions
+      if cohorts_enabled?
+        # Flexible Group (With Enrollment)
+        actions << {
+          text: I18n.t("roster.group_category.flexible_group"),
+          path: Rails.application.routes.url_helpers
+                     .new_cohort_path(lecture_id: @lecture.id,
+                                      group_type: @group_type,
+                                      format: :turbo_stream,
+                                      cohort: { purpose: "general", propagate_to_lecture: true })
+        }
+      end
+
+      actions
+    end
+
+    def build_isolated_actions
+      return [] unless cohorts_enabled?
+
+      [
+        {
+          text: I18n.t("roster.group_category.flexible_group"),
+          path: Rails.application.routes.url_helpers
+                     .new_cohort_path(lecture_id: @lecture.id,
+                                      group_type: @group_type,
+                                      format: :turbo_stream,
+                                      cohort: { purpose: "general", propagate_to_lecture: false })
+        }
+      ]
+    end
+
+    def build_group_items(type)
+      items = @lecture.public_send(type)
+      return [] if items.empty?
+
+      # Sorting: Completed campaigns at bottom, then by title
+      # Actually: Completed campaigns at TOP (0), others at bottom (1)
+      items.sort_by do |item|
+        if type == :talks
+          item.position
+        else
+          # Use campaign_completed? which is more direct
+          has_completed_campaign = item.in_completed_campaign?
+          [has_completed_campaign ? 0 : 1, item.title.to_s]
+        end
+      end
+    end
+
+    def sort_mixed_items(items)
+      items.sort_by do |item|
+        type_rank = item.is_a?(Cohort) ? 2 : 1
+        [type_rank, item.title.to_s]
+      end
+    end
+
+    def primary_type_enabled?
+      target_types.intersect?([:tutorials, :talks])
+    end
+
+    def cohorts_enabled?
+      target_types.include?(:cohorts)
+    end
+
+    def primary_section_title
+      I18n.t("roster.cohorts.with_lecture_enrollment_title")
+    end
+
+    def target_types
+      if @group_type == :all
+        SUPPORTED_TYPES.keys
+      elsif @group_type.is_a?(Array)
+        @group_type.map(&:to_sym)
+      else
+        [@group_type.to_sym]
+      end
+    end
+
+    def build_cohort_groups
+      # Filter for access groups or sidecars if needed,
+      # but returning all in one table per user request.
+
+      # Use eager loaded associations and sort in memory
+      items = @lecture.cohorts.sort_by(&:title)
+
+      # Removed early return to ensure "Add" button is always visible
+      # even if no cohorts exist yet.
+
+      [{
+        type: :cohorts,
+        title: Cohort.model_name.human(count: 2),
+        items: items,
+        link: Rails.application.routes.url_helpers.new_cohort_path(lecture_id: @lecture.id,
+                                                                   format: :turbo_stream,
+                                                                   group_type: @group_type)
+      }]
+    end
+
+    def build_group_data(type)
+      config = SUPPORTED_TYPES[type]
+      # Using public_send returns the pre-loaded association target (Array) because
+      # we eager loaded it in controller
+      items = @lecture.public_send(type)
+
+      return nil if items.empty?
+
+      # Sort items: completed campaigns first, then others, each subgroup sorted by title
+      sorted_items = items.sort_by do |item|
+        if type == :talks
+          item.position
+        else
+          has_completed_campaign = item.in_completed_campaign?
+          [has_completed_campaign ? 0 : 1, item.title.to_s]
+        end
+      end
+
+      klass = config[:model].constantize
+
+      {
+        title: klass.model_name.human(count: 2),
+        items: sorted_items,
+        type: type,
+        link: Rails.application.routes.url_helpers.public_send(
+          "new_#{config[:model].underscore}_path",
+          lecture_id: @lecture.id,
+          format: :turbo_stream,
+          group_type: @group_type
+        )
+      }
+    end
+end

--- a/app/frontend/roster/components/roster_participants_component.rb
+++ b/app/frontend/roster/components/roster_participants_component.rb
@@ -1,0 +1,236 @@
+# Renders the "Participants" tab in the Roster UI.
+# Manages the list of students on the lecture roster, their assignment status,
+# and actions to assign/move them.
+class RosterParticipantsComponent < ViewComponent::Base
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(lecture:, group_type:, participants: nil, pagy: nil, filter_mode: "all",
+                 counts: {})
+    super()
+    @lecture = lecture
+    @group_type = group_type
+    @participants = participants
+    @pagy = pagy
+    @filter_mode = filter_mode
+    @counts = counts
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  attr_reader :lecture, :group_type, :pagy, :filter_mode, :counts
+
+  # Returns the officially enrolled participants (Lecture Superset).
+  def participants
+    @participants ||= []
+  end
+
+  # Returns participants who are assigned to at least one functional group
+  def assigned_participants
+    # Only applicable to current page
+    @assigned_participants ||= participants.select { |m| participant_status(m.user) == :assigned }
+  end
+
+  # Returns participants who are not assigned to any functional group
+  def unassigned_participants
+    # Only applicable to current page
+    @unassigned_participants ||= participants.select do |m|
+      participant_status(m.user) == :unassigned
+    end
+  end
+
+  # Checks if a participant is assigned to any functional sub-group (Tutorial or Talk).
+  # Returns :assigned or :unassigned.
+  def participant_status(user)
+    # Check if user is in any group that is NOT a Cohort
+    is_assigned = user_memberships[user.id].any? do |group_id|
+      group = all_groups_map[group_id]
+      group && !group.is_a?(Cohort)
+    end
+
+    is_assigned ? :assigned : :unassigned
+  end
+
+  # Returns the groups the user is currently a member of (including Cohorts)
+  def participant_groups(user)
+    ids = user_memberships[user.id]
+    ids.filter_map { |id| all_groups_map[id] }.sort_by(&:title)
+  end
+
+  # Returns groups compatible for assignment for a specific user
+  # Logic: (All Groups) - (Locked Groups) - (User's Current Groups)
+  def available_groups_for(user)
+    reserved_ids = user_memberships[user.id]
+
+    all_assignable_groups.reject do |g|
+      g.locked? || reserved_ids.include?(group_key(g))
+    end
+  end
+
+  def available_transfer_targets_for(user)
+    available = available_groups_for(user)
+    return [] unless available.any?
+
+    grouped = available.group_by(&:class)
+    sorted_groups = grouped.sort_by { |klass, _| klass.name == "Cohort" ? 2 : 1 }
+
+    sorted_groups.map do |klass, groups|
+      {
+        title: I18n.t("registration.item.groups.#{klass.name.underscore.pluralize}"),
+        groups: groups.sort_by(&:title)
+      }
+    end
+  end
+
+  # Returns all available actions (Add and/or Switch) for a target group
+  def assignment_actions(user, target_group)
+    actions = []
+    current_of_type = participant_groups(user).select { |g| g.instance_of?(target_group.class) }
+
+    # Only Tutorial is a partition type (mutually exclusive)
+    # Talk and Cohort allow multiple memberships
+    is_partition_type = target_group.is_a?(Tutorial)
+
+    if is_partition_type
+      # For partition types: Only offer "Switch" if already in a group, otherwise "Add"
+      if current_of_type.any?
+        current_of_type.each do |source|
+          actions << {
+            url: helpers.public_send("move_member_#{source.class.name.underscore}_path",
+                                     source, user),
+            method: :patch,
+            params: {
+              target_id: target_group.id,
+              target_type: target_group.class.name
+            },
+            label: t("roster.actions.switch_from_to",
+                     from: source.title,
+                     to: target_group.title),
+            icon: "arrow-left-right"
+          }
+        end
+      else
+        actions << {
+          url: helpers.public_send("add_member_#{target_group.model_name.singular_route_key}_path",
+                                   target_group),
+          method: :post,
+          params: { email: user.email },
+          label: t("roster.actions.add_to", to: target_group.title),
+          icon: "plus-circle"
+        }
+      end
+    else
+      # For multi-membership types: Offer both "Add" and "Switch" options
+      actions << {
+        url: helpers.public_send("add_member_#{target_group.model_name.singular_route_key}_path",
+                                 target_group),
+        method: :post,
+        params: { email: user.email },
+        label: t("roster.actions.add_to", to: target_group.title),
+        icon: "plus-circle"
+      }
+
+      current_of_type.each do |source|
+        actions << {
+          url: helpers.public_send("move_member_#{source.class.name.underscore}_path",
+                                   source, user),
+          method: :patch,
+          params: {
+            target_id: target_group.id,
+            target_type: target_group.class.name
+          },
+          label: t("roster.actions.switch_from_to",
+                   from: source.title,
+                   to: target_group.title),
+          icon: "arrow-left-right"
+        }
+      end
+    end
+
+    actions
+  end
+
+  # Helper to generate the correct polymorphic path
+  # Copied from RosterOverviewComponent as it is needed for links here.
+  def group_path(item)
+    method_name = "#{item.model_name.singular_route_key}_roster_path"
+    Rails.application.routes.url_helpers.public_send(method_name, item)
+  end
+
+  # Returns the HTML for the pagination navigation (top and bottom)
+  # Uses Pagy with custom querify logic to preserve tabs and filters.
+  def pagination_nav
+    return unless @pagy && @pagy.pages > 1
+
+    helpers.pagy_series_nav(@pagy,
+                            path: helpers.lecture_roster_path(@lecture),
+                            querify: lambda { |p|
+                              p["tab"] = "participants"
+                              p["filter"] = @filter_mode
+                              p["group_type"] =
+                                if @group_type.is_a?(Array)
+                                  @group_type.map(&:to_s)
+                                else
+                                  @group_type.to_s
+                                end
+                            })
+  end
+
+  private
+
+    def all_assignable_groups
+      @all_assignable_groups ||=
+        [].concat(@lecture.tutorials.includes(:tutorial_memberships,
+                                              registration_items: :registration_campaign).to_a)
+          .concat(@lecture.talks.includes(:speaker_talk_joins,
+                                          registration_items: :registration_campaign).to_a)
+          .concat(@lecture.cohorts.includes(:cohort_memberships,
+                                            registration_items: :registration_campaign).to_a)
+          .sort_by(&:title)
+    end
+
+    def all_groups_map
+      @all_groups_map ||= all_assignable_groups.index_by { |g| group_key(g) }
+    end
+
+    def group_key(group)
+      "#{group.class.name}-#{group.id}"
+    end
+
+    # Pre-fetches all memberships for the lecture to avoid N+1 queries
+    # Returns: Hash { user_id => Set<group_id> }
+    def user_memberships
+      @user_memberships ||= begin
+        map = Hash.new { |h, k| h[k] = Set.new }
+
+        # OPTIMIZE: Only fetch memberships for users on the current page
+        user_ids = participants.map(&:user_id)
+
+        if user_ids.any?
+          # Bulk load Tutorial memberships
+          if @lecture.tutorials.exists?
+            TutorialMembership.joins(:tutorial)
+                              .where(tutorials: { lecture_id: @lecture.id }, user_id: user_ids)
+                              .pluck(:user_id, :tutorial_id)
+                              .each { |uid, tid| map[uid].add("Tutorial-#{tid}") }
+          end
+
+          # Bulk load Talk memberships
+          if @lecture.talks.exists?
+            SpeakerTalkJoin.joins(:talk)
+                           .where(talks: { lecture_id: @lecture.id }, speaker_id: user_ids)
+                           .pluck(:speaker_id, :talk_id)
+                           .each { |uid, tid| map[uid].add("Talk-#{tid}") }
+          end
+
+          # Bulk load Cohort memberships
+          if @lecture.cohorts.exists?
+            CohortMembership.joins(:cohort)
+                            .where(cohorts: { context_id: @lecture.id,
+                                              context_type: "Lecture" }, user_id: user_ids)
+                            .pluck(:user_id, :cohort_id)
+                            .each { |uid, cid| map[uid].add("Cohort-#{cid}") }
+          end
+        end
+
+        map
+      end
+    end
+end

--- a/app/frontend/roster/components/roster_transferable.rb
+++ b/app/frontend/roster/components/roster_transferable.rb
@@ -1,0 +1,42 @@
+# Organizes available groups into categorized lists (e.g., Tutorials, Cohorts)
+# with formatted titles and capacity status for student transfers.
+# Serves as a shared concern for components that need to display valid assignment
+#  destinations and check for overbooking.
+module RosterTransferable
+  extend ActiveSupport::Concern
+
+  def transfer_targets
+    return @transfer_targets if @transfer_targets
+
+    targets = available_groups.group_by(&:class).map do |klass, groups|
+      {
+        type: klass.name.underscore.pluralize.to_sym,
+        title: I18n.t("registration.item.groups.#{klass.name.underscore.pluralize}"),
+        items: groups.map do |group|
+          {
+            group: group,
+            id: group.id,
+            title: helpers.group_title_with_capacity(group),
+            overbooked: overbooked?(group)
+          }
+        end
+      }
+    end
+
+    @transfer_targets = targets.sort_by { |target| group_order(target[:type]) }
+  end
+
+  def overbooked?(group)
+    group.full?
+  end
+
+  private
+
+    def group_order(type)
+      case type
+      when :tutorials, :talks then 1
+      when :cohorts then 2
+      else 3
+      end
+    end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,6 +48,46 @@ module ApplicationHelper
     value ? "none;" : "block;"
   end
 
+  # rubocop:disable Metrics/ParameterLists
+  def progress_bar(value, max, classification: :neutral, label: nil,
+                   height: "1.5rem", show_label: true,
+                   container_class: "progress mb-2", style: nil)
+    # rubocop:enable Metrics/ParameterLists
+    percentage = max.to_i.positive? ? (value.to_f / max * 100).clamp(0, 100) : 0
+
+    color_class = case classification
+                  when :utilization
+                    utilization_color(percentage)
+                  when :time
+                    "bg-info"
+                  when :neutral
+                    "bg-primary"
+                  else
+                    "bg-#{classification}"
+    end
+
+    tag.div(class: container_class, style: [style, "height: #{height}"].compact.join("; ")) do
+      tag.div(class: "progress-bar #{color_class}",
+              role: "progressbar",
+              style: "width: #{percentage}%",
+              "aria-valuenow": value,
+              "aria-valuemin": 0,
+              "aria-valuemax": max) do
+        label || "#{percentage.round}%" if show_label
+      end
+    end
+  end
+
+  def utilization_color(percentage)
+    if percentage >= 100
+      "bg-danger"
+    elsif percentage >= 80
+      "bg-warning"
+    else
+      "bg-success"
+    end
+  end
+
   def show(value)
     value ? "block;" : "none;"
   end
@@ -269,10 +309,13 @@ module ApplicationHelper
   def helpdesk(text, html, title = t("info"))
     tag.i(class: "far fa-question-circle helpdesk ms-2",
           tabindex: -1,
-          "data-bs-toggle": "popover",
-          "data-bs-trigger": "focus",
-          "data-bs-content": text,
-          "data-bs-html": html,
+          data: {
+            controller: "bs-popover",
+            "bs-toggle": "popover",
+            "bs-trigger": "focus",
+            "bs-content": text,
+            "bs-html": html
+          },
           title: title)
   end
 
@@ -319,5 +362,13 @@ module ApplicationHelper
     result.first(length).tap do |truncated|
       return truncated.length < length ? truncated : "#{truncated}..."
     end
+  end
+
+  def format_talk_dates(dates)
+    return "" if dates.blank?
+
+    dates.sort.map do |date|
+      tag.span(l(date, format: :long), class: "badge bg-light text-dark border me-1")
+    end.join.html_safe
   end
 end

--- a/app/helpers/cohorts_helper.rb
+++ b/app/helpers/cohorts_helper.rb
@@ -1,0 +1,24 @@
+# This helper provides methods to manage cohort propagation and special purposes.
+module CohortsHelper
+  def cohort_propagates?(cohort, params)
+    if cohort.persisted?
+      cohort.propagate_to_lecture?
+    else
+      propagate_flag = params.dig(:cohort, :propagate_to_lecture)
+      propagate_flag == "true"
+    end
+  end
+
+  def cohort_special_purpose_type(propagates)
+    propagates ? "enrollment" : "planning"
+  end
+
+  def cohort_has_special_purpose?(cohort, special_purpose)
+    current_purpose = cohort.purpose.to_s.presence || "general"
+    current_purpose == special_purpose
+  end
+
+  def show_enrollment_warning?(cohort, propagates)
+    propagates && (cohort.context.tutorials.exists? || cohort.context.talks.exists?)
+  end
+end

--- a/app/helpers/registration/campaigns_helper.rb
+++ b/app/helpers/registration/campaigns_helper.rb
@@ -1,0 +1,157 @@
+module Registration
+  module CampaignsHelper
+    def campaign_badge_color(campaign)
+      {
+        draft: "secondary",
+        open: "success",
+        closed: "warning",
+        processing: "info",
+        completed: "dark"
+      }[campaign.status.to_sym]
+    end
+
+    def item_stats_label(campaign)
+      if campaign.first_come_first_served? || campaign.processing? || campaign.completed?
+        t("registration.item.columns.registrations")
+      else
+        t("registration.item.columns.first_choice")
+      end
+    end
+
+    def sorted_preference_counts(stats)
+      stats.preference_counts.sort_by { |k, _| k == :forced ? 999 : k }
+    end
+
+    def rank_color(rank)
+      case rank
+      when :forced then :danger
+      when 1 then :success
+      when 2 then :primary
+      else :secondary
+      end
+    end
+
+    def rank_label(rank)
+      if rank == :forced
+        t("registration.allocation.stats.forced")
+      else
+        t("registration.allocation.stats.rank_label", rank: rank)
+      end
+    end
+
+    def utilization_bar_class(percentage)
+      if percentage >= 100
+        "bg-danger"
+      elsif percentage >= 80
+        "bg-warning"
+      else
+        "bg-success"
+      end
+    end
+
+    def item_stats_count(item)
+      campaign = item.registration_campaign
+      if campaign.first_come_first_served? || campaign.processing? || campaign.completed?
+        item.confirmed_registrations_count
+      else
+        item.first_choice_count
+      end
+    end
+
+    def show_item_capacity_progress?(item)
+      campaign = item.registration_campaign
+      return false unless item.capacity.to_i.positive?
+
+      campaign.first_come_first_served? || campaign.completed?
+    end
+
+    def campaign_close_confirmation(campaign)
+      key = campaign.registration_deadline > Time.current ? "close_early" : "close"
+      t("registration.campaign.confirmations.#{key}")
+    end
+
+    def finalize_campaign_button(campaign)
+      button_to(t("registration.campaign.actions.finalize"),
+                finalize_registration_campaign_allocation_path(campaign),
+                method: :patch,
+                data: { confirm: t("registration.campaign.confirmations.finalize") },
+                class: "btn btn-danger")
+    end
+
+    def allocate_campaign_button(campaign)
+      has_allocation = campaign.last_allocation_calculated_at.present?
+      label = if has_allocation
+        t("registration.campaign.actions.reallocate")
+      else
+        t("registration.campaign.actions.allocate")
+      end
+      confirm = has_allocation ? t("registration.campaign.confirmations.reallocate") : nil
+
+      button_to(label,
+                registration_campaign_allocation_path(campaign),
+                method: :post,
+                class: "btn btn-primary",
+                data: { confirm: confirm, turbo: true })
+    end
+
+    def view_allocation_button(campaign)
+      link_to(t("registration.campaign.actions.view_allocation"),
+              registration_campaign_allocation_path(campaign),
+              class: "btn btn-secondary",
+              data: { turbo_stream: true })
+    end
+
+    def review_and_finalize_button(campaign)
+      link_to(t("registration.campaign.actions.review_and_finalize"),
+              registration_campaign_allocation_path(campaign),
+              class: "btn btn-primary",
+              data: { turbo_stream: true })
+    end
+
+    def open_campaign_button(campaign)
+      button_to(t("registration.campaign.actions.open"),
+                open_registration_campaign_path(campaign),
+                method: :patch,
+                form: {
+                  data: {
+                    controller: "campaign-action",
+                    "campaign-action-campaign-id-value": campaign.id,
+                    "campaign-action-confirm-message-value":
+                      t("registration.campaign.confirmations.open"),
+                    "campaign-action-warning-message-value":
+                      t("registration.campaign.warnings.unlimited_items"),
+                    action: "submit->campaign-action#confirm"
+                  }
+                },
+                class: "btn btn-success")
+    end
+
+    def close_campaign_button(campaign)
+      button_to(t("registration.campaign.actions.close"),
+                close_registration_campaign_path(campaign),
+                method: :patch,
+                data: { confirm: campaign_close_confirmation(campaign) },
+                class: "btn btn-warning")
+    end
+
+    def reopen_campaign_button(campaign)
+      button_to(t("registration.campaign.actions.reopen"),
+                reopen_registration_campaign_path(campaign),
+                method: :patch,
+                data: { confirm: t("registration.campaign.confirmations.reopen") },
+                class: "btn btn-success")
+    end
+
+    private
+
+      def utilization_color(percentage)
+        if percentage >= 100
+          "bg-danger"
+        elsif percentage >= 80
+          "bg-warning"
+        else
+          "bg-success"
+        end
+      end
+  end
+end

--- a/app/helpers/registration/items_helper.rb
+++ b/app/helpers/registration/items_helper.rb
@@ -1,0 +1,44 @@
+module Registration
+  module ItemsHelper
+    def registration_items_service(campaign)
+      @registration_items_service ||= Registration::AvailableItemsService.new(campaign)
+    end
+
+    def item_display_type(item)
+      case item.registerable_type
+      when "Tutorial"
+        t("registration.item.types.tutorial")
+      when "Talk"
+        t("registration.item.types.talk")
+      when "Cohort"
+        cohort = item.registerable
+        base_type = case cohort.purpose.to_sym
+                    when :enrollment
+                      t("registration.item.types.enrollment_group")
+                    when :planning
+                      t("registration.item.types.planning_survey")
+                    when :general
+                      t("registration.item.types.other_group")
+        end
+
+        if cohort.propagate_to_lecture
+          base_type
+        else
+          icon = tag.i(class: "bi bi-person-x ms-1",
+                       style: "color: #495057;",
+                       data: { bs_toggle: "tooltip",
+                               bs_title: t("registration.item.hints.no_propagation") })
+          safe_join([base_type, " ", icon])
+        end
+      end
+    end
+
+    def format_capacity(capacity)
+      if capacity.nil?
+        t("basics.unlimited")
+      else
+        "#{capacity} #{t("basics.seats")}"
+      end
+    end
+  end
+end

--- a/app/helpers/registration/user_registrations_helper.rb
+++ b/app/helpers/registration/user_registrations_helper.rb
@@ -1,0 +1,16 @@
+module Registration
+  module UserRegistrationsHelper
+    def registration_status_color(registration)
+      {
+        pending: "secondary",
+        confirmed: "success",
+        rejected: "danger"
+      }[registration.status.to_sym]
+    end
+
+    def sort_registrations_by_rank(registrations)
+      ranked, unranked = registrations.partition(&:preference_rank)
+      ranked.sort_by(&:preference_rank) + unranked
+    end
+  end
+end

--- a/app/helpers/roster_helper.rb
+++ b/app/helpers/roster_helper.rb
@@ -1,0 +1,208 @@
+module RosterHelper
+  def group_title_with_capacity(group)
+    count = if group.respond_to?(:roster_entries_count)
+      group.roster_entries_count
+    else
+      group.roster_entries.count
+    end
+    "#{group.title} (#{count}/#{group.capacity || "∞"})"
+  end
+
+  def should_display_cohort_purpose?(cohort)
+    cohort.purpose.present? && cohort.purpose != "general"
+  end
+
+  def item_overbooked?(item)
+    return false unless item.capacity
+
+    item.roster_entries.count > item.capacity
+  end
+
+  def tutor_names_with_fallback(tutorial)
+    tutorial.tutor_names.presence || "TBA"
+  end
+
+  def roster_group_types(lecture)
+    if lecture.seminar?
+      [:talks, :cohorts]
+    else
+      [:tutorials, :cohorts]
+    end
+  end
+
+  def roster_maintenance_frame_id(group_type)
+    suffix = group_type.is_a?(Array) ? group_type.join("_") : group_type
+    "roster_maintenance_#{suffix}"
+  end
+
+  def hidden_group_type_field(group_type)
+    if group_type.is_a?(Array)
+      safe_join(group_type.map { |t| hidden_field_tag("group_type[]", t) })
+    else
+      hidden_field_tag(:group_type, group_type)
+    end
+  end
+
+  def roster_manage_button(item, component, campaign)
+    locked = item.locked?
+
+    if locked
+      tooltip = if campaign
+        t("roster.tooltips.locked_manage")
+      else
+        t("roster.tooltips.locked_manage_no_campaign")
+      end
+      tag.span(title: tooltip,
+               data: { bs_toggle: "tooltip" }) do
+        tag.button(class: "btn btn-sm btn-outline-primary disabled opacity-50",
+                   style: "cursor: not-allowed;",
+                   disabled: true) do
+          tag.i(class: "bi bi-person-lines-fill")
+        end
+      end
+    else
+      link_to(component.group_path(item),
+              class: "btn btn-sm btn-primary",
+              title: t("roster.tooltips.manage_participants"),
+              data: { bs_toggle: "tooltip" }) do
+        tag.i(class: "bi bi-person-lines-fill")
+      end
+    end
+  end
+
+  def roster_campaign_button(item, component, campaign)
+    if campaign
+      # Active campaign - show view campaign button
+      link_to(edit_lecture_path(component.lecture, tab: "campaigns",
+                                                   campaign_id: campaign.id),
+              class: "btn btn-sm btn-secondary",
+              title: t("roster.view_campaign"),
+              data: { turbo_frame: "_top", bs_toggle: "tooltip" }) do
+        tag.i(class: "bi bi-calendar-event")
+      end
+    elsif item.in_campaign?
+      # Has campaign history - show view campaign button for most recent
+      recent_campaign = item.registration_items
+                            .joins(:registration_campaign)
+                            .order("registration_campaigns.created_at DESC")
+                            .first
+                            &.registration_campaign
+
+      if recent_campaign
+        link_to(edit_lecture_path(component.lecture, tab: "campaigns",
+                                                     campaign_id: recent_campaign.id),
+                class: "btn btn-sm btn-secondary",
+                title: t("roster.view_campaign"),
+                data: { turbo_frame: "_top", bs_toggle: "tooltip" }) do
+          tag.i(class: "bi bi-calendar-event")
+        end
+      end
+    else
+      # Never in campaign - show create campaign button (disabled if skip_campaigns is true)
+      can_create = !item.skip_campaigns?
+      if can_create
+        link_to(edit_lecture_path(component.lecture, tab: "campaigns", new_campaign: true),
+                class: "btn btn-sm btn-secondary",
+                title: t("roster.create_campaign"),
+                data: { turbo_frame: "_top", bs_toggle: "tooltip" }) do
+          tag.i(class: "bi bi-calendar-plus")
+        end
+      else
+        tag.span(title: t("roster.tooltips.create_campaign_disabled"),
+                 data: { bs_toggle: "tooltip" }) do
+          tag.button(class: "btn btn-sm btn-outline-secondary disabled opacity-50",
+                     style: "cursor: not-allowed;",
+                     disabled: true) do
+            tag.i(class: "bi bi-calendar-plus")
+          end
+        end
+      end
+    end
+  end
+
+  def roster_edit_button(item, group_type)
+    link_to(edit_polymorphic_path(item, group_type: group_type),
+            class: "btn btn-sm btn-primary",
+            title: t("roster.tooltips.edit_settings"),
+            data: { turbo_stream: true, bs_toggle: "tooltip" }) do
+      tag.i(class: "bi bi-tools")
+    end
+  end
+
+  def roster_destroy_button(item, group_type)
+    disabled = !item.destructible?
+    tooltip = if disabled
+      t("roster.tooltips.delete_disabled")
+    else
+      t("roster.tooltips.delete")
+    end
+
+    if disabled
+      tag.span(title: tooltip, data: { bs_toggle: "tooltip" }) do
+        tag.button(class: "btn btn-sm btn-outline-danger opacity-50",
+                   style: "cursor: not-allowed;",
+                   disabled: true,
+                   type: "button") do
+          tag.i(class: "bi bi-trash")
+        end
+      end
+    else
+      link_to(polymorphic_path(item, group_type: group_type),
+              data: { turbo_method: :delete, turbo_confirm: t("confirmation.generic"),
+                      bs_toggle: "tooltip" },
+              title: tooltip,
+              class: "btn btn-sm btn-danger") do
+        tag.i(class: "bi bi-trash")
+      end
+    end
+  end
+
+  def self_materialization_state(item, campaign)
+    active_campaign = campaign && !campaign.completed?
+    disabled = active_campaign || (!item.skip_campaigns? && !item.in_campaign?)
+
+    tooltip = if active_campaign
+      t("roster.tooltips.self_materialization_disabled_campaign")
+    elsif !item.skip_campaigns? && !item.in_campaign?
+      t("roster.tooltips.self_materialization_disabled_fresh")
+    else
+      t("roster.self_materialization.label")
+    end
+
+    { disabled: disabled, tooltip: tooltip }
+  end
+
+  def skip_campaigns_state(item)
+    can_skip = item.can_skip_campaigns?
+    can_unskip = item.can_unskip_campaigns?
+    disabled = !(item.skip_campaigns? ? can_unskip : can_skip)
+    icon_class = item.skip_campaigns? ? "bi-calendar-x" : "bi-calendar-check"
+
+    tooltip = if disabled
+      if item.skip_campaigns?
+        t("roster.disable_skip_campaigns_hint")
+      else
+        t("roster.enable_skip_campaigns_hint")
+      end
+    elsif item.skip_campaigns?
+      t("roster.tooltips.skip_campaigns_enabled")
+    else
+      t("roster.tooltips.skip_campaigns_disabled")
+    end
+
+    { disabled: disabled, tooltip: tooltip, icon_class: icon_class }
+  end
+
+  def roster_group_badge(group, group_type)
+    isolating = group.is_a?(Cohort) && !group.propagate_to_lecture?
+    # Use secondary (gray) for normal propagating groups to reduce visual noise.
+    # Use light/border (ghost) for isolating groups to differentiate them.
+    badge_class = isolating ? "bg-light text-dark border" : "bg-secondary text-white"
+
+    link_to(group.title,
+            polymorphic_path([group, :roster]),
+            class: "badge #{badge_class} me-1 text-decoration-none",
+            style: "cursor: pointer;",
+            data: { turbo_frame: roster_maintenance_frame_id(group_type), turbo_prefetch: false })
+  end
+end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,0 +1,48 @@
+class Cohort < ApplicationRecord
+  include Registration::Registerable
+  include Rosters::Rosterable
+
+  belongs_to :context, polymorphic: true
+
+  has_many :cohort_memberships, dependent: :destroy
+  has_many :users, through: :cohort_memberships
+  has_many :members, through: :cohort_memberships, source: :user
+
+  enum :purpose, {
+    general: 0,
+    enrollment: 1,
+    planning: 2
+  }
+
+  attr_readonly :propagate_to_lecture
+
+  validates :title, presence: true
+  validates :purpose, presence: true
+  validates :capacity, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validate :validate_purpose_propagate_compatibility
+
+  def roster_entries
+    cohort_memberships
+  end
+
+  def lecture
+    context if context.is_a?(Lecture)
+  end
+
+  def registration_title
+    title
+  end
+
+  private
+
+    def validate_purpose_propagate_compatibility
+      return unless purpose_changed?
+
+      case purpose
+      when "enrollment"
+        errors.add(:purpose, :enrollment_must_propagate) unless propagate_to_lecture?
+      when "planning"
+        errors.add(:purpose, :planning_cannot_propagate) if propagate_to_lecture?
+      end
+    end
+end

--- a/app/models/cohort_membership.rb
+++ b/app/models/cohort_membership.rb
@@ -1,0 +1,5 @@
+class CohortMembership < ApplicationRecord
+  belongs_to :cohort
+  belongs_to :user
+  belongs_to :source_campaign, class_name: "Registration::Campaign", optional: true
+end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -2,7 +2,7 @@
 class Lecture < ApplicationRecord
   include ApplicationHelper
   include Registration::Campaignable
-  include Registration::Registerable
+  include Rosters::Rosterable
 
   belongs_to :course
 
@@ -60,6 +60,10 @@ class Lecture < ApplicationRecord
   has_many :lecture_user_joins, dependent: :destroy
   has_many :users, -> { distinct }, through: :lecture_user_joins
 
+  # Roster associations
+  has_many :lecture_memberships, dependent: :destroy
+  has_many :members, through: :lecture_memberships, source: :user
+
   # a lecture has many users who have starred it (fans)
   has_many :user_favorite_lecture_joins, dependent: :destroy
   has_many :fans, -> { distinct }, through: :user_favorite_lecture_joins,
@@ -85,6 +89,8 @@ class Lecture < ApplicationRecord
   # a lecture has many vouchers that can be redeemed to promote
   # users to tutors, editors or teachers
   has_many :vouchers, dependent: :destroy
+
+  has_many :cohorts, as: :context, dependent: :destroy
 
   # we do not allow that a teacher gives a certain lecture in a given term
   # of the same sort twice
@@ -206,6 +212,10 @@ class Lecture < ApplicationRecord
     Rails.cache.fetch("#{cache_key_with_version}/title_for_viewers") do
       short_title
     end
+  end
+
+  def registration_title
+    title_for_viewers
   end
 
   def locale_with_inheritance
@@ -784,6 +794,26 @@ class Lecture < ApplicationRecord
     touch
   end
 
+  def ensure_roster_membership!(user_ids)
+    # Efficiently insert missing memberships using upsert (ignoring duplicates)
+    # Note: Requires a unique index on [:user_id, :lecture_id]
+    attributes = user_ids.map do |uid|
+      { user_id: uid, lecture_id: id, created_at: Time.current,
+        updated_at: Time.current }
+    end
+
+    return if attributes.empty?
+
+    # Skipping validations for performance; ensure data integrity via unique index
+    # rubocop:disable Rails/SkipsModelValidations
+    LectureMembership.upsert_all(
+      attributes,
+      unique_by: [:user_id, :lecture_id],
+      record_timestamps: false # Timestamps handled manually above
+    )
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
   def eligible_as_tutors
     (tutors + Redemption.tutors_by_redemption_in(self) + editors + [teacher]).uniq
     # the first one should (in the future) actually be contained in the sum of
@@ -831,6 +861,10 @@ class Lecture < ApplicationRecord
 
   def vignettes?
     vignettes_questionnaires.any?
+  end
+
+  def roster_entries
+    lecture_memberships
   end
 
   private

--- a/app/models/lecture_membership.rb
+++ b/app/models/lecture_membership.rb
@@ -1,0 +1,7 @@
+# Represents a user's official membership in a lecture's roster, distinct from
+# casual subscriptions, and tracks the source campaign for automated management.
+class LectureMembership < ApplicationRecord
+  belongs_to :user
+  belongs_to :lecture
+  belongs_to :source_campaign, class_name: "Registration::Campaign", optional: true
+end

--- a/app/models/registration/allocation_dashboard.rb
+++ b/app/models/registration/allocation_dashboard.rb
@@ -1,0 +1,60 @@
+module Registration
+  class AllocationDashboard
+    attr_reader :campaign
+
+    def initialize(campaign)
+      @campaign = campaign
+    end
+
+    def stats
+      @stats ||= begin
+        assignment = @campaign.user_registrations
+                              .where(status: :confirmed)
+                              .pluck(:user_id, :registration_item_id)
+                              .to_h
+        Registration::AllocationStats.new(@campaign, assignment)
+      end
+    end
+
+    def unassigned_students
+      @unassigned_students ||= User.where(id: stats.unassigned_user_ids).order(:email)
+    end
+
+    def policy_violations
+      @policy_violations ||= begin
+        guard_result = Registration::FinalizationGuard.new(@campaign).check
+        guard_result.success? ? [] : (guard_result.data || [])
+      end
+    end
+
+    def conflicting_registrations
+      @conflicting_registrations ||= calculate_conflicts
+    end
+
+    private
+
+      def calculate_conflicts
+        return [] unless @campaign.campaignable.is_a?(Lecture)
+
+        registered_user_ids = @campaign.user_registrations.pluck(:user_id)
+
+        existing_memberships =
+          TutorialMembership.joins(:tutorial)
+                            .where(tutorials: { lecture_id: @campaign.campaignable.id })
+                            .where(user_id: registered_user_ids)
+                            .includes(:user, :tutorial)
+
+        registrations_by_user = @campaign.user_registrations
+                                         .where(user_id: existing_memberships.map(&:user_id))
+                                         .index_by(&:user_id)
+
+        existing_memberships.map do |m|
+          {
+            user: m.user,
+            tutorial: m.tutorial,
+            registration: registrations_by_user[m.user_id]
+          }
+        end
+      end
+  end
+end

--- a/app/models/registration/allocation_materializer.rb
+++ b/app/models/registration/allocation_materializer.rb
@@ -1,0 +1,28 @@
+module Registration
+  class AllocationMaterializer
+    def initialize(campaign)
+      @campaign = campaign
+    end
+
+    def materialize!
+      @campaign.registration_items.includes(:registerable).find_each do |item|
+        # Delegate the actual creation of domain objects (e.g. TutorTutorialUser)
+        # to the registerable model (e.g. Tutorial).
+        # This assumes the registerable implements `materialize_allocation!`.
+        user_ids = item.confirmed_user_ids
+
+        item.registerable.materialize_allocation!(
+          user_ids: user_ids,
+          campaign: @campaign
+        )
+
+        # Mark the registrations as materialized
+        # We only mark those that were actually confirmed/allocated.
+        # rubocop:disable Rails/SkipsModelValidations
+        item.user_registrations.where(user_id: user_ids)
+            .update_all(materialized_at: Time.current)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/app/models/registration/allocation_service.rb
+++ b/app/models/registration/allocation_service.rb
@@ -1,0 +1,144 @@
+module Registration
+  class AllocationService
+    def initialize(campaign, strategy: :min_cost_flow, **opts)
+      @campaign = campaign
+      @strategy = strategy
+      @opts = opts
+    end
+
+    # Runs the allocation algorithm and saves results.
+    #
+    # Locks all registerables (tutorials/talks/cohorts) during solver execution to prevent
+    # capacity modifications that would invalidate the computed allocation. Without this lock,
+    # concurrent capacity edits via tutorial/talk/cohort controllers could cause the solver
+    # results to be based on stale data.
+    #
+    # Philosophy: "Hands off while the solver is running" - capacity edits are blocked for
+    # the brief window (~1 second) when allocation is being computed to ensure data consistency.
+    #
+    # Note: Row-level locks are automatically released when the transaction commits or rolls back.
+    def allocate!
+      Registration::Campaign.transaction do
+        # Lock campaign to prevent concurrent allocate! calls
+        @campaign.lock!
+
+        # Lock all registerables to prevent capacity changes during solver run
+        # These locks will be held for ~1 second and automatically released on commit/rollback
+        @campaign.registration_items.includes(:registerable).find_each do |item|
+          item.registerable.lock!
+        end
+
+        # Clean up forced registrations from previous runs (idempotency)
+        # Only delete rank-less registrations if the user has other registrations,
+        # preserving manual single-assignments.
+        subquery = Registration::UserRegistration
+                   .select(:user_id)
+                   .where(registration_campaign_id: @campaign.id)
+                   .group(:user_id)
+                   .having("count(*) > 1")
+
+        @campaign.user_registrations
+                 .where(preference_rank: nil)
+                 .where(user_id: subquery)
+                 .delete_all
+
+        solver =
+          case @strategy
+          when :min_cost_flow
+            Registration::Solvers::MinCostFlow.new(@campaign, **@opts)
+          else
+            raise(ArgumentError, "Unknown strategy '#{@strategy}'")
+          end
+
+        result = solver.run
+        save_allocation(result)
+      end
+    end
+
+    private
+
+      def save_allocation(allocation)
+        Registration::Campaign.transaction do
+          reset_registrations
+          process_allocations(allocation)
+          update_item_counts
+          update_campaign_status
+        end
+      end
+
+      def reset_registrations
+        # Reset all registrations to pending to clear previous runs
+        # This ensures idempotency if we run the solver multiple times.
+        # rubocop:disable Rails/SkipsModelValidations
+        @campaign.user_registrations.update_all(status: :pending, updated_at: Time.current)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      def process_allocations(allocation)
+        # Group allocations by item_id to perform bulk updates
+        allocations_by_item = Hash.new { |h, k| h[k] = [] }
+        allocation.each do |user_id, item_id|
+          allocations_by_item[item_id] << user_id
+        end
+
+        allocations_by_item.each do |item_id, user_ids|
+          update_existing_registrations(item_id, user_ids)
+          create_forced_assignments(item_id, user_ids)
+        end
+      end
+
+      def update_existing_registrations(item_id, user_ids)
+        # Update existing registrations
+        # rubocop:disable Rails/SkipsModelValidations
+        @campaign.user_registrations
+                 .where(registration_item_id: item_id, user_id: user_ids)
+                 .update_all(status: :confirmed, updated_at: Time.current)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      def create_forced_assignments(item_id, user_ids)
+        # Handle forced assignments: create records for users who didn't select this item
+        existing_user_ids = @campaign.user_registrations
+                                     .where(registration_item_id: item_id, user_id: user_ids)
+                                     .pluck(:user_id)
+
+        missing_user_ids = user_ids - existing_user_ids
+        return if missing_user_ids.empty?
+
+        records = missing_user_ids.map do |user_id|
+          {
+            user_id: user_id,
+            registration_item_id: item_id,
+            registration_campaign_id: @campaign.id,
+            status: Registration::UserRegistration.statuses[:confirmed],
+            preference_rank: nil,
+            created_at: Time.current,
+            updated_at: Time.current
+          }
+        end
+
+        # rubocop:disable Rails/SkipsModelValidations
+        Registration::UserRegistration.insert_all(records)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      def update_item_counts
+        # Recalculate confirmed_registrations_count for all items in the campaign
+        # This is necessary because we used update_all/delete_all/insert_all which skip callbacks
+        @campaign.registration_items.each do |item|
+          count = item.user_registrations.confirmed.count
+          # rubocop:disable Rails/SkipsModelValidations
+          item.update_columns(confirmed_registrations_count: count)
+          # rubocop:enable Rails/SkipsModelValidations
+        end
+      end
+
+      def update_campaign_status
+        # Mark the campaign as having been allocated
+        @campaign.touch(:last_allocation_calculated_at)
+
+        # Ensure campaign is in processing state (Allocation Run)
+        @campaign.update!(status: :processing) unless @campaign.processing?
+      end
+  end
+end

--- a/app/models/registration/allocation_stats.rb
+++ b/app/models/registration/allocation_stats.rb
@@ -1,0 +1,161 @@
+module Registration
+  class AllocationStats
+    attr_reader :total_registrations, :assigned_users, :unassigned_users,
+                :global_avg_rank, :percent_top_choice, :preference_counts, :items,
+                :unassigned_user_ids
+
+    def initialize(campaign, assignment)
+      @campaign = campaign
+      @assignment = assignment
+      calculate
+    end
+
+    def assigned_percentage
+      return 0 if total_registrations.zero?
+
+      (assigned_users.to_f / total_registrations * 100)
+    end
+
+    def unassigned_percentage
+      return 0 if total_registrations.zero?
+
+      (unassigned_users.to_f / total_registrations * 100)
+    end
+
+    def percentage_of_assigned(count)
+      return 0 unless assigned_users.positive?
+
+      (count.to_f / assigned_users * 100)
+    end
+
+    def item_stats
+      mapped_items = @campaign.registration_items.includes(:registerable).map do |item|
+        stats = @items[item.id] || { count: 0 }
+        capacity = item.capacity
+        {
+          item: item,
+          count: stats[:count],
+          capacity: capacity,
+          percentage: if capacity.present? && capacity.positive?
+                        (stats[:count].to_f / capacity * 100)
+                      end
+        }
+      end
+
+      mapped_items.sort_by { |data| data[:item].title }
+    end
+
+    private
+
+      def calculate
+        if @campaign.first_come_first_served?
+          calculate_fcfs
+        else
+          calculate_preference_based
+        end
+      end
+
+      def calculate_fcfs
+        @total_registrations = @campaign.total_registrations_count
+        @assigned_users = @assignment.size
+        @unassigned_users = @total_registrations - @assigned_users
+
+        # In FCFS, unassigned users are those who have registrations but are not
+        # in the assignment list (e.g. rejected or pending if any)
+        all_user_ids = @campaign.user_registrations.distinct.pluck(:user_id)
+        @unassigned_user_ids = all_user_ids - @assignment.keys
+
+        @preference_counts = Hash.new(0)
+        @items = {}
+        @global_avg_rank = 0
+        @percent_top_choice = 0
+
+        @assignment.each_value do |item_id|
+          update_item_stats(item_id, :fcfs)
+        end
+      end
+
+      def calculate_preference_based
+        user_preferences = @campaign.user_registrations
+                                    .where.not(preference_rank: nil)
+                                    .includes(:registration_item)
+                                    .order(:preference_rank)
+                                    .group_by(&:user_id)
+                                    .transform_values do |regs|
+          regs.map(&:registration_item_id)
+        end
+
+        @total_registrations = user_preferences.keys.size
+        @assigned_users = @assignment.size
+        @unassigned_users = @total_registrations - @assigned_users
+        @unassigned_user_ids = user_preferences.keys - @assignment.keys
+        @preference_counts = Hash.new(0)
+        @items = {}
+        @global_avg_rank = 0
+        @percent_top_choice = 0
+
+        @assignment.each do |user_id, item_id|
+          process_assignment(user_id, item_id, user_preferences)
+        end
+
+        calculate_averages
+        calculate_global_metrics
+      end
+
+      def process_assignment(user_id, item_id, user_preferences)
+        prefs = user_preferences[user_id] || []
+        rank_index = prefs.index(item_id)
+        rank = rank_index ? rank_index + 1 : :forced
+
+        @preference_counts[rank] += 1
+        update_item_stats(item_id, rank)
+      end
+
+      def update_item_stats(item_id, rank)
+        @items[item_id] ||= { count: 0, sum_rank: 0, forced: 0 }
+        @items[item_id][:count] += 1
+
+        if rank == :forced
+          @items[item_id][:forced] += 1
+        elsif rank == :fcfs
+          # No rank stats for FCFS
+        else
+          @items[item_id][:sum_rank] += rank
+        end
+      end
+
+      def calculate_averages
+        @items.each_value do |data|
+          valid_ranks = data[:count] - data[:forced]
+          data[:avg_rank] = if valid_ranks.positive?
+            (data[:sum_rank].to_f / valid_ranks).round(2)
+          else
+            0
+          end
+          data.delete(:sum_rank)
+        end
+      end
+
+      def calculate_global_metrics
+        return if @assigned_users.zero?
+
+        # Global Average Rank (lower is better)
+        # We exclude forced assignments from the average to avoid skewing
+        sum_rank = @preference_counts.sum do |rank, count|
+          rank == :forced ? 0 : rank * count
+        end
+
+        non_forced = @assigned_users - (@preference_counts[:forced] || 0)
+
+        @global_avg_rank = if non_forced.positive?
+          (sum_rank.to_f / non_forced).round(2)
+        else
+          0
+        end
+
+        # Percent Top Choice
+        top_choice_count = @preference_counts[1] || 0
+        @percent_top_choice = (top_choice_count.to_f / @assigned_users * 100).round(2)
+      end
+  end
+end

--- a/app/models/registration/available_items_service.rb
+++ b/app/models/registration/available_items_service.rb
@@ -1,0 +1,42 @@
+module Registration
+  # Identifies registerable items (Tutorials, Talks, or Cohorts)
+  # from the parent lecture that are not yet part of the campaign.
+  # Filters based on lecture type: seminars show Talks, regular lectures show Tutorials.
+  # Cohorts are available for all lecture types.
+  class AvailableItemsService
+    def initialize(campaign)
+      @campaign = campaign
+      @lecture = campaign.campaignable
+    end
+
+    def items
+      return {} unless @lecture.is_a?(Lecture)
+
+      groups = {}
+      add_tutorials(groups) unless @lecture.seminar?
+      add_talks(groups) if @lecture.seminar?
+      add_cohorts(groups)
+      groups
+    end
+
+    private
+
+      def add_tutorials(groups)
+        used_ids = Registration::Item.where(registerable_type: "Tutorial").pluck(:registerable_id)
+        tutorials = @lecture.tutorials.where(skip_campaigns: false).where.not(id: used_ids)
+        groups[:tutorials] = tutorials if tutorials.any?
+      end
+
+      def add_talks(groups)
+        used_ids = Registration::Item.where(registerable_type: "Talk").pluck(:registerable_id)
+        talks = @lecture.talks.where(skip_campaigns: false).where.not(id: used_ids)
+        groups[:talks] = talks if talks.any?
+      end
+
+      def add_cohorts(groups)
+        used_ids = Registration::Item.where(registerable_type: "Cohort").pluck(:registerable_id)
+        cohorts = @lecture.cohorts.where(skip_campaigns: false).where.not(id: used_ids)
+        groups[:cohorts] = cohorts if cohorts.any?
+      end
+  end
+end

--- a/app/models/registration/campaign.rb
+++ b/app/models/registration/campaign.rb
@@ -22,6 +22,8 @@ module Registration
              dependent: :destroy,
              inverse_of: :registration_campaign
 
+    has_many :users, -> { distinct }, through: :user_registrations
+
     has_many :registration_policies,
              class_name: "Registration::Policy",
              dependent: :destroy,
@@ -36,8 +38,22 @@ module Registration
                     processing: 3,
                     completed: 4 }
 
-    validates :title, :registration_deadline, :allocation_mode, :status, presence: true
-    validates :planning_only, inclusion: { in: [true, false] }
+    validates :registration_deadline, :allocation_mode, :status, presence: true
+    validates :description, length: { maximum: 100 }
+
+    validate :allocation_mode_frozen, on: :update
+    validate :cannot_revert_to_draft, on: :update
+    validate :ensure_editable, on: :update
+    validate :registration_deadline_future_if_open
+    validate :prerequisites_not_draft, if: :open?
+    validate :items_present_before_open, if: -> { status_changed? && open? }
+
+    before_destroy :ensure_campaign_is_draft, prepend: true
+    before_destroy :ensure_not_referenced_as_prerequisite, prepend: true
+
+    def locale_with_inheritance
+      campaignable.try(:locale_with_inheritance) || campaignable.try(:locale)
+    end
 
     def evaluate_policies_for(user, phase: :registration)
       policy_engine.eligible?(user, phase: phase)
@@ -47,11 +63,196 @@ module Registration
       evaluate_policies_for(user, phase: phase).pass
     end
 
+    def open_for_registrations?
+      open? && registration_deadline > Time.current
+    end
+
     def user_registration_confirmed?(user)
       user_registrations.exists?(user_id: user.id, status: :confirmed)
     end
 
+    def can_be_deleted?
+      draft?
+    end
+
+    def total_registrations_count
+      return user_registrations.map(&:user_id).uniq.size if user_registrations.loaded?
+
+      user_registrations.distinct.count(:user_id)
+    end
+
+    def confirmed_count
+      user_registrations.confirmed.distinct.count(:user_id)
+    end
+
+    def pending_count
+      # Users with at least one pending registration, but no confirmed registration.
+      # This covers:
+      # - Preference mode: All applicants before allocation (since none are confirmed).
+      # - FCFS mode: Users on the waitlist who haven't secured a spot elsewhere in this campaign.
+      user_registrations.pending
+                        .where.not(user_id: user_registrations.confirmed.select(:user_id))
+                        .distinct
+                        .count(:user_id)
+    end
+
+    def rejected_count
+      # Users with at least one rejected registration, but no confirmed or pending registration.
+      # This explicitly queries for :rejected state, ensuring we don't count possibly other future
+      # states.
+      user_registrations.rejected
+                        .where.not(user_id: user_registrations
+                        .where(status: [:confirmed,
+                                        :pending]).select(:user_id))
+                        .distinct
+                        .count(:user_id)
+    end
+
+    def user_registrations_grouped_by_user
+      user_registrations.includes(:user, :registration_item)
+                        .joins(:user)
+                        .order("users.name")
+                        .group_by(&:user)
+    end
+
+    def finalize!
+      # Protect against concurrent finalization attempts via locking
+      with_lock do
+        return if completed?
+
+        Registration::AllocationMaterializer.new(self).materialize!
+
+        # Reject all remaining pending registrations so the state is explicit
+        # rubocop:disable Rails/SkipsModelValidations
+        user_registrations.pending.update_all(status: :rejected)
+        # rubocop:enable Rails/SkipsModelValidations
+
+        update!(status: :completed)
+      end
+    end
+
+    # Returns users registered in this campaign who are not assigned to any group
+    # of the same type within the campaignable (Lecture).
+    # This respects the materialization logic: if a user is assigned via another campaign
+    # (or manually), they are considered "assigned" and thus not a candidate here.
+    def unassigned_users
+      return User.none if draft?
+
+      types = if registration_items.loaded?
+        registration_items.map(&:registerable_type).uniq
+      else
+        registration_items.pluck(:registerable_type).uniq
+      end
+
+      # Find users already assigned to ANY item of these types in the lecture.
+      allocated_user_ids = types.flat_map do |type|
+        # Optimization: Use eager-loaded associations on the campaignable logic
+        assoc = type.tableize.to_sym
+        if campaignable.respond_to?(assoc) && campaignable.association(assoc).loaded?
+          campaignable.public_send(assoc).flat_map(&:allocated_user_ids)
+        else
+          klass = type.constantize
+          scope = if type == "Cohort"
+            klass.where(context: campaignable)
+          else
+            klass.where(lecture: campaignable)
+          end
+
+          # Optimization: Use direct SQL join if the standard :members association exists.
+          # This avoids N+1 queries on instances.
+          if klass.reflect_on_association(:members)
+            scope.joins(:members).pluck("users.id")
+          else
+            # Fallback: Load instances and use the Rosterable interface.
+            # This is slower but guarantees correctness if the association name differs.
+            scope.flat_map(&:allocated_user_ids)
+          end
+        end
+      end.uniq
+
+      # Return registered users who are not in the allocated list
+      # We look at all users who have at least one registration entry in this campaign
+      # (regardless of status, as they are "candidates" until assigned elsewhere)
+      users.where.not(id: allocated_user_ids)
+    end
+
+    def roster_group_type
+      items = if association(:registration_items).loaded?
+        registration_items
+      else
+        registration_items.limit(1)
+      end
+      items.first&.registerable_type&.tableize || "tutorials"
+    end
+
     private
+
+      def ensure_editable
+        return unless completed?
+        return unless changed?
+
+        errors.add(:base, :already_finalized) unless status_changed?
+      end
+
+      def prerequisites_not_draft
+        prereq_ids = registration_policies.select { |p| p.kind == "prerequisite_campaign" }
+                                          .filter_map { |p| p.prerequisite_campaign_id.presence }
+
+        return if prereq_ids.empty?
+
+        Registration::Campaign.where(id: prereq_ids, status: :draft).find_each do |prereq|
+          errors.add(:base, :prerequisite_is_draft, description: prereq.description)
+        end
+      end
+
+      def ensure_not_referenced_as_prerequisite
+        referencing_policies = Registration::Policy
+                               .referencing_campaign(id)
+                               .where.not(registration_campaign_id: id)
+                               .includes(:registration_campaign)
+
+        return unless referencing_policies.any?
+
+        descriptions = referencing_policies.filter_map { |p| p.registration_campaign&.description }
+                                           .uniq.join(", ")
+        errors.add(:base, :referenced_as_prerequisite, descriptions: descriptions)
+        throw(:abort)
+      end
+
+      def ensure_campaign_is_draft
+        return if draft?
+
+        errors.add(:base, :cannot_delete_active_campaign)
+        throw(:abort)
+      end
+
+      def allocation_mode_frozen
+        return unless allocation_mode_changed? && status_was != "draft"
+
+        errors.add(:allocation_mode, :frozen)
+      end
+
+      def cannot_revert_to_draft
+        return unless status_changed? && draft?
+
+        errors.add(:status, :cannot_revert_to_draft)
+      end
+
+      def registration_deadline_future_if_open
+        return unless open?
+        return unless registration_deadline_changed? || status_changed?
+        return if registration_deadline.blank?
+
+        return unless registration_deadline <= Time.current
+
+        errors.add(:registration_deadline, :must_be_in_future)
+      end
+
+      def items_present_before_open
+        return unless registration_items.empty?
+
+        errors.add(:base, :no_items)
+      end
 
       def policy_engine
         @policy_engine ||= Registration::PolicyEngine.new(self)

--- a/app/models/registration/finalization_guard.rb
+++ b/app/models/registration/finalization_guard.rb
@@ -1,0 +1,75 @@
+module Registration
+  class FinalizationGuard
+    Result = Struct.new(:success?, :error_code, :error_message, :data, keyword_init: true)
+
+    def initialize(campaign)
+      @campaign = campaign
+    end
+
+    def check(ignore_policies: false)
+      if @campaign.completed?
+        return failure(:already_completed,
+                       I18n.t("registration.allocation.errors.already_completed"))
+      end
+
+      # 1. Status Check
+      # FCFS must be closed. Preference-based must be processing.
+      if @campaign.preference_based?
+        unless @campaign.processing?
+          return failure(:wrong_status,
+                         I18n.t("registration.allocation.errors.wrong_status"))
+        end
+      else
+        unless @campaign.closed?
+          return failure(:wrong_status,
+                         I18n.t("registration.allocation.errors.wrong_status"))
+        end
+      end
+
+      # 2. Policy Check
+      unless ignore_policies
+        policy_errors = check_policies
+        if policy_errors.any?
+          return failure(:policy_violation,
+                         I18n.t("registration.allocation.errors.policy_violation"), policy_errors)
+        end
+      end
+
+      success
+    end
+
+    private
+
+      def check_policies
+        # Check policies that apply to finalization phase (or both)
+        policies = @campaign.registration_policies.active.for_phase(:finalization)
+        return [] if policies.empty?
+
+        invalid_users = []
+
+        @campaign.user_registrations.confirmed.includes(:user).find_each do |registration|
+          user = registration.user
+          policies.each do |policy|
+            result = policy.evaluate(user)
+            next if result[:pass]
+
+            invalid_users << { user_id: user.id,
+                               registration_id: registration.id,
+                               name: user.name,
+                               email: user.email,
+                               policy: policy.kind }
+          end
+        end
+
+        invalid_users
+      end
+
+      def success
+        Result.new(success?: true)
+      end
+
+      def failure(code, message, data = nil)
+        Result.new(success?: false, error_code: code, error_message: message, data: data)
+      end
+  end
+end

--- a/app/models/registration/item.rb
+++ b/app/models/registration/item.rb
@@ -22,15 +22,97 @@ module Registration
                class_name: "Registration::Campaign",
                inverse_of: :registration_items
 
-    belongs_to :registerable, polymorphic: true
+    belongs_to :registerable, polymorphic: true, autosave: true
+
+    delegate :capacity, :capacity=, to: :registerable, allow_nil: true
 
     has_many :user_registrations,
              class_name: "Registration::UserRegistration",
-             dependent: :destroy
+             foreign_key: :registration_item_id,
+             dependent: :destroy,
+             inverse_of: :registration_item
 
     validates :registerable_id,
               uniqueness: {
                 scope: [:registration_campaign_id, :registerable_type]
               }
+
+    validate :validate_registerable_allows_campaigns, on: :create
+    validate :validate_capacity_reduction, on: :update
+    validate :validate_uniqueness_constraints
+    before_destroy :ensure_campaign_is_draft
+
+    def title
+      registerable&.registration_title || registerable&.title
+    end
+
+    def confirmed_user_ids
+      user_registrations.confirmed.pluck(:user_id)
+    end
+
+    # Validates if a capacity change initiated by the registerable (e.g. on a Tutorial
+    # in the tutorial GUI) is permissible under the current campaign rules.
+    def validate_capacity_change_from_registerable!(new_capacity)
+      unless valid_capacity_reduction?(new_capacity)
+        confirmed_count = user_registrations.confirmed.count
+        return [:base, :capacity_too_low, { count: confirmed_count }]
+      end
+
+      nil
+    end
+
+    def first_choice_count
+      user_registrations.where(preference_rank: 1).count
+    end
+
+    private
+
+      def valid_capacity_reduction?(new_capacity)
+        return true if registration_campaign.draft?
+        # After completion, we trust the user (teacher) to manage capacity vs roster size.
+        return true if registration_campaign.completed?
+        return true unless registration_campaign.first_come_first_served?
+        return true if new_capacity.nil?
+
+        confirmed_count = user_registrations.confirmed.count
+        new_capacity >= confirmed_count
+      end
+
+      def validate_capacity_reduction
+        return unless registerable&.will_save_change_to_capacity?
+
+        return if valid_capacity_reduction?(capacity)
+
+        confirmed_count = user_registrations.confirmed.count
+        errors.add(:base, :capacity_too_low, count: confirmed_count)
+      end
+
+      def ensure_campaign_is_draft
+        return if registration_campaign.draft?
+
+        errors.add(:base, :frozen)
+        throw(:abort)
+      end
+
+      def validate_uniqueness_constraints
+        return unless registerable
+
+        scope = Registration::Item.where(registerable: registerable)
+        scope = scope.where.not(id: id) if persisted?
+
+        return unless scope.exists?
+
+        errors.add(:base, :already_in_other_campaign)
+      end
+
+      # Registerables that have the skip_campaigns flag set are excluded from
+      # becoming items in campaigns.
+      def validate_registerable_allows_campaigns
+        return unless registerable
+        return unless registerable.respond_to?(:skip_campaigns?)
+        return unless registerable.skip_campaigns?
+
+        errors.add(:base, :registerable_not_managed_by_campaign)
+      end
   end
 end

--- a/app/models/registration/policy.rb
+++ b/app/models/registration/policy.rb
@@ -17,7 +17,10 @@ module Registration
 
     validates :kind, :phase, presence: true
     validates :active, inclusion: { in: [true, false] }
-    validates :position, uniqueness: { scope: :registration_campaign_id }
+    validate :campaign_is_draft, on: [:create, :update]
+    validate :validate_config
+
+    before_destroy :ensure_campaign_is_draft
 
     acts_as_list scope: :registration_campaign
 
@@ -27,68 +30,70 @@ module Registration
       where(phase: [phases[:both], phases[phase]])
     }
 
-    def evaluate(user)
-      case kind.to_sym
-      when :institutional_email
-        evaluate_institutional_email(user)
-      when :prerequisite_campaign
-        evaluate_prerequisite_campaign(user)
-      else
-        raise(ArgumentError, "Unknown policy kind: #{kind}")
+    scope :referencing_campaign, lambda { |campaign_id|
+      where("config->>'prerequisite_campaign_id' = ?", campaign_id.to_s)
+    }
+
+    # Virtual attributes for form handling and validation
+    def allowed_domains
+      val = config&.fetch("allowed_domains", nil)
+      return val if val.is_a?(String)
+
+      Array(val).join(", ")
+    end
+
+    def allowed_domains=(value)
+      self.config ||= {}
+      self.config["allowed_domains"] = value
+    end
+
+    def prerequisite_campaign_id
+      config&.fetch("prerequisite_campaign_id", nil)
+    end
+
+    def prerequisite_campaign_id=(value)
+      self.config ||= {}
+      self.config["prerequisite_campaign_id"] = value
+    end
+
+    def config_summary
+      handler.summary || "-"
+    end
+
+    delegate :evaluate, to: :handler
+
+    def handler
+      return Registration::Policy::Handler.new(self) if kind.blank?
+
+      @handler ||= case kind.to_sym
+                   when :institutional_email
+                     Registration::Policy::InstitutionalEmailHandler.new(self)
+                   when :prerequisite_campaign
+                     Registration::Policy::PrerequisiteCampaignHandler.new(self)
+                   when :student_performance
+                     Registration::Policy::Handler.new(self)
+                   else
+                     raise(ArgumentError, "Unknown policy kind: #{kind}")
       end
     end
 
     private
 
-      def pass_result(code = :ok, details = {})
-        { pass: true, code: code, details: details }
+      def campaign_is_draft
+        return unless registration_campaign && !registration_campaign.draft?
+
+        errors.add(:base, :frozen)
       end
 
-      def fail_result(code, message, details = {})
-        { pass: false, code: code, message: message, details: details }
+      def validate_config
+        handler.validate
       end
 
-      def evaluate_institutional_email(user)
-        domains = Array(config&.fetch("allowed_domains", nil)).map do |domain|
-          (domain || "").strip.downcase
-        end.reject(&:empty?)
+      def ensure_campaign_is_draft
+        return unless registration_campaign && !registration_campaign.draft?
 
-        return fail_result(:configuration_error, "No allowed domains configured") if domains.empty?
-
-        email = user.email.to_s.downcase
-        allowed = domains.any? do |domain|
-          email.end_with?("@#{domain}")
-        end
-
-        if allowed
-          pass_result(:domain_ok)
-        else
-          fail_result(:institutional_email_mismatch, "Email domain not allowed",
-                      allowed_domains: domains)
-        end
-      end
-
-      def evaluate_prerequisite_campaign(user)
-        campaign_id = config&.fetch("prerequisite_campaign_id", nil)
-
-        if campaign_id.blank?
-          return fail_result(:configuration_error,
-                             "Prerequisite campaign not configured")
-        end
-
-        prereq_campaign = Registration::Campaign.find_by(id: campaign_id)
-
-        unless prereq_campaign
-          return fail_result(:prerequisite_campaign_not_found,
-                             "Prerequisite campaign missing")
-        end
-
-        if prereq_campaign.user_registration_confirmed?(user)
-          pass_result(:prerequisite_met)
-        else
-          fail_result(:prerequisite_not_met,
-                      "Prerequisite campaign not completed")
-        end
+        errors.add(:base, :frozen)
+        throw(:abort)
       end
   end
 end

--- a/app/models/registration/policy/handler.rb
+++ b/app/models/registration/policy/handler.rb
@@ -1,0 +1,39 @@
+module Registration
+  class Policy
+    # Base class for policy handlers.
+    # Encapsulates logic for validation, evaluation, and summary of a specific policy kind.
+    class Handler
+      attr_reader :policy
+
+      def initialize(policy)
+        @policy = policy
+      end
+
+      def evaluate(_user)
+        raise(NotImplementedError)
+      end
+
+      def validate
+        # Default no-op
+      end
+
+      def summary
+        "-"
+      end
+
+      protected
+
+        def config
+          policy.config || {}
+        end
+
+        def pass_result(code = :ok, details = {})
+          { pass: true, code: code, details: details }
+        end
+
+        def fail_result(code, message, details = {})
+          { pass: false, code: code, message: message, details: details }
+        end
+    end
+  end
+end

--- a/app/models/registration/policy/institutional_email_handler.rb
+++ b/app/models/registration/policy/institutional_email_handler.rb
@@ -1,0 +1,49 @@
+module Registration
+  class Policy
+    # Handles the "Institutional Email" policy.
+    # Checks if the user's email address ends with one of the allowed domains.
+    class InstitutionalEmailHandler < Handler
+      def evaluate(user)
+        return fail_result(:configuration_error, "No allowed domains configured") if domains.empty?
+
+        email = user.email.to_s.downcase
+        allowed = domains.any? do |domain|
+          email.end_with?("@#{domain}", ".#{domain}")
+        end
+
+        if allowed
+          pass_result(:domain_ok)
+        else
+          fail_result(:institutional_email_mismatch, "Email domain not allowed",
+                      allowed_domains: domains)
+        end
+      end
+
+      def validate
+        return unless domains.empty?
+
+        policy.errors.add(:allowed_domains, I18n.t("registration.policy.errors.missing_domains"))
+      end
+
+      def summary
+        domains.join(", ")
+      end
+
+      private
+
+        def domains
+          @domains ||= parse_domains(config["allowed_domains"])
+        end
+
+        def parse_domains(raw)
+          raw_domains = raw
+          list = if raw_domains.is_a?(String)
+            raw_domains.split(",")
+          else
+            Array(raw_domains)
+          end
+          list.map { |d| (d || "").strip.downcase.delete_prefix(".") }.reject(&:empty?)
+        end
+    end
+  end
+end

--- a/app/models/registration/policy/prerequisite_campaign_handler.rb
+++ b/app/models/registration/policy/prerequisite_campaign_handler.rb
@@ -1,0 +1,50 @@
+module Registration
+  class Policy
+    # Handles the "Prerequisite Campaign" policy.
+    # Checks if the user has a confirmed registration in a specific other campaign.
+    class PrerequisiteCampaignHandler < Handler
+      def evaluate(user)
+        if campaign_id.blank?
+          return fail_result(:configuration_error,
+                             "Prerequisite campaign not configured")
+        end
+        unless campaign
+          return fail_result(:prerequisite_campaign_not_found,
+                             "Prerequisite campaign missing")
+        end
+
+        if campaign.user_registration_confirmed?(user)
+          pass_result(:prerequisite_met)
+        else
+          fail_result(:prerequisite_not_met, "Prerequisite campaign not completed")
+        end
+      end
+
+      def validate
+        if campaign_id.blank?
+          policy.errors.add(:prerequisite_campaign_id,
+                            I18n.t("registration.policy.errors.missing_prerequisite_campaign"))
+        elsif !Registration::Campaign.exists?(campaign_id)
+          policy.errors.add(:prerequisite_campaign_id,
+                            I18n.t("registration.policy.errors.prerequisite_campaign_not_found"))
+        end
+      end
+
+      def summary
+        campaign&.description
+      end
+
+      private
+
+        def campaign_id
+          config["prerequisite_campaign_id"]
+        end
+
+        def campaign
+          return @campaign if defined?(@campaign)
+
+          @campaign = Registration::Campaign.find_by(id: campaign_id)
+        end
+    end
+  end
+end

--- a/app/models/registration/registerable.rb
+++ b/app/models/registration/registerable.rb
@@ -5,17 +5,54 @@ module Registration
   module Registerable
     extend ActiveSupport::Concern
 
+    included do
+      has_many :registration_items, as: :registerable, class_name: "Registration::Item"
+
+      before_update :validate_capacity_change_via_items
+    end
+
     # Models including this concern must:
     # - Have a `capacity` integer column (nullable: nil = infinite capacity)
+    # - Have a `skip_campaigns` boolean column (default: false, allows manual-only management)
     # - Implement #allocated_user_ids (returns array of user IDs)
     # - Implement #materialize_allocation!(user_ids:, campaign:)
+    #
+    # Note: Including Rosters::Rosterable provides default implementations for
+    # the last two requirements.
 
     def allocated_user_ids
-      raise(NotImplementedError, "Registerable must implement #allocated_user_ids")
+      raise(NotImplementedError,
+            "#{self.class} must implement #allocated_user_ids. You may want to include Rosters::Rosterable.")
     end
 
     def materialize_allocation!(user_ids:, campaign:)
-      raise(NotImplementedError, "Registerable must implement #materialize_allocation!")
+      raise(NotImplementedError,
+            "#{self.class} must implement #materialize_allocation!. You may want to include Rosters::Rosterable.")
     end
+
+    private
+
+      # Enforces registration rules when updating capacity directly on the registerable.
+      # Delegates validation to associated registration items to ensure consistency.
+      def validate_capacity_change_via_items
+        return unless will_save_change_to_capacity?
+
+        registration_items.each do |item|
+          error = item.validate_capacity_change_from_registerable!(capacity)
+
+          next unless error
+
+          _key, msg, options = error
+          # Map :base errors from Item to :capacity errors on Registerable
+          # We must translate the message here using the Item scope, otherwise
+          # Rails will try to look it up in the Registerable scope (e.g. Lecture)
+          # where it doesn't exist.
+          translated_msg = I18n.t(
+            "activerecord.errors.models.registration/item.attributes.base.#{msg}", **(options || {})
+          )
+          errors.add(:capacity, translated_msg)
+          throw(:abort)
+        end
+      end
   end
 end

--- a/app/models/registration/solvers/min_cost_flow.rb
+++ b/app/models/registration/solvers/min_cost_flow.rb
@@ -1,0 +1,189 @@
+require "or-tools"
+
+module Registration
+  module Solvers
+    class MinCostFlow
+      # Scale factor to allow adding random noise for tie-breaking without violating rank order.
+      # Rank 1 becomes 1000..1999, Rank 2 becomes 2000..2999.
+      COST_SCALE = 1_000
+
+      # Cost for leaving a user unassigned (must be higher than any possible preference cost)
+      UNASSIGNED_COST = 1_000_000 * COST_SCALE
+      # Cost for assigning a user to an item they didn't select (when force_assignments: true)
+      FORCED_COST = 5_000 * COST_SCALE
+
+      # @param campaign [Registration::Campaign]
+      # @param force_assignments [Boolean] If true, adds high-cost edges to non-selected items,
+      #   allowing users to be assigned to items they didn't choose if necessary.
+      #   If false, users can only be assigned to their preferences or remain unassigned.
+      #   Note: The unassigned path (dummy node) is always available as a last resort.
+      def initialize(campaign, force_assignments: true)
+        @campaign = campaign
+        @force_assignments = force_assignments
+
+        # Load data
+        # Fetch all registrations (preferences) for this campaign
+        @registrations = campaign.user_registrations.includes(:user)
+
+        # Identify unique users involved in the campaign
+        @user_ids = @registrations.map(&:user_id).uniq
+        @items = campaign.registration_items.includes(:registerable)
+
+        # Map IDs to 0..N indices for the solver
+        @user_to_idx = @user_ids.each_with_index.to_h
+        @item_to_idx = @items.map(&:id).each_with_index.to_h
+      end
+
+      def run
+        return {} if @user_ids.empty?
+
+        build_and_solve
+      end
+
+      private
+
+        def build_and_solve
+          mcf = ORTools::SimpleMinCostFlow.new
+
+          # Node Indices
+          source = 0
+          user_offset = 1
+          item_offset = user_offset + @user_ids.size
+          sink_real = item_offset + @items.size
+          dummy_node = sink_real + 1
+          sink_final = dummy_node + 1
+
+          # Supply / Demand
+          # Source produces flow equal to number of users
+          mcf.set_node_supply(source, @user_ids.size)
+          # Sink has demand equal to number of users
+          mcf.set_node_supply(sink_final, -@user_ids.size)
+
+          # Edges: Source -> Users
+          @user_ids.each_with_index do |_, i|
+            mcf.add_arc_with_capacity_and_unit_cost(source, user_offset + i, 1, 0)
+          end
+
+          # Edges: Users -> Items (Preferences & Forced)
+          # Pre-load preferences: user_id -> { item_id -> rank }
+          user_prefs = @registrations.group_by(&:user_id).transform_values do |regs|
+            regs.to_h { |r| [r.registration_item_id, r.preference_rank] }
+          end
+
+          @user_ids.each_with_index do |user_id, u_idx|
+            prefs = user_prefs[user_id] || {}
+
+            @items.each_with_index do |item, i_idx|
+              rank = prefs[item.id]
+
+              if rank
+                # Preference edge with random noise for tie-breaking
+                # Cost = Rank * 1000 + Random(0..999)
+                cost = (rank * COST_SCALE) + rand(COST_SCALE)
+
+                mcf.add_arc_with_capacity_and_unit_cost(
+                  user_offset + u_idx,
+                  item_offset + i_idx,
+                  1,
+                  cost
+                )
+              elsif @force_assignments
+                # Forced assignment edge (only if unassigned is NOT allowed)
+                # Add noise here too for consistency
+                cost = FORCED_COST + rand(COST_SCALE)
+
+                mcf.add_arc_with_capacity_and_unit_cost(
+                  user_offset + u_idx,
+                  item_offset + i_idx,
+                  1,
+                  cost
+                )
+              end
+            end
+          end
+
+          # Edges: Items -> Sink
+          @items.each_with_index do |item, i|
+            # nil capacity means unlimited (modeled as total user count, since
+            # flow cannot exceed supply)
+            cap = item.capacity.nil? ? @user_ids.size : [item.capacity.to_i, 0].max
+
+            # Items flow into the real sink
+            mcf.add_arc_with_capacity_and_unit_cost(
+              item_offset + i,
+              sink_real,
+              cap,
+              0
+            )
+          end
+
+          # Edges: Dummy Node (Unassigned)
+          # Always allow unassigned path as a fallback (with high penalty)
+          # Users -> Dummy (High Cost)
+          @user_ids.each_with_index do |_, i|
+            # Add noise to unassigned cost so that if we MUST reject people,
+            # the choice of whom to reject is also randomized.
+            cost = UNASSIGNED_COST + rand(COST_SCALE)
+
+            mcf.add_arc_with_capacity_and_unit_cost(
+              user_offset + i,
+              dummy_node,
+              1,
+              cost
+            )
+          end
+
+          # Dummy -> SinkFinal
+          mcf.add_arc_with_capacity_and_unit_cost(
+            dummy_node,
+            sink_final,
+            @user_ids.size,
+            0
+          )
+
+          # SinkReal -> SinkFinal (Pass-through for assigned flow)
+          mcf.add_arc_with_capacity_and_unit_cost(
+            sink_real,
+            sink_final,
+            @user_ids.size,
+            0
+          )
+
+          status = mcf.solve
+
+          if status == :optimal
+            extract_solution(mcf, user_offset, item_offset)
+          else
+            Rails.logger.error("MinCostFlow solver failed with status: #{status}")
+            {}
+          end
+        end
+
+        def extract_solution(mcf, user_offset, item_offset)
+          allocation = {}
+
+          # Iterate over all arcs to find active assignments
+          mcf.num_arcs.times do |arc|
+            next unless mcf.flow(arc).positive?
+
+            tail = mcf.tail(arc)
+            head = mcf.head(arc)
+
+            # Check if this arc is User -> Item
+            next unless tail >= user_offset && tail < item_offset &&
+                        head >= item_offset && head < item_offset + @items.size
+
+            u_idx = tail - user_offset
+            i_idx = head - item_offset
+
+            user_id = @user_ids[u_idx]
+            item_id = @items[i_idx].id
+
+            allocation[user_id] = item_id
+          end
+
+          allocation
+        end
+    end
+  end
+end

--- a/app/models/registration/user_registration.rb
+++ b/app/models/registration/user_registration.rb
@@ -10,7 +10,8 @@ module Registration
                inverse_of: :user_registrations
 
     belongs_to :registration_item,
-               class_name: "Registration::Item"
+               class_name: "Registration::Item",
+               inverse_of: :user_registrations
 
     enum :status, { pending: 0, confirmed: 1, rejected: 2 }
 
@@ -18,13 +19,19 @@ module Registration
 
     validate :ensure_item_belongs_to_campaign, if: :registration_item
 
-    # preference-based campaigns: rank required and unique per user+campaign
-    # For the uniqueness validation, there is also a DB index to enforce it at the
-    # database level (see the schema).
+    # preference-based campaigns: rank required unless it is a forced assignment
+    # (confirmed with no rank).
     validates :preference_rank,
               presence: true,
+              if: -> { registration_campaign.preference_based? && !confirmed? }
+
+    # preference-based campaigns: rank must be unique per user+campaign.
+    # We allow nil here because forced assignments (nil rank) are handled by the
+    # partial index `index_reg_user_regs_unique_unranked` in the database.
+    validates :preference_rank,
               uniqueness: {
-                scope: [:user_id, :registration_campaign_id]
+                scope: [:user_id, :registration_campaign_id],
+                allow_nil: true
               },
               if: -> { registration_campaign.preference_based? }
 
@@ -41,7 +48,42 @@ module Registration
               },
               if: -> { registration_campaign.first_come_first_served? }
 
+    after_create :increment_confirmed_counter
+    after_update :update_confirmed_counter
+    after_destroy :decrement_confirmed_counter
+
     private
+
+      # We use increment_counter/decrement_counter to update the counter cache
+      # atomically without instantiating the item or running its validations.
+      # This is the intended behavior for counter caches.
+      # rubocop:disable Rails/SkipsModelValidations
+      def increment_confirmed_counter
+        return unless confirmed? && registration_item_id
+
+        Registration::Item.increment_counter(:confirmed_registrations_count, registration_item_id)
+      end
+
+      def decrement_confirmed_counter
+        return unless confirmed? && registration_item_id
+
+        Registration::Item.decrement_counter(:confirmed_registrations_count, registration_item_id)
+      end
+
+      def update_confirmed_counter
+        return unless saved_change_to_status? && registration_item_id
+
+        old_status, new_status = saved_change_to_status
+        was_confirmed = old_status == "confirmed"
+        is_confirmed = new_status == "confirmed"
+
+        if !was_confirmed && is_confirmed
+          Registration::Item.increment_counter(:confirmed_registrations_count, registration_item_id)
+        elsif was_confirmed && !is_confirmed
+          Registration::Item.decrement_counter(:confirmed_registrations_count, registration_item_id)
+        end
+      end
+      # rubocop:enable Rails/SkipsModelValidations
 
       def ensure_item_belongs_to_campaign
         return if registration_item.registration_campaign_id == registration_campaign_id

--- a/app/models/rosters/maintenance_service.rb
+++ b/app/models/rosters/maintenance_service.rb
@@ -1,0 +1,105 @@
+module Rosters
+  class UserAlreadyInBundleError < StandardError
+    attr_reader :conflicting_group
+
+    def initialize(conflicting_group)
+      @conflicting_group = conflicting_group
+      super
+    end
+  end
+
+  class MaintenanceService
+    # Manages manual roster operations (add, remove, move) while enforcing capacity
+    # constraints and ensuring transactional integrity
+    class CapacityExceededError < StandardError; end
+
+    def add_user!(user, rosterable, force: false)
+      return if user_in_roster?(user, rosterable)
+
+      ensure_uniqueness!(user, rosterable)
+
+      unless force || within_capacity?(rosterable)
+        raise(CapacityExceededError,
+              "Capacity exceeded for #{rosterable.class.name} #{rosterable.id}")
+      end
+
+      rosterable.add_user_to_roster!(user)
+      propagate_to_lecture!(user, rosterable)
+      update_registration_materialization(user, rosterable)
+    end
+
+    def remove_user!(user, rosterable)
+      rosterable.remove_user_from_roster!(user)
+      cascade_removal_from_subgroups!(user, rosterable)
+    end
+
+    def move_user!(user, from_rosterable, to_rosterable, force: false)
+      ActiveRecord::Base.transaction do
+        remove_user!(user, from_rosterable)
+        add_user!(user, to_rosterable, force: force)
+      end
+    end
+
+    private
+
+      def user_in_roster?(user, rosterable)
+        rosterable.roster_entries.exists?(rosterable.roster_user_id_column => user.id)
+      end
+
+      def within_capacity?(rosterable)
+        return true unless rosterable.respond_to?(:capacity)
+        return true if rosterable.capacity.nil?
+
+        rosterable.roster_entries.count < rosterable.capacity
+      end
+
+      def update_registration_materialization(user, rosterable)
+        Registration::Item.where(registerable: rosterable).find_each do |item|
+          # rubocop:disable Rails/SkipsModelValidations
+          item.user_registrations.where(user: user)
+              .update_all(materialized_at: Time.current)
+          # rubocop:enable Rails/SkipsModelValidations
+        end
+      end
+
+      def ensure_uniqueness!(user, rosterable)
+        return unless rosterable.is_a?(Tutorial)
+
+        siblings = rosterable.lecture.tutorials.where.not(id: rosterable.id)
+        membership = TutorialMembership.where(tutorial: siblings, user: user).first
+
+        return unless membership
+
+        raise(UserAlreadyInBundleError, membership.tutorial)
+      end
+
+      def propagate_to_lecture!(user, rosterable)
+        return if rosterable.is_a?(Cohort) && !rosterable.propagate_to_lecture?
+        return unless rosterable.respond_to?(:lecture)
+
+        lecture = rosterable.lecture
+        return unless lecture.is_a?(Lecture)
+        return if lecture == rosterable
+
+        lecture.ensure_roster_membership!([user.id])
+      end
+
+      def cascade_removal_from_subgroups!(user, rosterable)
+        return unless rosterable.is_a?(Lecture)
+
+        rosterable.tutorials.find_each do |tutorial|
+          tutorial.remove_user_from_roster!(user)
+        end
+
+        rosterable.talks.find_each do |talk|
+          talk.remove_user_from_roster!(user)
+        end
+
+        rosterable.cohorts.find_each do |cohort|
+          next unless cohort.propagate_to_lecture?
+
+          cohort.remove_user_from_roster!(user)
+        end
+      end
+  end
+end

--- a/app/models/rosters/participant_query.rb
+++ b/app/models/rosters/participant_query.rb
@@ -1,0 +1,73 @@
+module Rosters
+  # Service object to query participants of a Lecture with filtering options.
+  class ParticipantQuery
+    Result = Struct.new(:scope, :total_count, :unassigned_count, :filter_mode, keyword_init: true)
+
+    def initialize(lecture, params)
+      @lecture = lecture
+      @params = params
+    end
+
+    def call
+      filter_mode = @params[:filter] || "all"
+
+      base_scope =
+        @lecture.lecture_memberships
+                .joins(:user)
+                .includes(:user)
+                .order(Arel.sql("COALESCE(NULLIF(users.name_in_tutorials, ''), users.name) ASC"))
+
+      total_count = base_scope.count
+
+      unassigned_scope = build_unassigned_scope(base_scope)
+      unassigned_count = unassigned_scope.count
+
+      scope = case filter_mode
+              when "unassigned"
+                unassigned_scope
+              else
+                base_scope
+      end
+
+      Result.new(
+        scope: scope,
+        total_count: total_count,
+        unassigned_count: unassigned_count,
+        filter_mode: filter_mode
+      )
+    end
+
+    private
+
+      def build_unassigned_scope(base_scope)
+        # Users in tutorial memberships for this lecture
+        tutorial_user_ids = TutorialMembership.joins(:tutorial)
+                                              .where(tutorials: { lecture_id: @lecture.id })
+                                              .select(:user_id)
+
+        # Users in talk memberships for this lecture
+        talk_user_ids = SpeakerTalkJoin.joins(:talk)
+                                       .where(talks: { lecture_id: @lecture.id })
+                                       .select(:speaker_id)
+
+        # Users in Access Cohorts (which propagate directly to lecture roster)
+        # Waitlist cohorts do not count as "having a spot", so we treat them as unassigned
+        # unless they are also in a tutorial.
+        # Currently, the `propagate_to_lecture` flag serves as a proxy for "Access Cohort".
+        cohort_user_ids = CohortMembership.joins(:cohort)
+                                          .where(cohorts: {
+                                                   context_id: @lecture.id,
+                                                   context_type: "Lecture",
+                                                   propagate_to_lecture: true
+                                                 })
+                                          .select(:user_id)
+
+        # Rails 7+ allows .union but can be finicky with different table structures / primary keys
+        # We manually construct the SQL to be safe regardless of the primary key differences
+        assigned_ids_sql = "(#{tutorial_user_ids.to_sql}) UNION (#{talk_user_ids.to_sql}) " \
+                           "UNION (#{cohort_user_ids.to_sql})"
+
+        base_scope.where("lecture_memberships.user_id NOT IN (#{assigned_ids_sql})")
+      end
+  end
+end

--- a/app/models/rosters/roster_superset_checker.rb
+++ b/app/models/rosters/roster_superset_checker.rb
@@ -1,0 +1,139 @@
+module Rosters
+  class RosterSupersetChecker
+    class RosterSupersetViolationError < StandardError; end
+
+    def check_all_lectures!
+      Rails.logger.info("[RosterSupersetChecker] Starting nightly check")
+
+      total_lectures = 0
+      total_violations = 0
+
+      lectures_to_check = relevant_lectures
+
+      lectures_to_check.find_each do |lecture|
+        total_lectures += 1
+
+        lecture_ids = lecture_user_ids(lecture)
+        group_ids = propagating_group_user_ids(lecture)
+
+        violations = find_violations(lecture, lecture_ids, group_ids)
+
+        if violations.any?
+          total_violations += violations.size
+          log_violation(lecture, violations)
+        end
+      end
+
+      Rails.logger.info("[RosterSupersetChecker] Completed: " \
+                        "checked #{total_lectures} lectures, " \
+                        "found #{total_violations} violations")
+
+      return unless total_violations.positive?
+
+      raise(RosterSupersetViolationError,
+            "Found #{total_violations} user(s) missing from lecture rosters " \
+            "(checked #{total_lectures} lectures). Check logs for details.")
+    end
+
+    private
+
+      # Returns lectures from the active term and the next term.
+      # This scopes validation to currently relevant lectures, avoiding
+      # unnecessary checks on historical/archived data.
+      def relevant_lectures
+        active_term = Term.active
+        return Lecture.none if active_term.blank?
+
+        term_ids = [active_term.id]
+        term_ids << active_term.next&.id if active_term.next.present?
+
+        Lecture.where(term_id: term_ids)
+      end
+
+      def lecture_user_ids(lecture)
+        lecture.lecture_memberships.pluck(:user_id).uniq
+      end
+
+      def propagating_group_user_ids(lecture)
+        # We intentionally skip SpeakerTalkJoins here. Historical seminars
+        # created before lecture-level rosters existed have speakers in talks
+        # but not in lecture rosters, which would cause false positives.
+        tutorial_ids = TutorialMembership
+                       .joins(:tutorial)
+                       .where(tutorials: { lecture_id: lecture.id })
+                       .pluck(:user_id)
+
+        cohort_ids = CohortMembership
+                     .joins(:cohort)
+                     .where(cohorts: { context_type: "Lecture",
+                                       context_id: lecture.id,
+                                       propagate_to_lecture: true })
+                     .pluck(:user_id)
+
+        (tutorial_ids + cohort_ids).uniq
+      end
+
+      def find_violations(lecture, lecture_ids, group_ids)
+        missing_ids = group_ids - lecture_ids
+        return [] if missing_ids.empty?
+
+        users_by_id = User.where(id: missing_ids)
+                          .index_by(&:id)
+
+        tutorial_groups =
+          lecture.tutorials
+                 .joins(:tutorial_memberships)
+                 .where(tutorial_memberships: { user_id: missing_ids })
+                 .select("tutorials.id, tutorials.title, tutorial_memberships.user_id")
+                 .group_by(&:user_id)
+
+        cohort_groups = lecture.cohorts
+                               .where(propagate_to_lecture: true)
+                               .joins(:cohort_memberships)
+                               .where(cohort_memberships: { user_id: missing_ids })
+                               .select("cohorts.id, cohorts.title, cohort_memberships.user_id")
+                               .group_by(&:user_id)
+
+        missing_ids.map do |user_id|
+          user = users_by_id[user_id]
+          groups = []
+
+          tutorial_groups[user_id]&.each do |tutorial|
+            groups << "Tutorial: #{tutorial.title}"
+          end
+
+          cohort_groups[user_id]&.each do |cohort|
+            groups << "Cohort: #{cohort.title}"
+          end
+
+          {
+            user_id: user_id,
+            user_email: user&.email || "Unknown",
+            found_in_groups: groups
+          }
+        end
+      end
+
+      def log_violation(lecture, violations)
+        return if violations.empty?
+
+        log_data = {
+          timestamp: Time.current.iso8601,
+          lecture_id: lecture.id,
+          lecture_title: lecture.title,
+          violation_count: violations.size,
+          violations: violations
+        }
+
+        Rails.logger.error("[RosterSupersetViolation] #{log_data.to_json}")
+
+        Rails.logger.error("Lecture #{lecture.id} (#{lecture.title}): " \
+                           "#{violations.size} user(s) missing from roster")
+
+        violations.each do |v|
+          Rails.logger.error("  - User #{v[:user_id]} (#{v[:user_email]}): " \
+                             "in #{v[:found_in_groups].join(", ")}")
+        end
+      end
+  end
+end

--- a/app/models/rosters/rosterable.rb
+++ b/app/models/rosters/rosterable.rb
@@ -1,0 +1,307 @@
+module Rosters
+  # Standardizes roster management interfaces across models like Lectures, Tutorials and Talks.
+  # Provides idempotent synchronization logic to update campaign-based assignments while preserving
+  # manual entries.
+  module Rosterable
+    extend ActiveSupport::Concern
+
+    TYPES = ["Tutorial", "Talk", "Cohort", "Lecture"].freeze
+
+    # Models including this concern must:
+    # - Implement #roster_entries (returns ActiveRecord::Relation)
+    #
+    # Models that are also Registerable should additionally:
+    # - Have a `skip_campaigns` boolean column (default: false)
+    #   (This allows switching between campaign-managed and manual roster management)
+
+    included do
+      # Abstract method to retrieve the roster entries (e.g., memberships or joins)
+      # Should return an ActiveRecord::Relation
+      def roster_entries
+        raise(NotImplementedError, "#{self.class} must implement #roster_entries")
+      end
+
+      # Override this method if the foreign key for the user in the roster entry is not :user_id
+      def roster_user_id_column
+        :user_id
+      end
+
+      # Override this method if the association name doesn't follow the pattern
+      # #{model_name}_memberships (e.g., Talk uses :speaker_talk_joins)
+      def roster_association_name
+        :"#{self.class.name.underscore}_memberships"
+      end
+
+      enum :self_materialization_mode, {
+        disabled: 0,
+        add_only: 1,
+        remove_only: 2,
+        add_and_remove: 3
+      }, prefix: true
+
+      before_validation :enforce_consistency_between_modes
+      validate :validate_skip_campaigns_switch
+      validate :validate_self_materialization_switch
+      before_destroy :enforce_rosterable_destruction_constraints, prepend: true
+    end
+
+    # Checks if the item can be safely destroyed.
+    def destructible?
+      !in_campaign? && roster_empty?
+    end
+
+    # Checks if the roster is locked for manual modifications.
+    # Models without skip_campaigns (e.g., Lecture) are never locked.
+    # A roster is locked if campaigns are NOT skipped AND no campaign
+    # has been completed yet.
+    def locked?
+      return false unless respond_to?(:skip_campaigns)
+      return false if skip_campaigns?
+
+      !in_completed_campaign?
+    end
+
+    # Checks if skip_campaigns can be enabled (switched from false to true).
+    # This is only allowed if the item has never been part of any campaign.
+    # Models without skip_campaigns always return false.
+    def can_skip_campaigns?
+      return false unless respond_to?(:skip_campaigns)
+
+      !in_campaign?
+    end
+
+    # Checks if skip_campaigns can be disabled (switched from true to false).
+    # This is generally allowed as long as the roster is empty (to prevent data loss/inconsistency),
+    # but since we enforce "once in campaign, always in campaign" via can_skip_campaigns?,
+    # the reverse path is less critical but should still be safe.
+    # For now, we allow it if the roster is empty.
+    # Models without skip_campaigns always return false.
+    def can_unskip_campaigns?
+      return false unless respond_to?(:skip_campaigns)
+
+      roster_empty?
+    end
+
+    # Checks if the roster is currently empty.
+    def roster_entries_count
+      association_name = roster_association_name
+
+      if association_name && association(association_name).loaded?
+        public_send(association_name).size
+      else
+        roster_entries.count
+      end
+    end
+
+    def roster_empty?
+      association_name = roster_association_name
+
+      if association_name && association(association_name).loaded?
+        public_send(association_name).empty?
+      else
+        !roster_entries.exists?
+      end
+    end
+
+    # Checks if the item is associated with any campaign.
+    def in_campaign?
+      return false unless respond_to?(:registration_items)
+
+      return @in_campaign if defined?(@in_campaign)
+
+      @in_campaign = registration_items.exists?
+    end
+
+    # Checks if the item is associated with a completed campaign.
+    def in_completed_campaign?
+      return false unless respond_to?(:registration_items)
+
+      return @in_completed_campaign if defined?(@in_completed_campaign)
+
+      @in_completed_campaign = Registration::Campaign
+                               .joins(:registration_items)
+                               .where(registration_items: { registerable_id: id,
+                                                            registerable_type: self.class.name })
+                               .exists?(status: :completed)
+    end
+
+    # Returns the IDs of users currently in the roster.
+    # Required by the Registration::Registerable concern.
+    def allocated_user_ids
+      if roster_entries.loaded?
+        roster_entries.map { |e| e.public_send(roster_user_id_column) }
+      else
+        roster_entries.pluck(roster_user_id_column)
+      end
+    end
+
+    # Adds a single user to the roster.
+    # Can be overridden by the model if custom logic/callbacks are needed.
+    def add_user_to_roster!(user, source_campaign = nil)
+      roster_entries.create!(
+        roster_user_id_column => user.id,
+        :source_campaign => source_campaign
+      )
+    end
+
+    # Removes a single user from the roster.
+    # Can be overridden by the model if custom logic/callbacks are needed.
+    def remove_user_from_roster!(user)
+      roster_entries.find_by(roster_user_id_column => user.id)&.destroy
+    end
+
+    # Updates the roster based on the target list of users and the source campaign.
+    # - Synchronizes the local roster (bulk adds/removes users for this campaign).
+    # - Propagates new members to the parent lecture roster (if applicable).
+    def materialize_allocation!(user_ids:, campaign:)
+      transaction do
+        current_ids = roster_entries.pluck(roster_user_id_column)
+        target_ids = user_ids.uniq
+
+        add_missing_users!(target_ids, current_ids, campaign)
+        remove_excess_users!(target_ids, campaign)
+        propagate_to_lecture!(target_ids)
+      end
+    end
+
+    def propagate_to_lecture!(user_ids)
+      return if user_ids.empty?
+
+      return if is_a?(Cohort) && !propagate_to_lecture
+
+      return unless respond_to?(:lecture)
+
+      parent = lecture
+      return unless parent.is_a?(Lecture)
+      return if parent == self
+
+      parent.ensure_roster_membership!(user_ids)
+    end
+
+    # Identifies users in the target list who are not yet in the roster and
+    # performs a bulk insert to add them efficiently, associating them with
+    # the given campaign.
+    def add_missing_users!(target_ids, current_ids, campaign)
+      users_to_add = target_ids - current_ids
+      return if users_to_add.empty?
+
+      # insert_all does not automatically apply the association scope (e.g. foreign keys).
+      # We must explicitly merge the scope attributes (like { tutorial_id: 123 }).
+      scope_attrs = roster_entries.scope_attributes
+
+      attributes = users_to_add.map do |uid|
+        {
+          roster_user_id_column => uid,
+          :source_campaign_id => campaign.id,
+          :created_at => Time.current,
+          :updated_at => Time.current
+        }.merge(scope_attrs)
+      end
+      roster_entries.insert_all(attributes) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    # Identifies users currently in the roster associated with this specific
+    # campaign but not in the target list, and removes them. This cleans up
+    # allocations from the same campaign that are no longer valid,
+    # without touching members added manually or by other campaigns.
+    def remove_excess_users!(target_ids, campaign)
+      roster_entries.where(source_campaign: campaign)
+                    .where.not(roster_user_id_column => target_ids)
+                    .delete_all
+    end
+
+    # Checks if the roster is over capacity.
+    def over_capacity?
+      return false unless respond_to?(:capacity)
+      return false if capacity.nil?
+
+      roster_entries_count > capacity
+    end
+
+    # Checks if the roster is full (reached or exceeded capacity).
+    def full?
+      return false unless respond_to?(:capacity)
+      return false if capacity.nil?
+
+      roster_entries_count >= capacity
+    end
+
+    # Returns the group type symbol for this rosterable (e.g. :tutorials, :talks).
+    def roster_group_type
+      self.class.name.tableize.to_sym
+    end
+
+    private
+
+      def validate_skip_campaigns_switch
+        return unless respond_to?(:skip_campaigns)
+        return if new_record?
+        return unless skip_campaigns_changed?
+
+        if skip_campaigns?
+          # Switching from false (Campaign Mode) to true (Skip Campaigns)
+          # Only allowed if never in any campaign
+          errors.add(:base, I18n.t("roster.errors.campaign_associated")) if in_campaign?
+        else
+          # Switching from true (Skip Campaigns) to false (Campaign Mode)
+          # Only allowed if roster is empty (to avoid data inconsistency)
+          errors.add(:base, I18n.t("roster.errors.roster_not_empty")) unless roster_empty?
+        end
+      end
+
+      def validate_self_materialization_switch
+        return unless self_materialization_mode_changed?
+
+        if is_a?(Lecture) && !self_materialization_mode_disabled?
+          errors.add(:self_materialization_mode,
+                     I18n.t("roster.errors.lecture_cannot_self_materialize"))
+          return
+        end
+
+        return if self_materialization_mode_disabled?
+        return unless respond_to?(:skip_campaigns)
+
+        return unless locked?
+
+        errors.add(:base, I18n.t("roster.errors.campaign_associated"))
+      end
+
+      def enforce_rosterable_destruction_constraints
+        if in_campaign?
+          errors.add(:base, I18n.t("roster.errors.cannot_delete_in_campaign"))
+          throw(:abort)
+        end
+
+        return if roster_empty?
+
+        errors.add(:base, I18n.t("roster.errors.cannot_delete_not_empty"))
+        throw(:abort)
+      end
+
+      def enforce_consistency_between_modes
+        return unless respond_to?(:skip_campaigns)
+
+        # Detect conflicting user intent - both changed in same request
+        if skip_campaigns_changed? && self_materialization_mode_changed? &&
+           !skip_campaigns? && !self_materialization_mode_disabled?
+          errors.add(:base,
+                     I18n.t("roster.errors.cannot_enable_both_campaign_and_self_materialization"))
+          return
+        end
+
+        # Auto-disable self-materialization when switching to campaign mode
+        # (only if user didn't explicitly change self_materialization_mode)
+        if skip_campaigns_changed? && !skip_campaigns? && !self_materialization_mode_changed?
+          self.self_materialization_mode = :disabled
+          return
+        end
+
+        # Auto-enable skip_campaigns when enabling self-materialization
+        # (only if user didn't explicitly change skip_campaigns)
+        if self_materialization_mode_changed? && !self_materialization_mode_disabled? &&
+           !skip_campaigns_changed? && !in_campaign?
+          self.skip_campaigns = true
+        end
+      end
+  end
+end

--- a/app/models/rosters/stream_service.rb
+++ b/app/models/rosters/stream_service.rb
@@ -1,0 +1,88 @@
+module Rosters
+  # Generates Turbo Stream responses for roster updates.
+  #
+  # IMPORTANT: This service assumes the caller has already performed
+  # authorization checks. It should only be called from authorized controller
+  # actions. The service does not perform authorization itself.
+  class StreamService
+    def initialize(lecture, view_context)
+      @lecture = lecture
+      @view_context = view_context
+    end
+
+    # Call this when the structure of the roster changes
+    # (e.g. created group, deleted group, changed propagate_to_lecture)
+    def roster_changed(group_type: :all, flash: nil)
+      streams = []
+
+      # 1. Refresh the Roster List (lazy load for performance)
+      streams << refresh_roster_frame(group_type)
+
+      # 2. Flash
+      streams << render_flash(flash) if flash
+
+      streams.compact
+    end
+
+    # Call this when a single item's attributes change, but it stays in the same bucket
+    # (e.g. renamed tutorial, changed capacity)
+    # If structural update is needed, falls back to roster_changed
+    def item_updated(item, group_type: :all, flash: nil)
+      # If the change affects grouping (e.g. propagation), we must refresh the list
+      return roster_changed(group_type: group_type, flash: flash) if structural_change?(item)
+
+      # Otherwise, just replace the card in place
+      streams = []
+      streams << @view_context.turbo_stream.replace(
+        dom_id(item),
+        partial: "roster/components/groups_tab/item_tile",
+        locals: {
+          item: item,
+          component: component_for_item,
+          group: group_params_for(item),
+          group_type: group_type
+        }
+      )
+      streams << render_flash(flash) if flash
+      streams.compact
+    end
+
+    private
+
+      def refresh_roster_frame(group_type)
+        frame_id = "roster_groups"
+
+        @view_context.turbo_stream.replace(
+          frame_id,
+          @view_context
+          .turbo_frame_tag(frame_id,
+                           src: @view_context.lecture_roster_path(@lecture,
+                                                                  group_type: group_type),
+                           loading: "lazy")
+        )
+      end
+
+      # Mimics the behavior of Flash#include logic in partials, but adapted for service use.
+      # Generally we prepend to #flash-messages.
+      def render_flash(_flash)
+        @view_context.turbo_stream.prepend("flash-messages", partial: "flash/message")
+      end
+
+      def dom_id(record)
+        ActionView::RecordIdentifier.dom_id(record)
+      end
+
+      def structural_change?(item)
+        item.is_a?(Cohort) && item.saved_change_to_propagate_to_lecture?
+      end
+
+      def component_for_item
+        RosterOverviewComponent.new(lecture: @lecture)
+      end
+
+      def group_params_for(item)
+        # Mocking the group hash expected by the partial for styling (e.g. .cohort class)
+        { type: item.class.name.tableize.to_sym }
+      end
+  end
+end

--- a/app/models/speaker_talk_join.rb
+++ b/app/models/speaker_talk_join.rb
@@ -1,4 +1,7 @@
+# Represents a user's role as a speaker for a talk, tracking the source campaign
+# to distinguish between automated allocations and manual assignments.
 class SpeakerTalkJoin < ApplicationRecord
   belongs_to :talk
   belongs_to :speaker, class_name: "User", inverse_of: :speaker_talk_joins
+  belongs_to :source_campaign, class_name: "Registration::Campaign", optional: true
 end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -58,6 +58,12 @@ class Term < ApplicationRecord
     Term.find_by(year: previous_year, season: previous_season)
   end
 
+  def next
+    next_year = season == "SS" ? year : year + 1
+    next_season = season == "SS" ? "WS" : "SS"
+    Term.find_by(year: next_year, season: next_season)
+  end
+
   def assignments
     Assignment.where(lecture: lectures)
   end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -2,11 +2,16 @@ require "csv"
 
 class Tutorial < ApplicationRecord
   include Registration::Registerable
+  include Rosters::Rosterable
 
   belongs_to :lecture, touch: true
 
   has_many :tutor_tutorial_joins, dependent: :destroy
   has_many :tutors, through: :tutor_tutorial_joins
+
+  # Roster associations
+  has_many :tutorial_memberships, dependent: :destroy
+  has_many :members, through: :tutorial_memberships, source: :user
 
   has_many :submissions, dependent: :destroy
 
@@ -15,10 +20,18 @@ class Tutorial < ApplicationRecord
   before_destroy :check_destructibility, prepend: true
 
   validates :title, uniqueness: { scope: [:lecture_id] }, presence: true
+  validate :lecture_must_not_be_seminar
+
   def title_with_tutors
     return "#{title}, #{I18n.t("basics.tba")}" unless tutors.any?
 
     "#{title}, #{tutor_names}"
+  end
+
+  def registration_title
+    return title unless tutors.any?
+
+    "#{title} (#{tutor_names})"
   end
 
   def tutor_names
@@ -28,7 +41,7 @@ class Tutorial < ApplicationRecord
   end
 
   def destructible?
-    Submission.where(tutorial: self).proper.none?
+    super && Submission.where(tutorial: self).proper.none?
   end
 
   def teams_to_csv(assignment)
@@ -45,10 +58,38 @@ class Tutorial < ApplicationRecord
     tutors << tutor unless tutors.include?(tutor)
   end
 
+  def roster_entries
+    tutorial_memberships
+  end
+
+  def materialize_allocation!(user_ids:, campaign:)
+    enforce_lecture_uniqueness!(user_ids)
+    super
+  end
+
   private
 
+    def enforce_lecture_uniqueness!(user_ids)
+      # Enforce uniqueness: A student can only be in one tutorial per lecture.
+      # If we are about to add a student to this tutorial, remove them from any other
+      # tutorial in the same lecture.
+      TutorialMembership.joins(:tutorial)
+                        .where(tutorials: { lecture_id: lecture_id })
+                        .where.not(tutorial_id: id)
+                        .where(user_id: user_ids)
+                        .delete_all
+    end
+
     def check_destructibility
-      throw(:abort) unless destructible?
-      true
+      return unless Submission.where(tutorial: self).proper.any?
+
+      errors.add(:base, I18n.t("controllers.tutorials.errors.cannot_delete_with_submissions"))
+      throw(:abort)
+    end
+
+    def lecture_must_not_be_seminar
+      return unless lecture&.seminar?
+
+      errors.add(:lecture, :must_not_be_seminar)
     end
 end

--- a/app/models/tutorial_membership.rb
+++ b/app/models/tutorial_membership.rb
@@ -1,0 +1,24 @@
+# Represents a user's assignment to a tutorial group, tracking the source campaign
+# to distinguish between automated allocations and manual enrollments.
+class TutorialMembership < ApplicationRecord
+  belongs_to :user
+  belongs_to :tutorial
+  belongs_to :source_campaign, class_name: "Registration::Campaign", optional: true
+
+  validate :unique_membership_per_lecture
+
+  private
+
+    def unique_membership_per_lecture
+      return unless tutorial
+
+      scope = TutorialMembership.joins(:tutorial)
+                                .where(tutorials: { lecture_id: tutorial.lecture_id })
+                                .where(user_id: user_id)
+      scope = scope.where.not(id: id) if persisted?
+
+      return unless scope.exists?
+
+      errors.add(:base, :already_in_lecture_tutorial)
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,16 @@ class User < ApplicationRecord
   has_many :lecture_user_joins, dependent: :destroy
   has_many :lectures, -> { distinct }, through: :lecture_user_joins
 
+  # Roster memberships
+  has_many :lecture_memberships, dependent: :destroy
+  has_many :enrolled_lectures, through: :lecture_memberships, source: :lecture
+
+  has_many :tutorial_memberships, dependent: :destroy
+  has_many :enrolled_tutorials, through: :tutorial_memberships, source: :tutorial
+
+  has_many :cohort_memberships, dependent: :destroy
+  has_many :cohorts, through: :cohort_memberships
+
   # a user has many favorite lectures
   has_many :user_favorite_lecture_joins, dependent: :destroy
   has_many :favorite_lectures, -> { distinct },

--- a/app/models/voucher/voucher.rb
+++ b/app/models/voucher/voucher.rb
@@ -41,7 +41,11 @@ class Voucher < ApplicationRecord
   self.implicit_order_column = :created_at
 
   def self.roles_for_lecture(lecture)
-    return ROLE_HASH.keys if lecture.seminar?
+    if lecture.seminar?
+      return ROLE_HASH.keys - [:tutor] if Flipper.enabled?(:roster_maintenance)
+
+      return ROLE_HASH.keys
+    end
 
     ROLE_HASH.keys - [:speaker]
   end

--- a/app/workers/campaign_status_worker.rb
+++ b/app/workers/campaign_status_worker.rb
@@ -1,0 +1,12 @@
+class CampaignStatusWorker
+  include Sidekiq::Worker
+
+  def perform
+    # Auto-close campaigns that are open and have passed their deadline
+    Registration::Campaign.where(status: :open)
+                          .where(registration_deadline: ..Time.current)
+                          .find_each do |campaign|
+      campaign.update(status: :closed)
+    end
+  end
+end

--- a/app/workers/roster_superset_checker_job.rb
+++ b/app/workers/roster_superset_checker_job.rb
@@ -1,0 +1,12 @@
+class RosterSupersetCheckerJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default,
+                  retry: false,
+                  backtrace: true,
+                  dead: true
+
+  def perform
+    Rosters::RosterSupersetChecker.new.check_all_lectures!
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module Mampf
     backend_paths = Rails.root.glob("app/models/**/")
     backend_paths -= Rails.root.glob("app/models/vignettes/**/")
     backend_paths -= Rails.root.glob("app/models/registration/**/")
+    backend_paths -= Rails.root.glob("app/models/rosters/**/")
     frontend_paths = Rails.root.glob("app/frontend/**/")
     # For ViewComponents to work correctly with namespaces, we only load the
     # main components directory, but not any subdirectories.

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,46 @@
+Rails.application.configure do
+  ## Memoization ensures that only one adapter call is made per feature per request.
+  ## For more info, see https://www.flippercloud.io/docs/optimization#memoization
+  # config.flipper.memoize = true
+
+  ## Flipper preloads all features before each request, which is recommended if:
+  ##   * you have a limited number of features (< 100?)
+  ##   * most of your requests depend on most of your features
+  ##   * you have limited gate data combined across all features
+  ## (< 1k enabled gates, like individual actors, across all features)
+  ##
+  ## For more info, see https://www.flippercloud.io/docs/optimization#preloading
+  # config.flipper.preload = true
+
+  ## Warn or raise an error if an unknown feature is checked
+  ## Can be set to `:warn`, `:raise`, or `false`
+  # config.flipper.strict = Rails.env.development? && :warn
+
+  ## Show Flipper checks in logs
+  # config.flipper.log = true
+
+  ## Reconfigure Flipper to use the Memory adapter and disable Cloud in tests
+  # config.flipper.test_help = true
+
+  ## The path that Flipper Cloud will use to sync features
+  # config.flipper.cloud_path = "_flipper"
+
+  ## The instrumenter that Flipper will use. Defaults to ActiveSupport::Notifications.
+  # config.flipper.instrumenter = ActiveSupport::Notifications
+end
+
+Flipper.configure do |config|
+  ## Configure other adapters that you want to use here:
+  ## See http://flippercloud.io/docs/adapters
+  # config.use Flipper::Adapters::ActiveSupportCacheStore, Rails.cache, expires_in: 5.minutes
+end
+
+## Register a group that can be used for enabling features.
+##
+##   Flipper.enable_group :my_feature, :admins
+##
+## See https://www.flippercloud.io/docs/features#enablement-group
+#
+# Flipper.register(:admins) do |actor|
+#  actor.respond_to?(:admin?) && actor.admin?
+# end

--- a/db/migrate/20251225000000_remove_planning_only_and_lecture_capacity.rb
+++ b/db/migrate/20251225000000_remove_planning_only_and_lecture_capacity.rb
@@ -1,0 +1,6 @@
+class RemovePlanningOnlyAndLectureCapacity < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :registration_campaigns, :planning_only, :boolean
+    remove_column :lectures, :capacity, :integer
+  end
+end

--- a/db/migrate/20251225000001_remove_uniqueness_index_from_registration_policies.rb
+++ b/db/migrate/20251225000001_remove_uniqueness_index_from_registration_policies.rb
@@ -1,0 +1,7 @@
+class RemoveUniquenessIndexFromRegistrationPolicies < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :registration_policies, name: "index_registration_policies_uniqueness"
+    add_index :registration_policies, [:registration_campaign_id, :position],
+              name: "index_registration_policies_position"
+  end
+end

--- a/db/migrate/20251225000002_create_flipper_tables.rb
+++ b/db/migrate/20251225000002_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[8.0]
+  def up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.text :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/migrate/20251225000003_rename_title_to_description_in_registration_campaigns.rb
+++ b/db/migrate/20251225000003_rename_title_to_description_in_registration_campaigns.rb
@@ -1,0 +1,6 @@
+class RenameTitleToDescriptionInRegistrationCampaigns < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :registration_campaigns, :title, :description
+    change_column_null :registration_campaigns, :description, true
+  end
+end

--- a/db/migrate/20251226000000_add_confirmed_registrations_count_to_registration_items.rb
+++ b/db/migrate/20251226000000_add_confirmed_registrations_count_to_registration_items.rb
@@ -1,0 +1,6 @@
+class AddConfirmedRegistrationsCountToRegistrationItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :registration_items, :confirmed_registrations_count, :integer, default: 0,
+                                                                              null: false
+  end
+end

--- a/db/migrate/20251226000001_add_unique_index_to_registration_items.rb
+++ b/db/migrate/20251226000001_add_unique_index_to_registration_items.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToRegistrationItems < ActiveRecord::Migration[8.0]
+  def change
+    add_index :registration_items, [:registerable_type, :registerable_id],
+              unique: true,
+              name: "index_registration_items_on_unique_registerable"
+  end
+end

--- a/db/migrate/20251226000002_create_cohorts.rb
+++ b/db/migrate/20251226000002_create_cohorts.rb
@@ -1,0 +1,24 @@
+class CreateCohorts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :cohorts do |t|
+      t.string :title
+      t.text :description
+      t.integer :capacity
+      t.references :context, polymorphic: true, null: false
+      t.integer :purpose, default: 0, null: false
+      t.boolean :propagate_to_lecture, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :cohorts, [:context_type, :context_id, :purpose]
+
+    add_check_constraint :cohorts,
+                         "NOT (purpose = 2 AND propagate_to_lecture = true)",
+                         name: "planning_cohorts_must_not_propagate"
+
+    add_check_constraint :cohorts,
+                         "NOT (purpose = 1 AND propagate_to_lecture = false)",
+                         name: "enrollment_cohorts_must_propagate"
+  end
+end

--- a/db/migrate/20251227000000_create_roster_tables.rb
+++ b/db/migrate/20251227000000_create_roster_tables.rb
@@ -1,0 +1,39 @@
+class CreateRosterTables < ActiveRecord::Migration[8.0]
+  def change
+    # Stores the official roster for tutorials
+    create_table :tutorial_memberships, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :tutorial, null: false, foreign_key: true
+      # Tracks which campaign put the user here (for smart merges)
+      t.references :source_campaign, type: :uuid, foreign_key: { to_table: :registration_campaigns }
+
+      t.timestamps
+    end
+    add_index :tutorial_memberships, [:user_id, :tutorial_id], unique: true
+
+    # Stores the official roster for lectures (distinct from subscriptions/lecture_user_joins)
+    create_table :lecture_memberships, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :lecture, null: false, foreign_key: true
+      t.references :source_campaign, type: :uuid, foreign_key: { to_table: :registration_campaigns }
+
+      t.timestamps
+    end
+    add_index :lecture_memberships, [:user_id, :lecture_id], unique: true
+
+    # Stores the official roster for cohorts
+    create_table :cohort_memberships, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :cohort, null: false, foreign_key: true
+      t.references :source_campaign, type: :uuid, foreign_key: { to_table: :registration_campaigns }
+
+      t.timestamps
+    end
+    add_index :cohort_memberships, [:user_id, :cohort_id], unique: true
+
+    # Add tracking to the existing join table for talks
+    add_reference :speaker_talk_joins, :source_campaign,
+                  type: :uuid,
+                  foreign_key: { to_table: :registration_campaigns }
+  end
+end

--- a/db/migrate/20251227000001_add_last_allocation_calculated_at_to_registration_campaigns.rb
+++ b/db/migrate/20251227000001_add_last_allocation_calculated_at_to_registration_campaigns.rb
@@ -1,0 +1,5 @@
+class AddLastAllocationCalculatedAtToRegistrationCampaigns < ActiveRecord::Migration[8.0]
+  def change
+    add_column :registration_campaigns, :last_allocation_calculated_at, :datetime
+  end
+end

--- a/db/migrate/20251227000002_add_materialized_at_to_user_registrations.rb
+++ b/db/migrate/20251227000002_add_materialized_at_to_user_registrations.rb
@@ -1,0 +1,5 @@
+class AddMaterializedAtToUserRegistrations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :registration_user_registrations, :materialized_at, :datetime
+  end
+end

--- a/db/migrate/20251229000000_add_skip_campaigns_to_registerables.rb
+++ b/db/migrate/20251229000000_add_skip_campaigns_to_registerables.rb
@@ -1,0 +1,7 @@
+class AddSkipCampaignsToRegisterables < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tutorials, :skip_campaigns, :boolean, default: false, null: false
+    add_column :talks, :skip_campaigns, :boolean, default: false, null: false
+    add_column :cohorts, :skip_campaigns, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260110000000_add_self_materialization_mode_to_rosterables.rb
+++ b/db/migrate/20260110000000_add_self_materialization_mode_to_rosterables.rb
@@ -1,0 +1,14 @@
+class AddSelfMaterializationModeToRosterables < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tutorials, :self_materialization_mode, :integer, default: 0
+    add_column :cohorts, :self_materialization_mode, :integer, default: 0
+    add_column :talks, :self_materialization_mode, :integer, default: 0
+    add_column :lectures, :self_materialization_mode, :integer, default: 0
+
+    add_index :tutorials, :self_materialization_mode
+    add_index :cohorts, :self_materialization_mode
+    add_index :talks, :self_materialization_mode
+    # No index for lectures: Lectures as rosterables need the column but the value
+    # is always 0 (disabled), so indexing is not useful.
+  end
+end


### PR DESCRIPTION
These are only the `.rb` files changed in #1017 to maybe give Copilot a chance to review those separately from the view. However, files from the `spec/` folder are excluded, those are included in #1023.