### PR TITLE
Architecture book: Bring back changes to docs from PR 7.2

### DIFF
--- a/architecture/src/features/03-rosters.md
+++ b/architecture/src/features/03-rosters.md
@@ -120,6 +120,17 @@ The “contract” required by the maintenance service, defining how to read and
 - **Campaign Tracking:** The `materialize_allocation!` method preserves manually-added roster entries while replacing campaign-sourced entries, using the `source_campaign` field on join table records.
 - **Self-Materialization:** Enables student-initiated roster changes as an alternative to campaigns or post-campaign follow-up. Default is `disabled` (staff-only access).
 
+### Management Mode & Campaign Integration
+The `Rosterable` concern introduces a `skip_campaigns` boolean flag to explicitly control the lifecycle of the roster.
+
+- **Campaign Mode (`skip_campaigns: false`):** The roster is managed by registration campaigns. This is the default state. Even in campaign mode, manual adjustments (moves/adds) are allowed *after* the campaign is completed.
+- **Direct Management (`skip_campaigns: true`):** The roster is managed exclusively by staff. Users can be added or removed directly at any time. This is intended for groups that will *never* be part of a registration campaign (e.g., special "late-comers" groups or directly managed seminars).
+- **Transition Rules:**
+  - **Campaign → Skip:** Only allowed if the group has **never** been part of a real (non-planning) campaign. Once a group is used in a campaign, it is locked into campaign mode to ensure the integrity of the allocation process.
+  - **Skip → Campaign:** Only allowed if the roster is currently **empty**. This prevents data inconsistency where manually added students might be overwritten or ignored by the campaign allocation logic.
+
+This flag serves as a safety guardrail, ensuring that items with existing memberships aren't accidentally attached to a campaign which might overwrite them.
+
 ### Example Implementation
 ```ruby
 # filepath: app/models/concerns/roster/rosterable.rb

--- a/architecture/src/features/03-rosters.md
+++ b/architecture/src/features/03-rosters.md
@@ -126,7 +126,7 @@ The `Rosterable` concern introduces a `skip_campaigns` boolean flag to explicitl
 - **Campaign Mode (`skip_campaigns: false`):** The roster is managed by registration campaigns. This is the default state. Even in campaign mode, manual adjustments (moves/adds) are allowed *after* the campaign is completed.
 - **Direct Management (`skip_campaigns: true`):** The roster is managed exclusively by staff. Users can be added or removed directly at any time. This is intended for groups that will *never* be part of a registration campaign (e.g., special "late-comers" groups or directly managed seminars).
 - **Transition Rules:**
-  - **Campaign → Skip:** Only allowed if the group has **never** been part of a real (non-planning) campaign. Once a group is used in a campaign, it is locked into campaign mode to ensure the integrity of the allocation process.
+  - **Campaign → Skip:** Only allowed if the group has **never** been part of a campaign. Once a group is used in a campaign, it is locked into campaign mode to ensure the integrity of the allocation process.
   - **Skip → Campaign:** Only allowed if the roster is currently **empty**. This prevents data inconsistency where manually added students might be overwritten or ignored by the campaign allocation logic.
 
 This flag serves as a safety guardrail, ensuring that items with existing memberships aren't accidentally attached to a campaign which might overwrite them.

--- a/architecture/src/features/04-assessments-and-grading.md
+++ b/architecture/src/features/04-assessments-and-grading.md
@@ -29,6 +29,126 @@ We use a unified grading model with clear separation of concerns:
 
 ---
 
+## Tab Organization & Creation Contexts
+
+```admonish tip "Understanding the Separation"
+Assessable items (Assignments, Exams, Talks) are **created** in different tabs based on their primary purpose, but all are **graded** in a unified Assessments tab. This separates the creation context from the grading context.
+```
+
+### Where Things Are Created & Graded
+
+| Assessable Type | Created In        | Graded In         | Rationale                                                   |
+|-----------------|-------------------|-------------------|-------------------------------------------------------------|
+| **Assignment**  | Assessments Tab   | Assessments Tab   | Pure grading artifact; homework exists primarily to be graded |
+| **Exam**        | Assessments Tab   | Assessments Tab   | Pure grading artifact; exams exist primarily to assess knowledge |
+| **Talk**        | Roster/Groups Tab | Assessments Tab   | Seminar presentation created as part of roster setup; grading is secondary |
+| **Achievement** | TBD               | Assessments Tab   | Future: certificates/badges awarded based on performance |
+
+### Tab Purposes
+
+**Assessments Tab (Grading Hub):**
+- Primary interface for **all grading activities**
+- Lists assignments, exams, and talks together
+- Unified grading workflow for all types
+- Manage tasks/questions, enter grades, publish results
+- **Focus:** "What needs to be graded this week?"
+
+**Roster/Groups Tab (Seminar Organization):**
+- Create talks for seminars
+- Set up talk registration campaigns
+- Allocate students to presentation slots
+- Manage speaker rosters
+- **Focus:** "Who is presenting when?"
+
+**Registration Tab (Logistics Service):**
+- Configure registration campaigns **for existing exams**
+- Students register for exam slots
+- Allocate students to exam times/rooms
+- Finalize exam rosters
+- **Focus:** "Who is taking this exam and where?"
+
+### Workflow Examples
+
+**Creating an Assignment:**
+1. Teacher goes to **Assessments Tab**
+2. Clicks "New Assignment"
+3. System creates Assignment + Assessment (if flag enabled)
+4. Seeds participations from lecture tutorials
+5. Teacher adds tasks/problems
+6. Stays in Assessments Tab to grade
+
+**Creating an Exam:**
+1. Teacher goes to **Assessments Tab**
+2. Creates exam with date, duration, room capacity
+3. Adds exam questions as tasks
+4. (Later) Goes to **Registration Tab** to set up registration campaign
+5. Students register, allocations finalized, roster populated
+6. Returns to **Assessments Tab** to grade
+
+**Creating a Talk:**
+1. Teacher goes to **Roster/Groups Tab**
+2. Creates talk slot for seminar
+3. Sets up registration campaign for speakers
+4. Allocates students to presentation slots
+5. Talk appears automatically in **Assessments Tab** (if flag enabled)
+6. After presentation, goes to **Assessments Tab** to grade
+
+### Unified Assessments Index
+
+The Assessments Tab shows all gradeable items in one list, regardless of creation origin:
+
+```
+📊 Assessments for Linear Algebra WS2026
+
+┌─────────────────────────────────────────────────────┐
+│ Type       │ Title                │ Status          │
+├─────────────────────────────────────────────────────┤
+│ Assignment │ Homework 1           │ Graded ✓        │
+│ Assignment │ Homework 2           │ Grading... ⏳    │
+│ Exam       │ Midterm              │ Graded ✓        │
+│ Talk       │ Group Theory Talk    │ Pending grade   │
+│ Assignment │ Homework 3           │ Not started     │
+│ Exam       │ Final Exam           │ Registration ⏳  │
+└─────────────────────────────────────────────────────┘
+```
+
+```admonish success "Key Principle"
+**Creation context preserves domain meaning, grading context unifies workflow.**
+
+Teachers create items where they make semantic sense (homework vs presentations), but grade everything in one place for consistency and efficiency.
+```
+
+### Grading Tab vs. Performance Tab
+
+```admonish question "Why do we have both a Grading tab and a Performance tab?"
+The **Grading tab** (in the Assessment Dashboard) and the **Performance tab** (in the Roster Dashboard) serve different purposes despite some apparent overlap.
+```
+
+| Dimension | Grading Tab (Assessment) | Performance Tab (Roster) |
+|-----------|--------------------------|--------------------------|
+| **Location** | Assessment Dashboard (single assessment) | Roster Dashboard (lecture-wide) |
+| **Primary axis** | Tasks (columns) × Students (rows) | Assessments (columns) × Students (rows) |
+| **Editing** | Yes — enter points per task | No — read-only aggregate |
+| **Scope** | One assessment (e.g., "Homework 3") | All assessments in the lecture |
+| **Question answered** | "How did students do on Problem 2?" | "Is Alice eligible for the exam?" |
+| **User journey** | Grading workflow → enter data | Certification workflow → review eligibility |
+
+**The "filter to one assignment" overlap:** The Performance tab can filter to show a single assessment, which superficially resembles the Grading tab. However:
+1. Performance tab remains **read-only** — it consumes grading data, it doesn't produce it.
+2. Grading tab shows **task-level breakdown** — Performance shows only the total per assessment.
+3. Performance tab provides **cross-assessment context** — even when filtered, switching views is instant.
+
+```admonish tip "Design Pattern"
+This layered approach (detail view + aggregate view) is common in well-designed systems:
+- **Banking:** Transaction details vs. account statement
+- **LMS (Moodle/Canvas):** Assignment grading page vs. gradebook overview
+- **GitHub:** PR diff view vs. repository insights
+
+The names already signal the distinction: **grading** (verb, action) vs. **performance** (noun, outcome).
+```
+
+---
+
 ## Assessment::Assessment (ActiveRecord Model)
 **_The Gradebook Container_**
 
@@ -51,18 +171,21 @@ The main fields and methods of `Assessment` are:
 | `requires_points`         | DB column         | Boolean: whether this assessment tracks per-task points                  |
 | `requires_submission`     | DB column         | Boolean: whether students must upload files                              |
 | `total_points`            | DB column         | Optional maximum points (computed from tasks if blank)                   |
-| `status`                  | DB column (Enum)  | Workflow state: `draft` (0), `open` (1), `closed` (2), `graded` (3), `archived` (4) |
-| `visible_from`            | DB column         | Timestamp when assessment becomes visible to students                    |
-| `due_at`                  | DB column         | Deadline for submissions                                                 |
-| `results_published`       | DB column         | Boolean: whether students can see their points and grades                |
+| `results_published_at`    | DB column         | Timestamp when results were published (null = unpublished)               |
 | `participations`          | Association       | All student records for this assessment                                  |
 | `tasks`                   | Association       | Tasks (problems) for this assessment (only if `requires_points`)         |
 | `task_points`             | Association       | All task points through participations                                   |
 | `effective_total_points`  | Method            | Returns `total_points` or sum of task max_points                         |
 | `seed_participations_from!(user_ids:)` | Method | Creates participation records for given users                    |
 
-```admonish warning "Submission Support - Current Scope"
-The `requires_submission` field is currently only used for **Assignment** types. Submission interfaces (upload, view, grade) are only implemented for assignments. For Exams and Talks, this field should remain `false` as no submission workflow exists for these types yet. See [Future Extensions](10-future-extensions.md) for planned support.
+```admonish warning "Submission Support - Configurable for Assignments"
+The `requires_submission` field controls whether students must upload files:
+
+- **Assignments:** Configurable. Defaults to `true` (digital submission), but can be set to `false` for paper-based homework collected during tutorials. Editable in the Assessment Settings tab.
+- **Exams:** Always `false`. Exams are graded in person or from scanned papers.
+- **Talks:** Always `false`. Presentations are graded live.
+
+When `requires_submission: false`, the participation workflow skips the `submitted` status, and the Grading Tab shows only grading progress (not submission progress).
 ```
 
 ### Behavior Highlights
@@ -87,13 +210,15 @@ module Assessment
     has_many :task_points, through: :participations,
       class_name: "Assessment::TaskPoint"
 
-  enum status: { draft: 0, open: 1, closed: 2, graded: 3, archived: 4 }
-
   validates :title, presence: true
   validate :tasks_only_when_requires_points
 
   def effective_total_points
     total_points.presence || tasks.sum(:max_points)
+  end
+
+  def results_published?
+    results_published_at.present?
   end
 
   def seed_participations_from!(user_ids:)
@@ -135,7 +260,9 @@ Assignments and exams are created on-demand during the semester. Talks must exis
 
 ### Usage Scenarios
 
-- **For a homework assignment:** A teacher creates an `Assignment` record via the "New Assessment" UI. The system creates both the `Assignment` and a linked `Assessment::Assessment` record in one transaction, configured with `requires_points: true` and `requires_submission: true`. The teacher adds tasks for each problem (P1, P2, P3). Student records are seeded automatically from the tutorial roster.
+- **For a homework assignment (digital):** A teacher creates an `Assignment` record via the "New Assessment" UI. The system creates both the `Assignment` and a linked `Assessment::Assessment` record in one transaction, configured with `requires_points: true` and `requires_submission: true`. The teacher adds tasks for each problem (P1, P2, P3). Student records are seeded automatically from the tutorial roster.
+
+- **For a homework assignment (paper):** Same as above, but the teacher sets `requires_submission: false` in the Assessment Settings tab. Students hand in physical papers during tutorial sessions. Tutors enter points directly without expecting file uploads. The participation workflow skips the `submitted` status entirely.
 
 - **For an exam:** A teacher creates an `Exam` record via the "New Assessment" UI. The system creates both the `Exam` and a linked `Assessment::Assessment` whose `assessable` is that exam, with `requires_points: true` to track per-question scores. After the teacher defines all tasks and grades them, a final `grade_value` can be computed and stored for each student to represent the official exam grade.
 
@@ -164,8 +291,9 @@ One row in the gradebook spreadsheet for a specific student in a specific assess
 | `user_id`        | DB column (FK)   | The student being graded                                       |
 | `tutorial_id`    | DB column (FK)   | Tutorial context at participation creation time (optional, null for exams/talks) |
 | `points_total`   | DB column        | Aggregate points across all tasks (denormalized)               |
-| `grade_value`    | DB column        | Final grade (e.g., "1.3", "Pass") - optional                   |
-| `status`         | DB column (Enum) | Workflow state: `not_started`, `in_progress`, `submitted`, `graded`, `exempt` |
+| `grade_numeric`  | DB column (Decimal 2,1) | German grade (1.0-5.0) - for exam grades                    |
+| `grade_text`     | DB column (String) | Text-based grade ("pass", "fail", "exempt") - for achievements |
+| `status`         | DB column (Enum) | Workflow state: `submitted`, `graded`, `exempt` (see Status Workflow below) |
 | `submitted_at`   | DB column        | Timestamp when submission was uploaded (persists after grading)|
 | `grader_id`      | DB column (FK)   | The tutor/teacher who graded this (optional)                   |
 | `graded_at`      | DB column        | Timestamp when grading was completed                           |
@@ -174,10 +302,27 @@ One row in the gradebook spreadsheet for a specific student in a specific assess
 | `locked`         | DB column        | Boolean: prevents further edits after publication              |
 | `task_points`    | Association      | All task-level point records for this student in this assessment |
 
+```admonish info collapsible=true title="Grade Fields: Numeric vs Text"
+Two separate grade fields support different assessment types:
+
+**`grade_numeric` (Decimal):** For German exam grades (1.0, 1.3, 1.7, 2.0, 2.3, 2.7, 3.0, 3.3, 3.7, 4.0, 5.0)
+- Type-safe: Database constraint prevents invalid values like "1,3" or "2.5"
+- Fast input: Tutors can type "1.3" directly in grading forms
+- Analyzable: Can compute averages, distributions (`participations.average(:grade_numeric)`)
+- Display: Format as "1.3" (strip trailing zeros for integer grades: "4.0" → "4")
+
+**`grade_text` (String):** For pass/fail achievements and non-numeric assessments
+- Canonical values: "pass", "fail", "exempt" (lowercase, English)
+- I18n display: Translate on render (`t("assessment.grades.#{grade_text}")` → "Bestanden")
+- Flexible: Can store counts ("5"), percentages ("85"), or boolean results
+
+**Usage rule:** Exactly one of `grade_numeric` or `grade_text` should be present, never both.
+```
+
 ```admonish info collapsible=true title="Tutorial Context Details"
-The `tutorial_id` field captures which tutorial the student was in **at the time of participation creation** (when `seed_participations_from_roster!` runs during assessment setup). This field:
-- Is **set once** when participations are initialized from the roster
-- Is **never updated** if the student changes tutorials mid-semester
+The `tutorial_id` field captures which tutorial the student was in **at the time of participation creation** (when they submit work or are graded). This field:
+- Is **set once** when the participation record is created
+- Is **never updated** if the student changes tutorials after submission
 - Is **nullable** for assessments without tutorial context (e.g., exams, talks)
 - Enables **per-tutorial publication** control for assignments
 - Provides **performance optimization** for tutor grading queries
@@ -189,8 +334,56 @@ The `tutorial_id` field captures which tutorial the student was in **at the time
 - Maintains `points_total` as the sum of all associated `TaskPoint` records
 - Preserves submission history via `submitted_at` even after status transitions to `:graded`
 - Can carry both granular points (via tasks) and a final grade (for exams)
-- Supports workflow states from initial submission through final grading
+- Supports simple workflow states without intermediate "in progress" tracking
 - Provides locking mechanism to prevent post-publication tampering
+
+### Status Workflow
+
+Participation records are created lazily when a student submits work, a tutor enters a grade, or a teacher marks an exemption. The absence of a participation record means the student has not interacted with the assessment.
+
+**Digital submissions (`requires_submission: true`):**
+```
+[no record] → submitted → graded
+                  ↓
+               exempt
+```
+
+**Paper/in-person (`requires_submission: false`):**
+```
+[no record] → graded
+      ↓
+   exempt
+```
+
+| Status | Meaning | Trigger |
+|--------|---------|--------|
+| *(no record)* | No action taken | Student has not interacted with assessment |
+| `submitted` | Student uploaded file | File upload (only applicable when `requires_submission: true`) |
+| `graded` | All grading complete | Tutor marks grading done (all task points entered) |
+| `exempt` | Excused from assessment | Manual exemption (medical certificate, etc.) |
+
+```admonish note "Why no 'in_progress' status?"
+We intentionally omit an `in_progress` status because:
+1. Tutors typically grade all tasks in one sitting (seconds to minutes)
+2. The partial grading window is too brief to be a meaningful dashboard metric
+3. Partial grading state can be **computed** from `task_points` when needed
+
+To determine grading progress, query the data directly:
+- Fully graded: `task_points.count == assessment.tasks.count`
+- Partially graded: `task_points.any? && task_points.count < assessment.tasks.count`
+- Not started: `task_points.none?`
+```
+
+```admonish tip "Grading Progress Display"
+For dashboard views showing grading progress per tutorial:
+
+| Tutorial | Graded | Progress |
+|----------|--------|----------|
+| Tutorial 1 | 16/20 | ████████░░ 80% |
+| Tutorial 2 | 12/20 | ██████░░░░ 60% |
+
+This is computed from participation status, not stored as a separate field.
+```
 
 ### Example Implementation
 
@@ -209,11 +402,9 @@ module Assessment
       class_name: "Assessment::TaskPoint"
 
   enum status: {
-    not_started: 0,
-    in_progress: 1,
-    submitted: 2,
-    graded: 3,
-    exempt: 4
+    submitted: 0,
+    graded: 1,
+    exempt: 2
   }
 
   validates :user_id, uniqueness: { scope: :assessment_id }
@@ -229,10 +420,10 @@ end
 ```
 
 ```admonish warning collapsible=true title="Tutorial ID Behavior (Implementation Details)"
-The `tutorial_id` on participation is **never updated** after creation. It represents which tutorial the student was in when participations were initialized during assessment setup, not their current tutorial assignment.
+The `tutorial_id` on participation is **never updated** after creation. It represents which tutorial the student was in when the participation was created, not their current tutorial assignment.
 
 **When `tutorial_id` is set:**
-- **Assignments**: Set when `seed_participations_from_roster!` runs after assignment creation, capturing the tutorial each student belongs to at that moment
+- **Assignments**: Set when participation is created (on submission, grading, or deadline backfill), capturing the tutorial each student belongs to at that moment
 - **Exams**: Set to `nil` (exams don't have tutorial context)
 - **Talks**: Set to `nil` (talks have speakers, not tutorial participants)
 
@@ -251,9 +442,11 @@ The `tutorial_id` on participation is **never updated** after creation. It repre
 
 ### Usage Scenarios
 
-- **After assessment setup:** When an assignment is created, `assignment.seed_participations_from_roster!` runs, creating one `Assessment::Participation` record for each student across all lecture tutorials. Each participation is initialized with `status: :not_started`, `points_total: 0`, `submitted_at: nil`, and `tutorial_id` set to the tutorial the student currently belongs to.
+- **After assessment setup:** When an assignment is created, an `Assessment::Assessment` record is automatically created via the `Assessable` concern. No participation records are created at this point—they are created lazily when students submit work or tutors enter grades.
+- **Lazy participation creation:** Participations are **not** created eagerly when an assignment is set up. Instead, they are created on-demand when a student submits work, when a tutor enters a grade, or via a scheduled job after the deadline passes. The "expected" count for progress tracking comes from querying the current roster, not pre-seeded participations.
 
-- **Student submits work:** A student uploads their homework file. The system sets their participation to `status: :submitted` and records `submitted_at: Time.current`. This timestamp persists even after grading. The `tutorial_id` remains unchanged.
+- **Student submits work (digital assignment):** A student uploads their homework file. The system creates a participation record (if none exists) with `status: :submitted`, sets `submitted_at: Time.current`, and captures the student's current `tutorial_id`. This is the first time a participation record may be created for this student/assessment pair.
+
 
 - **After grading a submission:** A tutor grades a team submission for Problem 1. The grading service creates or updates `Assessment::TaskPoint` records for each team member, then calls `recompute_points_total!` on their participation to update the aggregate score. The status transitions to `:graded` and `graded_at` is set, but `submitted_at` and `tutorial_id` remain unchanged—preserving the submission and tutorial history.
 
@@ -261,11 +454,11 @@ The `tutorial_id` on participation is **never updated** after creation. It repre
 
 - **Per-tutorial publication (assignments):** Tutorial A completes grading on Monday. The tutor sets `results_published_at: Time.current` for all participations where `tutorial_id = tutorial_a.id`. Students in Tutorial A can now see their results. Tutorial B's students (with `tutorial_id = tutorial_b.id` and `results_published_at: nil`) still see "pending" status.
 
-- **Handling exemptions:** A student provides a medical certificate and is marked `status: :exempt`. Their participation record exists but no points are computed, no grade is assigned, and both `submitted_at` and `graded_at` remain `nil`. The `tutorial_id` is preserved for audit purposes.
+- **Handling exemptions:** A student provides a medical certificate. The teacher explicitly creates a participation with `status: :exempt`. No points are computed, no grade is assigned, and both `submitted_at` and `graded_at` remain `nil`. The `tutorial_id` is set to the student's current tutorial for audit purposes.
 
 - **Distinguishing submission vs non-submission:** After grading is complete, the teacher can query `submitted_at.present?` to distinguish students who submitted work (even if they received 0 points for quality) from those who never submitted at all.
 
-- **Student switches tutorials mid-semester:** Alice is in Tutorial A when participations are initialized for Homework 3. Her participation has `tutorial_id: 1` (Tutorial A). In week 6, she switches to Tutorial B. When Tutorial A publishes results, Alice's Homework 3 results become visible because her participation's `tutorial_id` still points to Tutorial A. Her future assignments will have new participations with `tutorial_id: 2` (Tutorial B).
+- **Student switches tutorials mid-semester:** Alice is in Tutorial A when she submits Homework 3. Her participation is created with `tutorial_id: 1` (Tutorial A). In week 6, she switches to Tutorial B. When Tutorial A publishes results, Alice's Homework 3 results become visible because her participation's `tutorial_id` still points to Tutorial A. Her future submissions will create participations with `tutorial_id: 2` (Tutorial B).
 
 ---
 
@@ -285,7 +478,6 @@ One graded component (problem, question, or rubric item) within an assessment th
 | Name/Field       | Type/Kind        | Description                                                    |
 |------------------|------------------|----------------------------------------------------------------|
 | `assessment_id`  | DB column (FK)   | The assessment this task belongs to                            |
-| `title`          | DB column        | Human-readable task name (e.g., "Problem 1", "Question 3a")    |
 | `position`       | DB column        | Display order within the assessment                            |
 | `max_points`     | DB column        | Maximum achievable points for this task                        |
 | `description`    | DB column        | Optional detailed instructions or rubric text                  |
@@ -357,11 +549,28 @@ The points and feedback assigned to a specific student for a specific task withi
 | `grader_id`                   | DB column (FK)   | The tutor who assigned these points (optional)                 |
 | `submission_id`               | DB column (FK)   | Links to the graded submission for audit trail (optional)      |
 
+```admonish info collapsible=true title="Why submission_id? Team Grading and Audit Trail"
+The `submission_id` field enables critical workflows for team assignments:
+
+**Team Grading Fan-Out:**
+- One team submission → Tutor grades once → System creates TaskPoint records for **each team member**
+- All team members' TaskPoints link back to the **same submission_id**
+- Example: Alice, Bob, Carol submit together → 6 TaskPoint records (3 students × 2 tasks) all reference `submission_id: abc-123`
+
+**Audit Trail Benefits:**
+- **Grade complaints:** "Show me the submission that produced my grade" → `task_point.submission.manuscript_url`
+- **Re-grading:** "Re-grade this submission for all team members" → `submission.task_points.destroy_all`
+- **Team context:** "Did this student work alone or in a team?" → `task_point.submission.users.count`
+- **Turnaround time:** "How long did grading take?" → `task_point.created_at - task_point.submission.created_at`
+
+Without this field, linking grades back to the graded artifact requires complex joins through participation → user → user_submission_join → submission, which breaks if students switch teams.
+```
+
 ### Behavior Highlights
 
 - Enforces uniqueness per (participation, task) via database constraint
 - Triggers recomputation of `Assessment::Participation.points_total` on save
-- Visibility controlled by `assessment.results_published`, not per-task state
+- Visibility controlled by `assessment.results_published?` (checks results_published_at), not per-task state
 - Links back to the specific submission that was graded for audit trails
 - Validation ensures points do not exceed task maximum
 - Maintains update history via `updated_at` for complaint resolution tracking
@@ -402,7 +611,7 @@ Points are allowed to exceed task maximum to support extra credit and bonus poin
 
 - **Bonus points:** A tutor awards 12 points out of 10 for exceptional work on a problem. The system accepts this without validation errors, allowing the student's total to exceed the nominal maximum.
 
-- **Publishing results:** After completing all grading, the teacher sets `assessment.results_published = true`. Students can now see all their task points and comments at once.
+- **Publishing results:** After completing all grading, the teacher sets `assessment.results_published_at = Time.current`. Students can now see all their task points and comments at once by checking `assessment.results_published?`.
 
 - **Recomputation trigger:** After saving a TaskPoint with 8 points, the `after_commit` callback automatically calls `assessment_participation.recompute_points_total!`, updating the student's aggregate score across all tasks.
 
@@ -419,10 +628,10 @@ The grading interface remains available even after an assessment transitions to 
 
 When accessing grading for a `graded` or published assessment, the UI should display a warning:
 
-> **Results already published**  
+> **Results already published**
 > Changes will be visible to students immediately. Continue?
 
-This ensures teachers are aware that modifications affect published results. The `results_published` flag controls visibility, not editability—`TaskPoint` records remain mutable across all assessment states, and `recompute_points_total!` is idempotent.
+This ensures teachers are aware that modifications affect published results. The `results_published_at` timestamp controls visibility (checked via `results_published?`), not editability—`TaskPoint` records remain mutable across all assessment states, and `recompute_points_total!` is idempotent.
 
 ````admonish info collapsible=true title="Per-Tutorial Result Publication (Implementation Details)"
 For assignments with multiple tutorials, results can be published independently per tutorial as grading completes. This eliminates coordination burden and provides faster feedback to students.
@@ -502,13 +711,12 @@ The minimal "make me gradeable" interface that all graded work must implement.
 |--------|-------------|
 | `assessment` | Returns the linked Assessment::Assessment record (polymorphic `has_one` association) |
 | `ensure_assessment!(...)` | Creates or updates the linked Assessment::Assessment with given configuration |
-| `seed_participations_from_roster!` | Creates Assessment::Participation records for all students in the roster |
 
 ### Behavior Highlights
 
 - Establishes the polymorphic link via `has_one :assessment, as: :assessable`
 - Provides a safe method to create/update the assessment without duplication
-- `seed_participations_from_roster!` should be overridden by including classes to define roster logic
+- Does not eagerly seed participations—participations are created lazily on submission/grading
 - Does not enforce whether points or grades are used—that's delegated to `Assessment::Pointable` and `Assessment::Gradable`
 
 ### Example Implementation
@@ -521,41 +729,204 @@ module Assessment
 
     included do
       has_one :assessment, as: :assessable, dependent: :destroy,
-        class_name: "Assessment::Assessment"
-  end
+                           class_name: "Assessment::Assessment"
+    end
 
-  def ensure_assessment!(title:, requires_points:, requires_submission: false,
-                        visible_from: nil, due_at: nil)
-    a = assessment || build_assessment
-    a.title = title
-    a.requires_points = requires_points
-    a.requires_submission = requires_submission
-    a.visible_from ||= visible_from if visible_from
-    a.due_at ||= due_at if due_at
-    a.lecture ||= try(:lecture)
-    a.save! if a.changed?
-    a
-  end
+    def ensure_assessment!(requires_points:, requires_submission: false)
+      a = assessment || build_assessment
+      a.requires_points = requires_points
+      a.requires_submission = requires_submission
+      a.lecture ||= try(:lecture)
+      a.save! if a.changed?
+      a
+    end
 
-  # Override this method in including classes to define roster logic
-  # For Assignment: aggregate from lecture.tutorials
-  # For Exam: use exam registration roster
-  # For Talk: use speaker roster
-  def seed_participations_from_roster!
-    raise NotImplementedError,
-      "#{self.class.name} must implement seed_participations_from_roster!"
   end
 end
+```
+
+```admonish info "Simplified Parameter Design"
+The `ensure_assessment!` method only takes `requires_points` and `requires_submission` parameters.
+Other attributes are accessed through delegation:
+- **Title:** `assessment.title` delegates to `assessable.title`
+- **Deadline:** Access via `assessment.assessable.deadline`
+- **Start date:** Access via `assessment.assessable.valid_from`
+
+This design avoids data duplication and ensures consistency with the source model.
+```
+
+### Concrete Implementations
+
+**Assignment:**
+
+```ruby
+# filepath: app/models/assignment.rb
+class Assignment < ApplicationRecord
+  include Assessment::Assessable
+
+  after_create :setup_assessment, if: -> { Flipper.enabled?(:assessment_grading) }
+
+  private
+
+  def setup_assessment
+    ensure_assessment!(
+      title: title,
+      requires_points: true,
+      requires_submission: true,
+
+    )
+  end
 end
+```
+
+**Talk:**
+
+```ruby
+# filepath: app/models/talk.rb
+class Talk < ApplicationRecord
+  include Assessment::Assessable
+
+  after_create :setup_assessment, if: -> { Flipper.enabled?(:assessment_grading) }
+
+  private
+
+  def setup_assessment
+    ensure_assessment!(
+      title: title,
+      requires_points: false,
+      requires_submission: false,
+    )
+  end
+end
+```
+
+**Assessment bulk creation method (for deadline backfill job or manual seeding):**
+
+```ruby
+# filepath: app/models/assessment/assessment.rb
+class Assessment::Assessment < ApplicationRecord
+  def seed_participations_from!(user_ids:, tutorial_mapping:)
+    existing = assessment_participations.pluck(:user_id).to_set
+    new_user_ids = user_ids.reject { |uid| existing.include?(uid) }
+
+    participations_data = new_user_ids.map do |user_id|
+      {
+        assessment_id: id,
+        user_id: user_id,
+        tutorial_id: tutorial_mapping[user_id],
+        status: 0,
+        points_total: 0.0,
+        created_at: Time.current,
+        updated_at: Time.current
+      }
+    end
+
+    Participation.insert_all(participations_data) if participations_data.any?
+  end
+end
+```
+
+### Lazy Participation Creation
+
+```admonish success "Why No Eager Seeding"
+Participations are created **lazily** rather than on assignment creation for several reasons:
+
+1. **No timing assumptions:** Assignments can be created before, during, or after roster materialization
+2. **Always current:** The roster may change between assignment creation and deadline
+3. **Reduced complexity:** No callbacks, no bulk insert workarounds, no race conditions
+4. **Clear semantics:** A participation record means something happened (submission, grading, exemption)
+
+The "expected" count for progress tracking comes from querying the current roster at display time.
 ```
 
 ### Usage Scenarios
 
-- **Initial setup for an assignment:** After creating an `Assignment` record, the teacher calls `assignment.ensure_assessment!(title: "Homework 3", requires_points: true, requires_submission: true)` to create the linked Assessment::Assessment. Then `assignment.seed_participations_from_roster!` aggregates students from all lecture tutorials and creates participation records for each.
+- **Initial setup for an assignment:** After creating an `Assignment` record, the `setup_assessment` callback calls `ensure_assessment!(requires_points: true, requires_submission: ...)` to create the linked Assessment::Assessment. No participations are created at this point—they will be created lazily on submission or grading.
 
-- **Updating assessment metadata:** A teacher realizes the due date was wrong and calls `assignment.ensure_assessment!(title: "Homework 3", requires_points: true, due_at: 1.week.from_now)` again. The method is idempotent—it updates the existing Assessment::Assessment rather than creating a duplicate.
+- **Updating assessment metadata:** A teacher realizes a setting was wrong and calls `ensure_assessment!` again. The method is idempotent—it updates the existing Assessment::Assessment rather than creating a duplicate.
 
-- **For exams after registration:** An `Exam` becomes `Rosterable` after its registration campaign is completed and allocations are materialized. When calling `exam.seed_participations_from_roster!`, the concern reads from the exam's roster (the confirmed exam registrants) to seed participations. Only students who successfully registered for the exam will have participation records created.
+- **For exams after registration:** An `Exam` becomes `Rosterable` after its registration campaign is completed and allocations are materialized. Exam participations are created when grades are entered or results are finalized.
+
+### Developer Guide: Adding New Assessable Types
+
+```admonish tip "Step-by-Step Integration"
+Follow this pattern when making a new model assessable (e.g., Achievement, Quiz):
+```
+
+**1. Include the Concern**
+
+```ruby
+class YourModel < ApplicationRecord
+  include Assessment::Assessable
+end
+```
+
+**2. Add Lifecycle Hook (Feature Flag Gated)**
+
+```ruby
+after_create :setup_assessment, if: -> { Flipper.enabled?(:assessment_grading) }
+```
+
+**3. Implement `setup_assessment` (Private)**
+
+```ruby
+private
+
+def setup_assessment
+  ensure_assessment!(
+    title: your_title,
+    requires_points: true_or_false,    # Does this need per-task grading?
+    requires_submission: true_or_false, # Do students upload files?
+  )
+end
+```
+
+**4. Write Tests**
+
+Test both feature flag states:
+
+```ruby
+RSpec.describe YourModel, type: :model do
+  describe "assessment integration" do
+    context "when assessment_grading flag is enabled" do
+      before { Flipper.enable(:assessment_grading) }
+      after { Flipper.disable(:assessment_grading) }
+
+      it "creates assessment on model creation" do
+        model = FactoryBot.create(:your_model)
+        expect(model.assessment).to be_present
+      end
+
+      it "seeds participations from roster" do
+        model = FactoryBot.create(:your_model)
+        expect(model.assessment.assessment_participations.count).to eq(expected_count)
+      end
+    end
+
+    context "when assessment_grading flag is disabled" do
+      it "does not create assessment" do
+        model = FactoryBot.create(:your_model)
+        expect(model.assessment).to be_nil
+      end
+    end
+  end
+end
+```
+
+**6. Verify Idempotency**
+
+Ensure calling setup methods multiple times is safe:
+
+```ruby
+it "does not create duplicate participations on re-seed" do
+  model = FactoryBot.create(:your_model)
+  initial_count = model.assessment.assessment_participations.count
+
+  model.seed_participations_from_roster!
+
+  expect(model.assessment.assessment_participations.count).to eq(initial_count)
+end
+```
 
 ---
 
@@ -593,12 +964,10 @@ module Assessment
     extend ActiveSupport::Concern
     include Assessment::Assessable
 
-  def ensure_pointbook!(title:, requires_submission: false, **opts)
+  def ensure_pointbook!(requires_submission: false)
     ensure_assessment!(
-      title: title,
       requires_points: true,
-      requires_submission: requires_submission,
-      **opts
+      requires_submission: requires_submission
     )
   end
 end
@@ -606,11 +975,11 @@ end
 
 ### Usage Scenarios
 
-- **For homework assignments:** After creating an assignment, call `assignment.ensure_pointbook!(title: "Homework 3", requires_submission: true, due_at: 1.week.from_now)`. The assessment is configured for task-level grading, and students must upload files. Tasks are then added for each problem.
+- **For homework assignments:** After creating an assignment, the `setup_assessment` callback calls `ensure_pointbook!(requires_submission: true)`. The assessment is configured for task-level grading, and students must upload files. Tasks are then added for each problem.
 
-- **For exams with per-question tracking:** An exam includes this concern to track points per question. Call `exam.ensure_pointbook!(title: "Final Exam", requires_submission: false)` since students don't upload files for in-person exams. Tasks represent individual exam questions.
+- **For exams with per-question tracking:** An exam includes this concern to track points per question. The callback calls `ensure_pointbook!(requires_submission: false)` since students don't upload files for in-person exams. Tasks represent individual exam questions.
 
-- **Idempotent reconfiguration:** A teacher realizes they set the wrong due date and calls `assignment.ensure_pointbook!(title: "Homework 3", requires_submission: true, due_at: 2.weeks.from_now)`. The method updates the existing assessment without creating a duplicate.
+- **Idempotent reconfiguration:** The method is idempotent—calling it again updates the existing assessment rather than creating a duplicate. Configuration changes can be done through the Assessment Settings UI.
 
 ---
 
@@ -649,13 +1018,11 @@ module Assessment
     extend ActiveSupport::Concern
     include Assessment::Assessable
 
-  def ensure_gradebook!(title:, **opts)
+  def ensure_gradebook!
     requires_points = assessment&.requires_points
     ensure_assessment!(
-      title: title,
       requires_points: requires_points.nil? ? false : requires_points,
-      requires_submission: false,
-      **opts
+      requires_submission: false
     )
   end
 
@@ -674,7 +1041,7 @@ end
 
 ### Usage Scenarios
 
-- **For seminar talks:** After creating a talk, call `talk.ensure_gradebook!(title: "Seminar Talk: Topology")` to create an assessment without tasks. After the presentation, call `talk.set_grade!(user: speaker, value: "1.0", grader: professor)` to record the final grade.
+- **For seminar talks:** After creating a talk, the `setup_assessment` callback calls `ensure_gradebook!` to create an assessment without tasks. After the presentation, call `talk.set_grade!(user: speaker, value: "1.0", grader: professor)` to record the final grade.
 
 - **For exams with final grades:** An exam includes both `Assessment::Pointable` and `Assessment::Gradable`. After all tasks are graded and points computed, the teacher can call `exam.set_grade!(user: student, value: "1.3", grader: professor)` to store the official grade that appears on transcripts.
 
@@ -715,26 +1082,22 @@ class Assignment < ApplicationRecord
   private
 
   def setup_grading
-    ensure_pointbook!(
-      title: title,
-      requires_submission: true,
-      due_at: deadline
-    )
+    ensure_pointbook!(requires_submission: true)
     seed_participations_from_roster!
   end
 
   def seed_participations_from_roster!
     return unless assessment
 
-    # Aggregate students from all tutorials in the lecture
-    lecture.tutorials.each do |tutorial|
-      user_ids = tutorial.roster_user_ids
-      user_ids.each do |user_id|
-        assessment.participations.find_or_create_by!(user_id: user_id) do |part|
-          part.tutorial_id = tutorial.id
-        end
-      end
-    end
+    memberships = TutorialMembership
+      .where(tutorial_id: lecture.tutorial_ids)
+      .pluck(:user_id, :tutorial_id)
+
+    tutorial_mapping = memberships.to_h
+    user_ids = memberships.map(&:first)
+
+    assessment.seed_participations_from!(user_ids: user_ids,
+                                         tutorial_mapping: tutorial_mapping)
   end
 end
 ```
@@ -1098,53 +1461,34 @@ sequenceDiagram
     participant A as Assignment
     participant Assess as Assessment::Assessment
     participant L as Lecture
-    participant Tut as Tutorial
-    participant Part as Assessment::Participation
     actor Student
     participant Sub as Submission
+    participant Part as Assessment::Participation
 
     Teacher->>A: Create assignment
     A->>Assess: ensure_pointbook!(title, requires_submission: true)
     Assess->>Assess: Create/update assessment record
     Assess-->>A: Assessment created
 
-    Teacher->>A: seed_participations_from_roster!
-    A->>L: lecture.tutorials
-    L-->>A: [tutorial_1, tutorial_2, ...]
-
-    loop For each tutorial
-        A->>Tut: tutorial.roster_user_ids
-        Tut-->>A: [student_ids...]
-    end
-
-    A->>A: user_ids.uniq (deduplicate)
-
-    loop For each unique student
-        A->>Part: Create participation
-        Part->>Part: Set status: :not_started
-        Part->>Part: Set points_total: 0
-    end
-
-    A-->>Teacher: Participations seeded
-
     Teacher->>Assess: Add tasks (Problem 1, Problem 2, ...)
     Assess->>Assess: Create Assessment::Task records
 
-    Note over Teacher,Assess: Assessment is now ready for student work
+    Note over Teacher,Assess: Assessment is ready. No participations created yet.
 
     Student->>Sub: Upload homework file
     Sub->>Sub: Create submission record
     Sub->>Sub: Link to team members via user_submission_joins
 
     loop For each team member
-        Sub->>Part: Find participation by user_id
-        Part->>Part: Update status: :submitted
+        Sub->>Part: Find or create participation
+        Part->>Part: Set status: :submitted
         Part->>Part: Set submitted_at: Time.current
+        Part->>Part: Set tutorial_id from current membership
     end
 
     Sub-->>Student: Submission confirmed
 
-    Note over Student,Part: Participations track submission history<br/>even after grading
+    Note over Student,Part: Participations created lazily on submission
 ```
 
 ---

--- a/architecture/src/features/09-integrity-and-invariants.md
+++ b/architecture/src/features/09-integrity-and-invariants.md
@@ -94,7 +94,7 @@ add_foreign_key :assessment_task_points, :assessment_participations, column: :pa
 | `Participation.total_points = sum(task_points.points)` | Automatic recomputation on `TaskPoint` save |
 | `TaskPoint.points ≤ Task.max_points` | Validation on save |
 | Task records exist only if `Assessment` has tasks | Validation |
-| Results visible only when `Assessment.results_published = true` | Controller authorization |
+| Results visible only when `Assessment.results_published?` returns true | Controller authorization |
 | `Participation.submitted_at` persists across status changes | Never overwritten after initial set |
 
 ```admonish note "Multiple Choice Extension"

--- a/architecture/src/features/10-future-extensions.md
+++ b/architecture/src/features/10-future-extensions.md
@@ -23,47 +23,25 @@ The core architecture documented in Chapters 1-9 represents the planned baseline
 
 ## 2. Registration & Policy System
 
-### Scheduled Campaign Opening
-
-**Current State:** Campaigns require manual teacher action to transition `draft → open`.
-
-**Proposed Enhancement:** Automatic opening via background job.
-
-**Implementation:**
-```ruby
-add_column :registration_campaigns, :registration_start, :datetime
-
-# Validation
-validates :registration_start, presence: true
-validate :start_before_deadline
-
-# Background job (every 5 minutes)
-Registration::CampaignOpenerJob.perform_async
-  Registration::Campaign.where(status: :draft)
-    .where("registration_start <= ?", Time.current)
-    .find_each(&:open!)
-end
-```
-
-**Benefits:**
-- Symmetry: auto-open + auto-close provides full automation
-- Teacher workflow: set up campaign in advance, forget about it
-- Reduces manual intervention during high-traffic registration windows
-
-**Trade-offs:**
-- Adds complexity (another background job, another timestamp)
-- Teachers lose last-minute verification opportunity before going live
-- Current manual flow forces review before opening
-
-**Recommendation:** Defer to post-MVP. Current workaround (manual open) is acceptable. Implement if teachers report frequent "forgot to open" incidents during beta testing.
-
-**Complexity:** Low (additive change, no schema conflicts)
-
-**References:** See [Registration - Campaign Lifecycle](02-registration.md#campaign-lifecycle-state-diagram)
+- **Roster membership policy (`on_roster`)**: Restrict registration to users on a specific lecture/course roster. Alternative to campaign chaining via `prerequisite_campaign` policy (e.g., seminar talk registration restricted to students on seminar enrollment roster). Config: `{ "roster_source_id": <lecture_id> }`. Check: `source.roster.include?(user)`.
+- **Item-level capacity**: Add `capacity` column to `registration_items` to enable capacity partitioning across campaigns (e.g., same tutorial in two campaigns with split capacity: 20 seats for CS students, 10 for Physics). Items have independent capacity from domain objects. Soft validation warns if `sum(items.capacity) > tutorial.capacity`.
+- **Asynchronous Allocation (`:calculating` status)**: When moving the allocation solver to a background job, introduce a `:calculating` status to lock the campaign during execution. This distinguishes "solver running" (locked) from "results ready for review" (`:processing`, unlocked for adjustments).
+- Policy trace persistence (store evaluation results for audit)
+- User-facing explanations (API endpoint showing why ineligible)
+- Rate limiting for FCFS hotspots
+- Bulk eligibility preview (matrix: users × policies)
+- Policy simulation mode (test changes without affecting real data)
+- Automated certification proposals (ML-based predictions from partial semester data)
+- Certification templates (pre-fill common override scenarios)
+- Certification bulk operations (approve/reject multiple students at once)
 
 ---
 
-### Full Trace for Policy Evaluation
+## 3. Roster Management
+
+- Batch operations (CSV import/export)
+- Capacity forecasting and rebalancing suggestions
+- Automatic load ### Full Trace for Policy Evaluation
 
 **Context:** The current policy engine stops at the first failure (`eligible?` returns false immediately).
 
@@ -118,6 +96,20 @@ end
 
 ---
 
+### Relaxed Policy Freezing
+
+**Current State:** All policies are frozen once a campaign leaves the `draft` state.
+
+**Proposed Enhancement:** Allow adding or editing policies with `phase: :finalization` even when the campaign is `open`.
+
+**Rationale:**
+Finalization policies (e.g., "Min/Max Credits") are only evaluated during the allocation algorithm and do not affect a student's ability to register. Changing them mid-flight does not invalidate existing registration records.
+
+**Implementation Challenges:**
+Requires conditional UI logic to show the "Add Policy" button but restrict the form to only allow the `finalization` phase, preventing accidental addition of `registration` policies which *must* remain frozen.
+
+---
+
 - **Roster membership policy (`on_roster`)**: Restrict registration to users on a specific lecture/course roster. Alternative to campaign chaining via `prerequisite_campaign` policy (e.g., seminar talk registration restricted to students on seminar enrollment roster). Config: `{ "roster_source_id": <lecture_id> }`. Check: `source.roster.include?(user)`.
 - **Item-level capacity**: Add `capacity` column to `registration_items` to enable capacity partitioning across campaigns (e.g., same tutorial in two campaigns with split capacity: 20 seats for CS students, 10 for Physics). Items have independent capacity from domain objects. Soft validation warns if `sum(items.capacity) > tutorial.capacity`.
 - Policy trace persistence (store evaluation results for audit)
@@ -137,6 +129,32 @@ end
 - Capacity forecasting and rebalancing suggestions
 - Automatic load balancing (heuristic-based)
 - Enhanced change history UI
+
+### Generic Registration Groups (Lightweight Rosterables)
+
+**Problem:** Currently, `Tutorial` is the primary unit for registration. This forces users to create "fake tutorials" for simple use cases like "Lecture Admission" (where no tutorials exist) or "Event Registration" (e.g., Faculty Barbecue).
+
+**Proposed Solution:** Introduce a `Cohort` model (contained within a generic `Grouping`) that acts as a lightweight container.
+
+**New Models:**
+1.  **`Cohort` (The Bucket):**
+    - **Concerns:** `Registration::Registerable`, `Rosters::Rosterable`.
+    - **Attributes:** `capacity`, `title`.
+    - **Polymorphic Parent:** Belongs to `context` (Lecture, Offering, etc.).
+    - **No Scheduling:** No tutors, rooms, or time slots.
+
+2.  **`Grouping` (The Context):**
+    - **Role:** Acts as the generic `campaignable` for non-academic scenarios (events, polls, organizational tasks).
+    - **Attributes:** `title`, `description`.
+    - **Associations:** `has_one :campaign`, `has_many :cohorts`.
+    - **Examples:**
+        - **Event:** "Faculty Barbecue" containing cohorts "Meat", "Vegetarian".
+        - **Poll:** "New Building Name" containing cohorts "Turing Hall", "Noether Hall".
+
+**Benefits:**
+- Decouples registration from academic scheduling.
+- Simplifies UI for non-tutorial use cases.
+- Reuses existing `MaintenanceController` and `Allocation` logic.
 
 ---
 

--- a/architecture/src/features/12-views.md
+++ b/architecture/src/features/12-views.md
@@ -252,6 +252,52 @@ Student “Show”.
 | Confirmation (result)                  | [Registration::UserRegistrationsController](11-controllers.md#registration-controllers) | show       | After submit/close                    | Shows assignment and summary |
 | Fulfill requirements (policy)          | —                                                                                      | Policy-configured flow | External or internal                  | Follow instructions to satisfy policy, then retry |
 
+## Roster Maintenance
+
+The **Roster Maintenance** view is the central hub for managing group allocations. It provides both a high-level overview of all groups in a lecture and detailed management for individual groups.
+
+### Placement & Access
+- **Location:** Accessible via the `Roster::MaintenanceController#index` action.
+- **Route:** `/lectures/:id/roster`
+- **Entry Points:**
+    - **Lecture Settings:** From the "Participants" tab in `Lecture#edit`.
+    - **Navigation:** (Future) Direct link from the lecture dashboard.
+
+### Architecture
+The view uses a **Tabbed Layout** to switch between different management contexts.
+
+#### 1. Groups Tab (Overview)
+*Focus: How are students distributed?*
+- **List View:** Displays all groups (Tutorials, Talks) with their current occupancy and capacity.
+- **Stats:** Shows total participants and unassigned candidates count.
+- **Actions:**
+    - **Manage:** Drill down into a specific group's detail view.
+    - **Skip Campaigns:** Toggle direct management for individual groups (if eligible).
+
+#### 2. Enrollment Tab (Candidates)
+*Focus: Who needs a spot?*
+- **Candidates List:** Displays students who registered via a campaign but are currently unassigned.
+- **Context:** Shows the student's original preferences (top 3) to aid in placement.
+- **Actions:**
+    - **Assign:** Directly assign a candidate to a specific group (checks capacity).
+
+#### 3. Performance Tab (Future)
+*Focus: How are they doing?*
+- Placeholder for future gradebook integration.
+
+### Detail View (Single Group)
+When selecting "Manage" on a group, the view updates (via Turbo Frame) to show the details for that specific group.
+
+- **Participants List:** Table of all students in the group.
+- **Actions:**
+    - **Add Member:** Manually add a student by email.
+    - **Move:** Move a student to another group (dropdown with capacity checks).
+    - **Remove:** Remove a student from the group.
+- **Navigation:** "Back" button returns to the Groups overview.
+
+### Integration in Lecture Settings
+The roster maintenance view is integrated directly into the `Lecture#edit` page as a tab, allowing seamless management without leaving the settings context. It uses Turbo Frames to load lazily and handle updates without full page reloads.
+
 ## Rosters
 
 #### Flow

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -79,7 +79,7 @@ Registration — Step 3: FCFS Mode
 - Controllers: `Registration::CampaignsController` (new/create/edit/update/show/destroy).
 - Actions: `open` (validates policies, updates status to :open), `close` (background job triggers status → :closed), `reopen` (reverts to :open if allocation not started).
 - Freezing: Campaign-level attributes freeze on lifecycle transitions (`allocation_mode`, `registration_opens_at` after draft; policies freeze on open).
-- UI: Turbo Frames for inline editing; flash messages for validation errors and freeze violations; feature flag `registration_campaigns_enabled`; disabled fields for frozen attributes.
+- UI: Turbo Frames for inline editing; flash messages for validation errors and freeze violations; feature flag `registration_campaigns`; disabled fields for frozen attributes.
 - Refs: [Campaign lifecycle & freezing](02-registration.md#campaign-lifecycle--freezing-rules),
   [State diagram](02-registration.md#campaign-state-diagram)
 - Acceptance: Teachers can create draft campaigns, add policies, open campaigns (with policy validation); campaigns cannot be deleted when open/processing; freezing rules enforced with clear error messages; frozen fields disabled in UI; feature flag gates UI.
@@ -246,12 +246,13 @@ Registration — Step 5: Roster Maintenance
 - Acceptance: Students receive emails on add/remove/move; emails queued asynchronously; feature flag gates delivery; teachers can configure notification timing per lecture.
 ```
 
-```admonish example "PR-5.8 — Integrity job (assigned/allocated reconciliation)"
-- Scope: Background job to verify roster consistency.
-- Job: `AllocatedAssignedMatchJob` compares `Item#assigned_users` with `Registerable#allocated_user_ids`.
-- Monitoring: Logs mismatches for admin review.
-- Refs: [Integrity invariants](09-integrity-and-invariants.md#registration-allocation)
-- Acceptance: Job runs nightly; reports mismatches; no auto-fix (manual review required).
+```admonish example "PR-5.8 — Integrity job (lecture roster superset validation)"
+- Scope: Background job to verify lecture roster superset principle.
+- Job: `RosterSupersetCheckerJob` validates that `Lecture#roster_user_ids` ⊇ (tutorials + talks + propagating cohorts).roster_user_ids.
+- Detection: Identifies users in sub-groups who are missing from lecture roster.
+- Monitoring: Logs violations for admin review; potential causes include callback failures, race conditions, or manual database edits.
+- Refs: [Superset Model](03-rosters.md#the-core-concept-lecture-roster-as-superset)
+- Acceptance: Job runs nightly; reports missing users; no auto-fix (manual review required); clear log format with lecture ID, user IDs, and affected groups.
 ```
 
 ```admonish example "PR-5.9 — Turbo Stream Orchestrator"
@@ -283,38 +284,41 @@ Grading — Step 6: Assessment Foundations (Schema)
 ```
 
 ```admonish abstract
-Grading — Step 7: Assessment Foundations (Backend & CRUD)
+Grading — Step 7: Assessments (Formalize Assignments)
 ```
 
-```admonish example "PR-7.1 — Assessment backend (Concerns + Integration)"
-- Scope: Core assessment concerns plus Assignment/Talk integration.
+```admonish example "PR-7.1 — Assessment backend (Assignment & Talk integration)"
+- Scope: Integrate Assessment::Assessable into Assignment and Talk models.
 - Backend:
-  - Create `Assessment::Assessable` concern (interface for all assessable types)
-  - Create `Assessment::Pointable` concern (for task-based grading: assignments, exams)
-  - Create `Assessment::Gradable` concern (for final grade: assignments, exams, talks)
-  - Include `Assessable + Pointable + Gradable` in Assignment model (behind feature flag)
-  - Include `Assessable + Gradable` in Talk model (behind feature flag)
-  - Add `after_create :setup_assessment` hooks
-  - Implement `seed_participations_from_roster!` for Assignment and Talk
-- Feature Flag: `assessment_grading_enabled` (per-lecture)
-- Behavior: When enabled, new assignments/talks automatically create Assessment record + Participations
-- Refs: [Assessment::Assessable](04-assessments-and-grading.md#assessmentassessable-concern), [Pointable](04-assessments-and-grading.md#assessmentpointable-concern), [Gradable](04-assessments-and-grading.md#assessmentgradable-concern)
-- Acceptance: All three concerns exist; Assignment has all three; Talk has Assessable+Gradable; participations seeded on creation; feature flag gates behavior; old assignments unaffected.
+  - Add `Assessment::Assessable` concern with `ensure_assessment!` method
+  - Add `Assessment::Assessment#seed_participations_from!(user_ids:, tutorial_mapping:)` instance method (for deadline backfill job)
+  - Include concern in Assignment and Talk models (behind feature flag)
+  - Add `after_create :setup_assessment` hook to both models
+- Participation Creation: **Lazy** — participations are NOT seeded on assignment creation. They are created on-demand when:
+  - A student submits work (status: :submitted)
+  - A tutor enters a grade (status: :graded)
+  - A teacher marks exemption (status: :exempt)
+  - A deadline backfill job runs (status: :not_started, for analytics)
+- Feature Flag: `assessment_grading` (global)
+- Test Coverage: 90 specs (60%), covering both flag enabled/disabled states
+- Behavior: When enabled, new assignments/talks automatically create Assessment record; participations are created lazily
+- Refs: [Assessment::Assessable](04-assessments-and-grading.md#assessmentassessable-concern)
+- Acceptance: Feature flag works; new assignments/talks get assessments; old records unaffected.
 ```
 
-```admonish example "PR-7.2 — Assessment CRUD UI (without grading)"
-- Scope: Complete assessment management UI without grading interface.
-- Controllers: `Assessment::AssessmentsController` (full CRUD), `Assessment::TasksController` (nested CRUD), `Assessment::ParticipationsController` (index only)
+```admonish example "PR-7.2 — Assessment UI (CRUD without grading)"
+- Scope: Complete assessment management UI (create, view, configure) without grading interface.
+- Controllers: `Assessment::AssessmentsController` (full CRUD), `Assessment::TasksController` (nested CRUD)
 - UI:
-  - "New Assessment" form (type/mode selection, schedule)
-  - Index page (list, filter, status badges)
-  - Show page with tabs (Overview, Settings, Tasks, Participants)
+  - "New Assessment" form (depending on assessable - only for assignments here)
+  - Index page (list)
+  - Show page with tabs (Overview, Settings, Tasks, Grading)
   - Task management (add/edit/reorder problems)
-  - Participation list (auto-seeded from PR-7.1)
+  - Grading tab shows aggregated progress from roster (expected count from roster, submitted/graded count from participations)
 - Limitations: No point entry, no grade calculation, no result publication (deferred to PR-8.x)
-- Feature Flag: Same `assessment_grading_enabled` flag gates entire UI
+- Feature Flag: Same `assessment_grading` flag gates entire UI
 - Refs: [Assessment controllers](11-controllers.md#assessmentassessmentscontroller), [Views](12-views.md#assessments)
-- Acceptance: Teachers can create assessments via UI; participations visible; tasks configurable; no grading actions available; feature flag gates access.
+- Acceptance: Teachers can create assessments via UI; grading overview shows progress; tasks configurable; no grading actions available; feature flag gates access.
 ```
 
 ```admonish example "PR-7.3 — Submission assessment support (dual-column)"
@@ -338,60 +342,12 @@ Grading — Step 7: Assessment Foundations (Backend & CRUD)
 ```
 
 ```admonish abstract
-Grading — Step 8: Unified Point Entry & Assignment Grading
+Grading — Step 8: Assignment Grading
 ```
 
-```admonish example "PR-8.1 — Exam foundations (model + registration + CRUD)"
-- Scope: Introduce Exam model with basic functionality (no grade schemes yet).
-- Migrations:
-  - `20251110000000_create_exams.rb`
-- Backend:
-  - Create `Exam` model with concerns: `Registration::Registerable`, `Roster::Rosterable`, `Assessment::Assessable`, `Assessment::Pointable`, `Assessment::Gradable`
-  - Implement `materialize_allocation!` (delegates to `replace_roster!`)
-  - Implement `allocated_user_ids` (returns roster user IDs)
-  - Implement `seed_participations_from_roster!`
-- Controllers: `ExamsController` (CRUD, scheduling)
-- Registration: Extend `Registration::CampaignsController` and `Registration::UserRegistrationsController` to support lecture-hosted exam campaigns
-- UI: Basic exam creation/editing form; exam registration flows (reuses campaign views); FCFS and preference-based modes
-- Limitations: No grading UI, no grade schemes, no point entry (deferred to PR-8.3 and Step 9)
-- Rationale: Having exams around enables unified point entry UI design in PR-8.3
-- Feature Flag: Same `assessment_grading_enabled` flag gates exam creation
-- Refs: [Exam model](05a-exam-model.md#exam-activerecord-model), [Exam registration flow](05a-exam-model.md#exam-registration-flow)
-- Acceptance: Exam model exists with all concerns; teachers can create exams and exam campaigns; students can register for exams; no grading functionality yet; feature flag gates UI.
-```
-
-```admonish example "PR-8.2 — Grading service (backend for point entry)"
-- Scope: `Assessment::GradingService` for saving points.
-- Implementation: Fanout pattern creates Participation and TaskPoints per student (or team); supports ANY Pointable (assignments and exams)
-- Refs: [GradingService](04-assessments-and-grading.md#assessmentgradingservice-service)
-- Acceptance: Service creates participations and task points; handles team grading; validates point ranges; works for Assignment and Exam assessables.
-```
-
-```admonish example "PR-8.3 — Unified point entry UI (for ANY Pointable)"
-- Scope: Point entry interface that works for both assignments and exams.
-- Controllers: `Assessment::GradingController` (new/create/update)
-- UI:
-  - Grid view with students × tasks
-  - Inline editing with Turbo Frames
-  - Design works for Assignment (homework) AND Exam (written test)
-  - No assignment-specific assumptions (reusable for exams)
-- Rationale: Design with both Assignment and Exam in mind from day 1
-- Testing: Verify UI works for both assessable types
-- Refs: [Grading UI mockup](12-views.md#grading-interface)
-- Acceptance: Teachers can enter points for assignments AND exams; service called on save; results preview shown; UI agnostic to assessable type; feature flag gates UI.
-```
-
-```admonish example "PR-8.4 — Publish/unpublish results"
-- Scope: Toggle result visibility for students.
-- Controllers: Extend `Assessment::AssessmentsController` with `publish_results` and `unpublish_results` actions
-- UI: Toggle button on assessment show page; works for both assignments and exams
-- Refs: [Publication workflow](04-assessments-and-grading.md#publication-workflow)
-- Acceptance: Teachers can publish/unpublish results; students see results only when published; toggle works via Turbo Frame; works for any assessable type; feature flag gates UI.
-```
-
-```admonish example "PR-8.5 — Student submission integration with participations"
+```admonish example "PR-8.0 — Student submission integration with participations"
 - Scope: Update student submission workflow to interact with Assessment::Participation (when feature flag enabled).
-- Controllers: Update `SubmissionsController` to conditionally set participation status
+- Controllers: Update `SubmissionsController` to conditionally set participation status.
 - Logic (when `assessment_grading_enabled?`):
   - On submission upload: Find or create `Assessment::Participation` for student(s)
   - Set `participation.status = :submitted`, `submitted_at = Time.current`
@@ -404,30 +360,61 @@ Grading — Step 8: Unified Point Entry & Assignment Grading
 - Acceptance: Feature flag controls behavior; new submissions link to assessments and update participations; old submissions continue working unchanged; no breaking changes to existing functionality.
 ```
 
-```admonish example "PR-8.6 — Student results interface"
+```admonish example "PR-8.1 — Grading service (backend)"
+- Scope: `Assessment::GradingService` for saving points and grades.
+- Implementation: Fanout pattern creates Participation and TaskPoints
+  per student (or team).
+- Refs: [GradingService](04-assessments-and-grading.md#assessmentgradingservice-service)
+- Acceptance: Service creates participations and task points; handles team grading; validates point ranges.
+```
+
+```admonish example "PR-8.2 — Grading UI (teacher/TA)"
+- Scope: Grading interface for entering points.
+- Controllers: `Assessment::GradingController` (new/create/update).
+- UI: Grid view with students × tasks; inline editing; Turbo Frames for updates.
+- Refs: [Grading UI mockup](12-views.md#grading-interface)
+- Acceptance: Teachers can enter points; service called on save; results preview shown; feature flag gates UI.
+```
+
+```admonish example "PR-8.3 — Publish/unpublish results"
+- Scope: Toggle result visibility for students.
+- Controllers: Extend `Assessment::AssessmentsController` with
+  `publish_results` and `unpublish_results` actions.
+- UI: Toggle button on assessment show page.
+- Refs: [Publication workflow](04-assessments-and-grading.md#publication-workflow)
+- Acceptance: Teachers can publish/unpublish results; students see results only when published; toggle works via Turbo Frame; feature flag gates UI.
+```
+
+```admonish example "PR-8.4 — Student results interface"
 - Scope: Student-facing views for published assessment results.
 - Controllers: `Assessment::ParticipationsController` (index, show for students)
 - UI:
   - **Results Overview:** Progress dashboard (points earned, graded count, certification status), assignment list with filters (All/Graded/Pending), collapsible older assignments section
   - **Results Detail:** Per-assignment view with task breakdown table, submitted files, tutor feedback, team info, overall progress sidebar
   - Published results only (students cannot see unpublished grades)
-  - Works for both assignments and exams (no exam-specific adjustments needed yet)
-- Authorization: Students see only their own participations; results hidden when `assessment.results_published == false`
+- Authorization: Students see only their own participations; results hidden when `assessment.results_published? == false`
 - Navigation: Links from assignment pages to results; download feedback PDFs
 - Refs: [Student results views](12-views.md#assessments-lectures---student)
-- Acceptance: Students can view published results; task points visible; feedback displayed; unpublished assessments hidden; certification status shown; works for any assessable type; feature flag gates access.
+- Acceptance: Students can view published results; task points visible; feedback displayed; unpublished assessments hidden; certification status shown; feature flag gates access.
+```
+- Refs: [Publication workflow](04-assessments-and-grading.md#publication-workflow)
+- Acceptance: Teachers can publish/unpublish results; students see results only when published.
 ```
 
 ```admonish abstract
-Exams — Step 9: Grade Schemes (Exam-Specific Layer)
+Exams — Step 9: Registration & Grading
 ```
 
-```admonish example "PR-9.1 — Exam registration consolidation"
-- Scope: Finalize exam registration workflows (no functional changes, just documentation).
-- Note: Exam registration was introduced in PR-8.1; this PR serves as checkpoint to verify all flows work correctly before adding grade schemes
-- Testing: Comprehensive end-to-end tests for exam registration and allocation
-- Refs: [Exam registration flow](05a-exam-model.md#exam-registration-flow)
-- Acceptance: All exam registration flows tested; campaign creation, student registration, allocation, and finalization work correctly.
+```admonish example "PR-9.1 — Exam schema and model"
+- Scope: Create `exams` table and `Exam` model with concerns.
+- Migrations:
+  - `20251110000000_create_exams.rb`
+- Concerns: `Registration::Registerable`, `Roster::Rosterable`,
+  `Assessment::Assessable`.
+- Implementation: `materialize_allocation!` delegates to `replace_roster!`;
+  `allocated_user_ids` returns roster user IDs.
+- Refs: [Exam model](05a-exam-model.md#exam-activerecord-model)
+- Acceptance: Exam model exists with all concerns; belongs_to lecture; methods implemented; no functional changes to existing data.
 ```
 
 ```admonish example "PR-9.2 — Grade scheme schema"
@@ -439,55 +426,54 @@ Exams — Step 9: Grade Schemes (Exam-Specific Layer)
 - Acceptance: Migrations run; models have correct validations; percentage-based thresholds supported.
 ```
 
-```admonish example "PR-9.3 — Grade scheme applier (service)"
+```admonish example "PR-9.3 — Exam registration (campaign integration)"
+- Scope: Enable exam registration using existing campaign infrastructure.
+- Controllers: Extend `Registration::CampaignsController` to support
+  lecture-hosted exam campaigns; extend
+  `Registration::UserRegistrationsController` for exam context.
+- UI: Exam registration flows; reuses campaign show/index views with
+  exam-specific context.
+- Refs: [Exam registration flow](05a-exam-model.md#exam-registration-flow)
+- Acceptance: Teachers can create exam campaigns (lecture as campaignable, exam as registerable item); students can register for exams; FCFS and preference-based modes work; feature flag gates UI.
+```
+
+```admonish example "PR-9.4 — Grade scheme applier (service)"
 - Scope: `GradeScheme::Applier` for converting exam points to grades.
-- Implementation: Supports absolute points and percentage-based bands; idempotent application via version_hash; respects manual overrides
+- Implementation: Supports absolute points and percentage-based bands;
+  idempotent application via version_hash; respects manual overrides.
 - Refs: [GradeScheme applier](05b-grading-schemes.md#gradeschemesapplier-service-object)
 - Acceptance: Service computes grades from points; handles both absolute and percentage schemes; version_hash prevents duplicate applications.
 ```
 
-```admonish example "PR-9.4 — Grade scheme UI + distribution analysis"
-- Scope: UI for grade scheme configuration and application (layers on top of PR-8.3 point entry).
-- Controllers: `GradeScheme::SchemesController` (configuration, preview, apply)
-- UI:
-  - Distribution analysis (histogram, statistics) based on entered points
-  - Scheme configuration (two-point auto-generation + manual adjustment)
-  - Grade preview showing how scheme maps to students
-  - Apply action (runs GradeScheme::Applier)
-- Integration: Uses existing point entry UI from PR-8.3; adds grade scheme layer
+```admonish example "PR-9.5 — Exam grading UI"
+- Scope: Complete exam grading workflow from point entry to grade publication.
+- Controllers: `ExamsController` (CRUD, scheduling),
+  `GradeScheme::SchemesController` (scheme configuration, preview, apply).
+- UI: Point entry grid; distribution analysis (histogram, statistics);
+  scheme configuration (two-point auto-generation + manual adjustment);
+  grade preview and application; results publication.
 - Refs: [Exam grading workflow](12-views.md#exam-grading-workflow)
-- Acceptance: Teachers can create and apply grade schemes; preview grade distribution; apply action creates final grades; publication uses existing PR-8.4 toggle; feature flag gates UI.
+- Acceptance: Teachers can enter exam points; create and apply grade schemes; preview grade distribution; publish results to students; feature flag gates UI.
 ```
 
 ```admonish abstract
-Grading — Step 10: Participation Tracking (Talk Grading)
+Grading — Step 10: Participation Tracking
 ```
 
-```admonish example "PR-10.1 — Talk grading UI (Gradable without Pointable)"
-- Scope: Direct grade entry for talks (no task points, just final grade).
-- Controllers: `Assessment::TalkGradingController` (new controller for Gradable-only workflow)
-- UI:
-  - Student list with grade dropdown (direct grade entry, no tasks)
-  - Reuses publication toggle from PR-8.4
-  - Demonstrates Gradable concern without Pointable (talks don't have task breakdowns)
-- Rationale: Talks have Assessable+Gradable but NOT Pointable (no task decomposition)
-- Refs: [Talk grading workflow](04-assessments-and-grading.md#talk-grading)
-- Acceptance: Teachers can assign final grades to talks; no task points involved; publication works; feature flag gates UI.
-```
-
-```admonish example "PR-10.2 — Achievement model (participation tracking)"
+```admonish example "PR-10.1 — Achievement model (new assessable type)"
 - Scope: Create Achievement as assessable for non-graded participation.
-- Model: `Achievement` with `value_type` (boolean/numeric/percentage)
-- Concerns: `Assessment::Assessable` (but NOT Pointable or Gradable)
-- Controllers: `AchievementsController` (CRUD), extend `Assessment::ParticipationsController` with achievement marking actions
-- UI: Checkbox/numeric input for marking; student list view
-- Rationale: Achievements track participation but don't contribute to grades
-- Refs: [Achievement model](04-assessments-and-grading.md#achievement-model), [Participation tracking](04-assessments-and-grading.md#participation-tracking)
-- Acceptance: Achievement model exists; can be linked to assessments; teachers can mark achievements; students see progress; value_type validated; feature flag gates UI.
+- Model: `Achievement` with `value_type` (boolean/numeric/percentage).
+- Refs: [Achievement model](04-assessments-and-grading.md#achievement-model)
+- Acceptance: Achievement model exists; can be linked to assessments; value_type validated.
 ```
 
-```admonish note
-**Status of Steps 11-15:** Steps 11 through 15 (Dashboards, Student Performance, Exam Eligibility, and Quality/Hardening) remain at high-level outline stage. These steps build upon the assessment/grading foundation established in Steps 7-10. Detailed PR breakdowns for Steps 11-15 will be added during implementation planning for those phases.
+```admonish example "PR-10.2 — Achievement marking UI"
+- Scope: UI for teachers to mark achievements.
+- Controllers: Extend `Assessment::ParticipationsController` with
+  achievement marking actions.
+- UI: Checkbox/numeric input for marking; student list view.
+- Refs: [Participation tracking](04-assessments-and-grading.md#participation-tracking)
+- Acceptance: Teachers can mark achievements; students see progress; feature flag gates UI.
 ```
 
 ```admonish abstract


### PR DESCRIPTION
In this PR we bring back some changes to the docs in 7.2 (and from previous PRs) - notably the PR roadmap - back to `next` such that the online version of the architecture book stays up-to-date.