### PR TITLE
Muesli: PR 9.1 - Grade scheme foundations

### DIFF
--- a/app/models/assessment/grade_scheme.rb
+++ b/app/models/assessment/grade_scheme.rb
@@ -60,7 +60,7 @@ module Assessment
       end
 
       # banded config schema:
-      #   { "bands" => [{ "min_points" => 54, "max_points" => 60, "grade" => "1.0" }, ...] }
+      #   { "bands" => [{ "min_points" => 54, "grade" => "1.0" }, ...] }
       # or with percentages:
       #   { "bands" => [{ "min_pct" => 90, "max_pct" => 100, "grade" => "1.0" }, ...] }
       # All bands must use the same format (points xor percentages).

--- a/app/models/assessment/grade_scheme.rb
+++ b/app/models/assessment/grade_scheme.rb
@@ -8,6 +8,7 @@ module Assessment
     validates :config, presence: true
     validates :assessment_id, uniqueness: true, if: :active?
     validate :config_matches_kind
+    validate :immutable_when_applied, on: :update
 
     before_save :compute_hash, if: :config_changed?
 
@@ -16,15 +17,34 @@ module Assessment
     end
 
     def compute_hash
-      self.version_hash = Digest::MD5.hexdigest(config.to_json)
+      self.version_hash = Digest::MD5.hexdigest(
+        deep_sort_keys(config).to_json
+      )
     end
 
     private
+
+      def immutable_when_applied
+        return if applied_at_was.blank?
+
+        errors.add(:base, :immutable_when_applied)
+      end
 
       def config_matches_kind
         case kind.to_sym
         when :banded
           validate_banded_config
+        end
+      end
+
+      def deep_sort_keys(obj)
+        case obj
+        when Hash
+          obj.sort.to_h.transform_values { |v| deep_sort_keys(v) }
+        when Array
+          obj.map { |v| deep_sort_keys(v) }
+        else
+          obj
         end
       end
 
@@ -52,9 +72,14 @@ module Assessment
         end
 
         key = has_points ? "min_points" : "min_pct"
-        return if bands.all? { |b| b.key?(key) }
+        unless bands.all? { |b| b.key?(key) }
+          errors.add(:config, "all bands must use the same format")
+          return
+        end
 
-        errors.add(:config, "all bands must use the same format")
+        return if bands.all? { |b| b["grade"].present? }
+
+        errors.add(:config, "every band must have a grade")
       end
   end
 end

--- a/app/models/assessment/grade_scheme.rb
+++ b/app/models/assessment/grade_scheme.rb
@@ -9,6 +9,7 @@ module Assessment
     validates :assessment_id, uniqueness: true, if: :active?
     validate :config_matches_kind
     validate :immutable_when_applied, on: :update
+    validate :assessable_must_be_pointable_and_gradable
 
     before_save :compute_hash, if: :config_changed?
 
@@ -28,6 +29,16 @@ module Assessment
         return if applied_at_was.blank?
 
         errors.add(:base, :immutable_when_applied)
+      end
+
+      def assessable_must_be_pointable_and_gradable
+        return unless assessment&.assessable
+
+        assessable = assessment.assessable
+        return if assessable.is_a?(::Assessment::Pointable) &&
+                  assessable.is_a?(::Assessment::Gradable)
+
+        errors.add(:assessment, :must_be_pointable_and_gradable)
       end
 
       def config_matches_kind

--- a/app/models/assessment/grade_scheme.rb
+++ b/app/models/assessment/grade_scheme.rb
@@ -1,0 +1,60 @@
+module Assessment
+  class GradeScheme < ApplicationRecord
+    belongs_to :assessment, class_name: "Assessment::Assessment"
+    belongs_to :applied_by, class_name: "User", optional: true
+
+    enum :kind, { banded: 0 }
+
+    validates :config, presence: true
+    validates :assessment_id, uniqueness: true, if: :active?
+    validate :config_matches_kind
+
+    before_save :compute_hash, if: :config_changed?
+
+    def applied?
+      applied_at.present?
+    end
+
+    def compute_hash
+      self.version_hash = Digest::MD5.hexdigest(config.to_json)
+    end
+
+    private
+
+      def config_matches_kind
+        case kind.to_sym
+        when :banded
+          validate_banded_config
+        end
+      end
+
+      # banded config schema:
+      #   { "bands" => [{ "min_points" => 54, "max_points" => 60, "grade" => "1.0" }, ...] }
+      # or with percentages:
+      #   { "bands" => [{ "min_pct" => 90, "max_pct" => 100, "grade" => "1.0" }, ...] }
+      # All bands must use the same format (points xor percentages).
+      def validate_banded_config
+        return unless config.is_a?(Hash)
+
+        bands = config["bands"]
+        unless bands.is_a?(Array) && bands.any?
+          errors.add(:config, "must have a non-empty bands array")
+          return
+        end
+
+        first = bands.first
+        has_points = first.key?("min_points")
+        has_pct = first.key?("min_pct")
+
+        unless has_points || has_pct
+          errors.add(:config, "bands must use min_points or min_pct")
+          return
+        end
+
+        key = has_points ? "min_points" : "min_pct"
+        return if bands.all? { |b| b.key?(key) }
+
+        errors.add(:config, "all bands must use the same format")
+      end
+  end
+end

--- a/architecture/src/features/01-domain-model.md
+++ b/architecture/src/features/01-domain-model.md
@@ -52,8 +52,8 @@ This chapter summarizes principal entities; authoritative behavioral details liv
 
 | Component | Type | Description |
 |-----------|------|-------------|
-| GradeScheme::Scheme | ActiveRecord | Versioned configuration for converting assessment points to final grades |
-| GradeScheme::Applier | Service | Applies scheme to compute and persist final grades for all participations |
+| Assessment::GradeScheme | ActiveRecord | Versioned configuration for converting assessment points to final grades |
+| Assessment::GradeSchemeApplier | Service | Applies scheme to compute and persist final grades for all participations |
 
 ## Allocation Algorithm
 

--- a/architecture/src/features/05a-exam-model.md
+++ b/architecture/src/features/05a-exam-model.md
@@ -193,7 +193,7 @@ Record and process exam grades using the assessment system.
 | 2 | Seed participations | System creates `Assessment::Participation` for each registered student |
 | 3 | Define tasks | Staff creates `Assessment::Task` records (e.g., Problem 1, Problem 2) |
 | 4 | Enter grades | Tutors record `Assessment::TaskPoint` for each student/task |
-| 5 | Apply grade scheme | Staff applies `GradeScheme::Scheme` to convert points to letter grades |
+| 5 | Apply grade scheme | Staff applies `Assessment::GradeScheme` to convert points to letter grades |
 
 ```admonish note "Multiple Choice Exam Extension"
 For exams with multiple choice components requiring legal compliance, see the [Multiple Choice Exams](05c-multiple-choice-exams.md) chapter for the two-stage grading process.

--- a/architecture/src/features/05b-grading-schemes.md
+++ b/architecture/src/features/05b-grading-schemes.md
@@ -73,8 +73,6 @@ The main fields and methods of `Assessment::GradeScheme` are:
 ```ruby
 module Assessment
   class GradeScheme < ApplicationRecord
-    self.table_name = "grade_schemes"
-
     belongs_to :assessment, class_name: "Assessment::Assessment"
     belongs_to :applied_by, class_name: "User", optional: true
 

--- a/architecture/src/features/05b-grading-schemes.md
+++ b/architecture/src/features/05b-grading-schemes.md
@@ -23,9 +23,9 @@ After an exam is graded and all points are recorded, MaMpf needs to:
 
 ## Solution Architecture
 We use a configurable scheme model with service-based application:
-- **Canonical Source:** `GradeScheme::Scheme` stores scheme configuration per assessment
+- **Canonical Source:** `Assessment::GradeScheme` stores scheme configuration per assessment
 - **Banded Config:** JSON config defines grade bands with either absolute points or percentages
-- **Service-Based Application:** `GradeScheme::Applier` iterates participations and computes grades
+- **Service-Based Application:** `Assessment::GradeSchemeApplier` iterates participations and computes grades
 - **Version Control:** Hash-based versioning prevents duplicate applications
 - **Override Respect:** Manual grades bypass scheme application
 - **Distribution Analysis:** Service provides statistics for informed decision-making
@@ -33,7 +33,7 @@ We use a configurable scheme model with service-based application:
 
 ---
 
-## GradeScheme::Scheme (ActiveRecord Model)
+## Assessment::GradeScheme (ActiveRecord Model)
 **_Grade Mapping Configuration_**
 
 ```admonish info "What it represents"
@@ -44,7 +44,7 @@ A versioned configuration that defines how to convert assessment points into fin
 "The grading curve for the Linear Algebra final exam: 54+ points gets 1.0, 48-53 points gets 1.3, ... or alternatively 90%+ gets 1.0, 80-89% gets 1.3, ..."
 ```
 
-The main fields and methods of `GradeScheme::Scheme` are:
+The main fields and methods of `Assessment::GradeScheme` are:
 
 | Name/Field       | Type/Kind        | Description                                                    |
 |------------------|------------------|----------------------------------------------------------------|
@@ -71,64 +71,76 @@ The main fields and methods of `GradeScheme::Scheme` are:
 ### Example Implementation
 
 ```ruby
-module GradeScheme
-  class Scheme < ApplicationRecord
+module Assessment
+  class GradeScheme < ApplicationRecord
     self.table_name = "grade_schemes"
 
     belongs_to :assessment, class_name: "Assessment::Assessment"
     belongs_to :applied_by, class_name: "User", optional: true
 
-    enum kind: { banded: 0 }
+    enum :kind, { banded: 0 }
 
-  validates :assessment_id, uniqueness: { scope: :active, if: :active? }
-  validates :config, presence: true
-  validate :config_matches_kind
+    validates :config, presence: true
+    validates :assessment_id, uniqueness: true, if: :active?
+    validate :config_matches_kind
 
-  before_save :compute_hash, if: :config_changed?
+    before_save :compute_hash, if: :config_changed?
 
-  def applied?
-    applied_at.present?
-  end
+    def applied?
+      applied_at.present?
+    end
 
-  def compute_hash
-    self.version_hash = Digest::MD5.hexdigest(config.to_json)
-  end
+    def compute_hash
+      self.version_hash = Digest::MD5.hexdigest(config.to_json)
+    end
 
-  private
+    private
 
-  def config_matches_kind
-    case kind.to_sym
-    when :banded
-      # Check for either absolute points or percentage-based bands
-      has_bands = config["bands"].is_a?(Array)
-      errors.add(:config, "must have bands array") unless has_bands
-
-      if has_bands
-        first_band = config["bands"].first
-        has_points = first_band&.key?("min_points")
-        has_pct = first_band&.key?("min_pct")
-
-        unless has_points || has_pct
-          errors.add(:config, "bands must have either min_points/max_points or min_pct/max_pct")
+      def config_matches_kind
+        case kind.to_sym
+        when :banded
+          validate_banded_config
         end
       end
-    end
-  end
+
+      def validate_banded_config
+        return unless config.is_a?(Hash)
+
+        bands = config["bands"]
+        unless bands.is_a?(Array) && bands.any?
+          errors.add(:config, "must have a non-empty bands array")
+          return
+        end
+
+        first = bands.first
+        has_points = first.key?("min_points")
+        has_pct = first.key?("min_pct")
+
+        unless has_points || has_pct
+          errors.add(:config, "bands must use min_points or min_pct")
+          return
+        end
+
+        key = has_points ? "min_points" : "min_pct"
+        return if bands.all? { |b| b.key?(key) }
+
+        errors.add(:config, "all bands must use the same format")
+      end
   end
 end
 ```
 
 ### Usage Scenarios
 
-- **Creating a draft scheme:** After an exam is graded, the professor creates: `GradeScheme::Scheme.create!(assessment: exam_assessment, kind: :banded, active: true, config: { bands: [...] })`. The scheme is saved but `applied_at` remains `nil`.
+- **Creating a draft scheme:** After an exam is graded, the professor creates: `Assessment::GradeScheme.create!(assessment: exam_assessment, kind: :banded, active: true, config: { bands: [...] })`. The scheme is saved but `applied_at` remains `nil`.
 
-- **Analyzing distribution:** Before applying, the professor requests distribution stats: `GradeScheme::Applier.new(scheme).analyze_distribution`. This returns `{ min: 15, max: 98, mean: 72, median: 74, percentiles: { 10 => 45, 25 => 60, ... } }`.
+- **Analyzing distribution:** Before applying, the professor requests distribution stats: `Assessment::GradeSchemeApplier.new(scheme).analyze_distribution`. This returns `{ min: 15, max: 98, mean: 72, median: 74, percentiles: { 10 => 45, 25 => 60, ... } }`.
 
 - **Adjusting cutoffs:** Seeing the exam was harder than expected, the professor lowers cutoffs: `scheme.update!(config: { bands: [...] })`. The `version_hash` updates automatically.
 
-- **Applying scheme:** The professor finalizes: `GradeScheme::Applier.new(scheme).apply!(applied_by: professor)`. All participations get `grade_value` computed, `scheme.applied_at` is set.
+- **Applying scheme:** The professor finalizes: `Assessment::GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. All participations get `grade_value` computed, `scheme.applied_at` is set.
 
-- **Preventing re-application:** Someone tries to apply again: `GradeScheme::Applier.new(scheme).apply!(applied_by: professor)`. The service checks `version_hash`, sees it matches, and returns early (idempotent).
+- **Preventing re-application:** Someone tries to apply again: `Assessment::GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. The service checks `version_hash`, sees it matches, and returns early (idempotent).
 
 ---
 
@@ -234,7 +246,7 @@ The `config` JSONB field contains scheme-specific configuration. Currently, MaMp
 | Dave | 22 pts | 36.67% | 5.0 | Failed |
 
 ```admonish note "Detection Logic"
-The `GradeScheme::Applier` automatically detects whether `min_points`/`max_points` or `min_pct`/`max_pct` is used by inspecting the first band. Both formats use the same `kind: :banded` enum value.
+The `Assessment::GradeSchemeApplier` automatically detects whether `min_points`/`max_points` or `min_pct`/`max_pct` is used by inspecting the first band. Both formats use the same `kind: :banded` enum value.
 ```
 
 ### Interactive Curve Generation (Frontend Convenience)
@@ -429,7 +441,7 @@ flowchart TD
     BuildConfig --> SendToBackend[Send POST request to backend]
     SendToBackend --> BackendValidate[Backend validates config]
 
-    BackendValidate --> SaveScheme[Save GradeScheme::Scheme record]
+    BackendValidate --> SaveScheme[Save Assessment::GradeScheme record]
     SaveScheme --> Success([Scheme created successfully])
 
     style Start fill:#e1f5ff
@@ -450,7 +462,7 @@ The flexible JSONB config structure makes it easy to add new scheme types withou
 
 ---
 
-## GradeScheme::Applier (Service Object)
+## Assessment::GradeSchemeApplier (Service Object)
 **_Grade Computer_**
 
 ```admonish info "What it represents"
@@ -588,8 +600,8 @@ flowchart TD
 ### Example Implementation
 
 ```ruby
-module GradeScheme
-  class Applier
+module Assessment
+  class GradeSchemeApplier
     def initialize(scheme)
       @scheme = scheme
       @assessment = scheme.assessment
@@ -699,15 +711,15 @@ end
 
 ### Usage Scenarios
 
-- **Preview before applying:** Professor wants to see results: `preview = GradeScheme::Applier.new(scheme).preview`. They review the proposed grades and see that 5 students would fail.
+- **Preview before applying:** Professor wants to see results: `preview = Assessment::GradeSchemeApplier.new(scheme).preview`. They review the proposed grades and see that 5 students would fail.
 
 - **Adjust and re-preview:** Professor lowers the passing threshold: `scheme.update!(config: { ... })`, then previews again. Now only 2 students fail, which seems fair.
 
-- **Final application:** Professor applies: `GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. All 150 students get their `grade_value` set.
+- **Final application:** Professor applies: `Assessment::GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. All 150 students get their `grade_value` set.
 
 - **Manual override:** One student had exceptional circumstances. The tutor marks: `participation.update!(manual_grade_override: true, grade_value: "2.0")`. Future scheme applications will skip this record.
 
-- **Idempotent reapplication:** System accidentally triggers apply again: `GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. The service detects identical `version_hash` and returns immediately.
+- **Idempotent reapplication:** System accidentally triggers apply again: `Assessment::GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. The service detects identical `version_hash` and returns immediately.
 
 ---
 
@@ -741,7 +753,7 @@ Grading schemes add:
 
 ### Usage Scenarios
 
-- **After exam grading:** All task points are entered and `Assessment::Participation.points_total` values are computed. The professor creates a `GradeScheme::Scheme` to convert these points to final grades.
+- **After exam grading:** All task points are entered and `Assessment::Participation.points_total` values are computed. The professor creates an `Assessment::GradeScheme` to convert these points to final grades.
 
 - **Manual grade override:** A student with exceptional circumstances gets `participation.manual_grade_override = true` and a direct grade entry. When the scheme is applied, this participation is skipped.
 
@@ -767,8 +779,8 @@ erDiagram
 sequenceDiagram
     actor Professor
     participant Assessment as Assessment::Assessment
-    participant Scheme as GradeScheme::Scheme
-    participant Applier as GradeScheme::Applier
+    participant Scheme as Assessment::GradeScheme
+    participant Applier as Assessment::GradeSchemeApplier
     participant Participation as Assessment::Participation
 
     rect rgb(235, 245, 255)
@@ -811,14 +823,14 @@ sequenceDiagram
 ```text
 app/
 └── models/
-    └── grade_scheme/
-        ├── scheme.rb
-        └── applier.rb
+    └── assessment/
+        ├── grade_scheme.rb
+        └── grade_scheme_applier.rb
 ```
 
 ### Key Files
-- `app/models/grade_scheme/scheme.rb` - Versioned scheme configuration
-- `app/models/grade_scheme/applier.rb` - Grade computation and application logic
+- `app/models/assessment/grade_scheme.rb` - Versioned scheme configuration
+- `app/models/assessment/grade_scheme_applier.rb` - Grade computation and application logic
 
 ---
 
@@ -827,5 +839,5 @@ app/
 - `grade_schemes` - Scheme configurations with version control
 
 ```admonish note
-Column details are documented in the GradeScheme::Scheme model section above.
+Column details are documented in the Assessment::GradeScheme model section above.
 ```

--- a/architecture/src/features/05b-grading-schemes.md
+++ b/architecture/src/features/05b-grading-schemes.md
@@ -458,6 +458,16 @@ Additional grading schemes (percentile-based ranking, piecewise mapping, etc.) c
 The flexible JSONB config structure makes it easy to add new scheme types without database migrations.
 ```
 
+```admonish todo "Manual Grade Override (Deferred)"
+A `manual_grade_override` boolean flag on `Assessment::Participation` could
+allow teachers to protect hand-picked grades from being overwritten by
+scheme (re-)application. The typical workflow — apply scheme first, then
+manually correct a few grades — does not require this flag initially.
+It becomes relevant only when re-application is needed (e.g. after fixing
+task points or adjusting band config). Deferred until the UI for manual
+grade editing exists and the re-application workflow is clearer.
+```
+
 ---
 
 ## Assessment::GradeSchemeApplier (Service Object)
@@ -483,7 +493,6 @@ The "grade calculator" that transforms points into grades according to the confi
 ### Behavior Highlights
 
 - **Idempotent:** Checks `version_hash` before applying; skip if already applied
-- **Manual override respect:** Skips participations with `manual_grade_override` flag
 - **Transaction-safe:** Uses database transaction for consistency
 - **Efficient:** Single query to load all participations, batch updates
 - **Statistics:** Analyzes distribution for informed decision-making
@@ -628,8 +637,6 @@ module Assessment
       participations = @assessment.participations.where(status: :reviewed)
 
       participations.each do |participation|
-        next if participation.manual_grade_override?
-
         grade = compute_grade_for(participation)
         participation.update!(grade_value: grade)
       end
@@ -715,8 +722,6 @@ end
 
 - **Final application:** Professor applies: `Assessment::GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. All 150 students get their `grade_value` set.
 
-- **Manual override:** One student had exceptional circumstances. The tutor marks: `participation.update!(manual_grade_override: true, grade_value: "2.0")`. Future scheme applications will skip this record.
-
 - **Idempotent reapplication:** System accidentally triggers apply again: `Assessment::GradeSchemeApplier.new(scheme).apply!(applied_by: professor)`. The service detects identical `version_hash` and returns immediately.
 
 ---
@@ -752,8 +757,6 @@ Grading schemes add:
 ### Usage Scenarios
 
 - **After exam grading:** All task points are entered and `Assessment::Participation.points_total` values are computed. The professor creates an `Assessment::GradeScheme` to convert these points to final grades.
-
-- **Manual grade override:** A student with exceptional circumstances gets `participation.manual_grade_override = true` and a direct grade entry. When the scheme is applied, this participation is skipped.
 
 - **Re-grading scenario:** A mistake is found in one student's exam. The tutor corrects their task points. The `points_total` updates via callback. The professor could re-apply the scheme (with same config) to update just that grade, but the idempotency check would skip all unchanged participations.
 
@@ -804,11 +807,7 @@ sequenceDiagram
     Professor->>Applier: apply!(applied_by: professor)
     Applier->>Applier: check version_hash (idempotency)
     loop for each participation
-        alt not manual override
-            Applier->>Participation: update(grade_value: computed_grade)
-        else manual override
-            Applier->>Participation: skip
-        end
+        Applier->>Participation: update(grade_value: computed_grade)
     end
     Applier->>Scheme: update(applied_at, applied_by)
     end

--- a/architecture/src/features/05b-grading-schemes.md
+++ b/architecture/src/features/05b-grading-schemes.md
@@ -24,7 +24,7 @@ After an exam is graded and all points are recorded, MaMpf needs to:
 ## Solution Architecture
 We use a configurable scheme model with service-based application:
 - **Canonical Source:** `GradeScheme::Scheme` stores scheme configuration per assessment
-- **Absolute Bands:** JSON config defines grade bands with either absolute points or percentages
+- **Banded Config:** JSON config defines grade bands with either absolute points or percentages
 - **Service-Based Application:** `GradeScheme::Applier` iterates participations and computes grades
 - **Version Control:** Hash-based versioning prevents duplicate applications
 - **Override Respect:** Manual grades bypass scheme application
@@ -49,7 +49,7 @@ The main fields and methods of `GradeScheme::Scheme` are:
 | Name/Field       | Type/Kind        | Description                                                    |
 |------------------|------------------|----------------------------------------------------------------|
 | `assessment_id`  | DB column (FK)   | The assessment this scheme applies to                          |
-| `kind`           | DB column (Enum) | Scheme type: currently only `absolute`                         |
+| `kind`           | DB column (Enum) | Scheme type: currently only `banded`                           |
 | `config`         | DB column (JSONB)| Scheme-specific configuration (bands, coefficients, etc.)      |
 | `version_hash`   | DB column        | MD5 hash of config for idempotency checking                    |
 | `applied_at`     | DB column        | Timestamp when scheme was last applied (nil if draft)          |
@@ -78,7 +78,7 @@ module GradeScheme
     belongs_to :assessment, class_name: "Assessment::Assessment"
     belongs_to :applied_by, class_name: "User", optional: true
 
-    enum kind: { absolute: 0 }
+    enum kind: { banded: 0 }
 
   validates :assessment_id, uniqueness: { scope: :active, if: :active? }
   validates :config, presence: true
@@ -98,7 +98,7 @@ module GradeScheme
 
   def config_matches_kind
     case kind.to_sym
-    when :absolute
+    when :banded
       # Check for either absolute points or percentage-based bands
       has_bands = config["bands"].is_a?(Array)
       errors.add(:config, "must have bands array") unless has_bands
@@ -120,7 +120,7 @@ end
 
 ### Usage Scenarios
 
-- **Creating a draft scheme:** After an exam is graded, the professor creates: `GradeScheme::Scheme.create!(assessment: exam_assessment, kind: :absolute, active: true, config: { bands: [...] })`. The scheme is saved but `applied_at` remains `nil`.
+- **Creating a draft scheme:** After an exam is graded, the professor creates: `GradeScheme::Scheme.create!(assessment: exam_assessment, kind: :banded, active: true, config: { bands: [...] })`. The scheme is saved but `applied_at` remains `nil`.
 
 - **Analyzing distribution:** Before applying, the professor requests distribution stats: `GradeScheme::Applier.new(scheme).analyze_distribution`. This returns `{ min: 15, max: 98, mean: 72, median: 74, percentiles: { 10 => 45, 25 => 60, ... } }`.
 
@@ -142,7 +142,7 @@ The `config` JSONB field contains scheme-specific configuration. Currently, MaMp
 |-------------|------------------|---------------|--------|
 | Absolute Points | Standard approach - fixed point thresholds | `min_points`/`max_points` | ✅ In use |
 | Percentage-Based | Cross-exam comparison | `min_pct`/`max_pct` | ✅ In use |
-| Interactive Curve | UI convenience for teachers | Generates absolute config | 🚧 Planned |
+| Interactive Curve | UI convenience for teachers | Generates `banded` config | 🚧 Planned |
 | Percentile/Linear | Advanced statistical schemes | N/A | ⏸️ Future |
 
 ### Absolute Cutoffs
@@ -234,18 +234,18 @@ The `config` JSONB field contains scheme-specific configuration. Currently, MaMp
 | Dave | 22 pts | 36.67% | 5.0 | Failed |
 
 ```admonish note "Detection Logic"
-The `GradeScheme::Applier` automatically detects whether `min_points`/`max_points` or `min_pct`/`max_pct` is used by inspecting the first band. Both formats use the same `kind: :absolute` enum value.
+The `GradeScheme::Applier` automatically detects whether `min_points`/`max_points` or `min_pct`/`max_pct` is used by inspecting the first band. Both formats use the same `kind: :banded` enum value.
 ```
 
 ### Interactive Curve Generation (Frontend Convenience)
 
 ```admonish warning "Implementation Status"
-**Backend:** ✅ Already supported via `absolute` scheme
+**Backend:** ✅ Already supported via `banded` scheme
 **Frontend:** 🚧 Planned - Interactive UI needs to be built
 ```
 
 ```admonish info "Design Philosophy"
-The backend only needs to support the `absolute` scheme with bands. The "curve generation" is purely a **frontend convenience feature** that produces valid `absolute` configs by helping teachers visualize and set boundaries.
+The backend only needs to support the `banded` scheme. The "curve generation" is purely a **frontend convenience feature** that produces valid `banded` configs by helping teachers visualize and set boundaries.
 ```
 
 **Comparison of UI approaches:**
@@ -271,7 +271,7 @@ Teacher sets just two anchors ("54+ gets 1.0", "30+ gets 4.0"), system fills in 
 4. Frontend calculates linear interpolation for intermediate grades
 5. Frontend displays preview: "54-60→1.0, 48-53→1.3, 42-47→1.7, ..."
 6. Teacher can manually adjust any band boundary if desired (see below)
-7. Frontend sends final `absolute` config to backend
+7. Frontend sends final `banded` config to backend
 
 **Example JavaScript helper:**
 ```javascript
@@ -296,7 +296,7 @@ function generateLinearBands(excellentPts, passingPts, maxPts, gradeSteps) {
 const bands = generateLinearBands(54, 30, 60,
   ["1.0", "1.3", "1.7", "2.0", "2.3", "3.0", "3.7", "4.0"]
 );
-// Send to backend: { kind: "absolute", config: { bands } }
+// Send to backend: { kind: "banded", config: { bands } }
 ```
 
 | Benefit | Description |
@@ -319,7 +319,7 @@ Teacher drags individual boundary markers for each grade on the histogram.
    - Drag "1.3/1.7 boundary" to adjust next boundary
    - ... (continues for all grades)
 4. Frontend displays current band configuration
-5. Frontend sends complete `absolute` config to backend
+5. Frontend sends complete `banded` config to backend
 
 | Benefit | Description |
 |---------|-------------|
@@ -343,7 +343,7 @@ Auto-generate initial bands from two points, then allow manual tweaking of indiv
      - **Option A:** Auto-adjusts neighboring bands to fill gaps
      - **Option B:** Shows warning "Gap detected between 1.0 and 1.3"
 4. Teacher previews grade distribution with adjusted boundaries
-5. Frontend sends final `absolute` config to backend
+5. Frontend sends final `banded` config to backend
 
 **Example of manual adjustment after auto-generation:**
 ```javascript
@@ -379,7 +379,7 @@ const adjustedBands = adjustBand(initialBands, "1.0", 50);
 | 🥧 Distribution chart | Pie/bar chart showing final grade distribution |
 
 ```admonish note "Backend Simplicity"
-- Backend receives only `{ kind: "absolute", config: { bands: [...] } }`
+- Backend receives only `{ kind: "banded", config: { bands: [...] } }`
 - Doesn't know or care how bands were generated (manual, auto, or hybrid)
 - No special "two-point" or "curve" scheme type needed
 - Simple validation: bands must not overlap, must cover 0 to max_points
@@ -779,7 +779,7 @@ sequenceDiagram
 
     rect rgb(255, 245, 235)
     note over Professor,Scheme: Phase 2: Scheme Configuration
-    Professor->>Scheme: create(kind: absolute, config: {...})
+    Professor->>Scheme: create(kind: banded, config: {...})
     Professor->>Applier: analyze_distribution
     Applier->>Participation: aggregate points statistics
     Applier-->>Professor: show distribution (mean, percentiles)

--- a/architecture/src/features/05c-multiple-choice-exams.md
+++ b/architecture/src/features/05c-multiple-choice-exams.md
@@ -264,7 +264,7 @@ module Assessment
         threshold_percentage
       )
 
-      GradeScheme::Applier.compute_grade(
+      Assessment::GradeSchemeApplier.compute_grade(
         mc_points,
         mc_task.max_points,
         adjusted_scheme
@@ -292,7 +292,7 @@ module Assessment
                           .sum(:points)
       max = regular_tasks.sum(:max_points)
 
-      GradeScheme::Applier.compute_grade(
+      Assessment::GradeSchemeApplier.compute_grade(
         total,
         max,
         @assessment.grade_scheme
@@ -310,7 +310,7 @@ end
 |------|--------|-------------------|
 | 1 | Create assessment | Staff creates `Assessment::Assessment` for the exam |
 | 2 | Create tasks | Staff creates tasks, marking one with `is_multiple_choice: true` |
-| 3 | Configure MC scheme | Staff creates and assigns a `GradeScheme::Scheme` to the MC task |
+| 3 | Configure MC scheme | Staff creates and assigns an `Assessment::GradeScheme` to the MC task |
 | 4 | Grade all tasks | Tutors grade MC questions and written problems normally |
 | 5 | Apply MC grader | Staff calls `Assessment::McGrader.new(assessment).apply_legal_scheme!` |
 | 6 | Results | Service computes threshold, checks eligibility, adjusts scheme, computes final grades |
@@ -400,9 +400,9 @@ assessment.tasks.create!(title: "Problem 2", max_points: 25)
 assessment.tasks.create!(title: "Problem 3", max_points: 25)
 
 mc_task = assessment.tasks.multiple_choice.first
-mc_scheme = GradeScheme::Scheme.create!(
+mc_scheme = Assessment::GradeScheme.create!(
   title: "MC Legal Scheme",
-  kind: :absolute,
+  kind: :banded,
   bands: [
     { min_percentage: 0.90, grade: 1.0 },
     { min_percentage: 0.80, grade: 2.0 },

--- a/architecture/src/features/06-end-to-end-workflow.md
+++ b/architecture/src/features/06-end-to-end-workflow.md
@@ -417,14 +417,14 @@ Record exam scores and assign final grades
 **Grade Scheme Application:**
 
 ```admonish note "Converting Points to Grades"
-Staff analyzes score distribution (histogram, percentiles), then creates and applies a `GradeScheme::Scheme`.
+Staff analyzes score distribution (histogram, percentiles), then creates and applies an `Assessment::GradeScheme`.
 ```
 
 | Step | Process |
 |------|---------|
 | Analyze | View distribution statistics and histogram |
-| Configure | Create `GradeScheme::Scheme` with absolute point bands or percentage cutoffs |
-| Apply | Call `GradeScheme::Applier.apply!(scheme)` |
+| Configure | Create `Assessment::GradeScheme` with absolute point bands or percentage cutoffs |
+| Apply | Call `Assessment::GradeSchemeApplier.apply!(scheme)` |
 | Result | Service computes `grade_value` for each participation based on points |
 | Override | Manual adjustments possible for exceptional cases |
 

--- a/architecture/src/features/08-examples-and-demos.md
+++ b/architecture/src/features/08-examples-and-demos.md
@@ -401,7 +401,7 @@ exam_assessment.participations.find_each do |part|
 end
 
 # Create and apply grade scheme
-exam_scheme = GradeScheme::Scheme.create!(
+exam_scheme = Assessment::GradeScheme.create!(
   title: "Final Exam Grading",
   bands: [
     { "min_points" => 90, "grade" => "1.0" },
@@ -412,7 +412,7 @@ exam_scheme = GradeScheme::Scheme.create!(
   ]
 )
 # Assuming an applier service exists
-# GradeScheme::Applier.new(exam_assessment, exam_scheme).apply!
+# Assessment::GradeSchemeApplier.new(exam_assessment, exam_scheme).apply!
 
 puts "\nExam graded (conceptual)."
 

--- a/architecture/src/features/09-integrity-and-invariants.md
+++ b/architecture/src/features/09-integrity-and-invariants.md
@@ -235,7 +235,7 @@ future extension.
 |-----------|---------------------|
 | `Campaign.finalize!` | Check `status != :finalized` before proceeding |
 | `materialize_allocation!` | Replace entire roster (not additive) |
-| `GradeScheme::Applier.apply!` | Compare `version_hash`; skip if unchanged |
+| `Assessment::GradeSchemeApplier.apply!` | Compare `version_hash`; skip if unchanged |
 | `StudentPerformance::ComputationService.compute!` | Upsert pattern preserves overrides |
 | `Roster::MaintenanceService` operations | Each operation atomic with validation |
 

--- a/architecture/src/features/11-controllers.md
+++ b/architecture/src/features/11-controllers.md
@@ -17,19 +17,17 @@ service objects to the right endpoints.
 |-------------|----------------------------------------------------|---------------------------|
 | Registration| Campaigns, UserRegistrations, Policies, Allocation | Teacher/Editor UI, Student UI, Job |
 | Roster      | Maintenance                                        | Teacher/Editor UI         |
-| Assessment  | Assessments, Grading, Participations               | Teacher/Editor UI, Tutor UI |
+| Assessment  | Assessments, Grading, Participations, GradeSchemes | Teacher/Editor UI, Tutor UI |
 | StudentPerformance | Records, Certifications, Evaluator           | Teacher/Editor UI         |
 | Exam        | Exams                                              | Teacher/Editor UI         |
-| GradeScheme | Schemes                                            | Teacher/Editor UI         |
 | Dashboard   | Dashboard, Admin::Dashboard                        | Student UI, Teacher/Editor UI |
 
 Controllers are grouped into the following namespaces:
 - Registration: Campaign setup, student registration, allocation
 - Roster: Post-allocation roster maintenance
-- Assessment: Assessment setup, grading, result viewing
+- Assessment: Assessment setup, grading, result viewing, grade scheme configuration
 - StudentPerformance: Performance records, teacher certification, evaluator proposals
 - Exam: Exam management
-- GradeScheme: Grading scheme configuration
 - Dashboard: Student and teacher/editor views
 
 ```admonish tip "Turbo responses"
@@ -435,7 +433,7 @@ Generate eligibility proposals using the Evaluator service.
 
 ## Grade Scheme Controllers
 
-### `GradeScheme::SchemesController`
+### `Assessment::GradeSchemesController`
 
 ```admonish info "Purpose"
 Configure grading schemes for courses.
@@ -443,7 +441,7 @@ Configure grading schemes for courses.
 
 | Controller | Primary callers | Responses |
 |------------|------------------|-----------|
-| GradeScheme::SchemesController | Teacher/Editor UI | HTML, Turbo Frames/Streams |
+| Assessment::GradeSchemesController | Teacher/Editor UI | HTML, Turbo Frames/Streams |
 
 **Actions**
 

--- a/architecture/src/features/12-views.md
+++ b/architecture/src/features/12-views.md
@@ -555,7 +555,7 @@ For advanced users, Manual Curve mode allows direct control of each grade bounda
 ```
 
 ```admonish note "Controller Reference"
-Grade scheme functionality is implemented in `GradeScheme::SchemesController` with actions: index, new, create, edit, update, preview, and apply. See [Controller Architecture](11-controllers.md#grade-scheme-controllers) for details.
+Grade scheme functionality is implemented in `Assessment::GradeSchemesController` with actions: index, new, create, edit, update, preview, and apply. See [Controller Architecture](11-controllers.md#grade-scheme-controllers) for details.
 ```
 
 ### Assessments (Lectures - Student)

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -502,12 +502,11 @@ Exams — Step 9: Grade Schemes (Exam-Specific Layer)
 ```
 
 ```admonish example "PR-9.1 — Grade scheme schema"
-- Scope: Create `grade_schemes` and `grade_scheme_thresholds`.
-- Migrations:
-  - `20251110000001_create_grade_schemes.rb`
-  - `20251110000002_create_grade_scheme_thresholds.rb`
-- Refs: [GradeScheme models](05b-grading-schemes.md#grading-scheme-models)
-- Acceptance: Migrations run; models have correct validations; percentage-based thresholds supported.
+- Scope: Create `grade_schemes` table; `GradeScheme::Scheme` model with factory and spec.
+- Design decision: bands are stored as JSONB in `config` (no separate thresholds table). Bands are always read/written as a unit, JSONB keeps versioning via `version_hash` atomic, and the schema stays flexible for future `kind` values.
+- Migration: `20260220000000_create_grade_schemes.rb`
+- Refs: [GradeScheme::Scheme](05b-grading-schemes.md#gradeschemeScheme-activerecord-model)
+- Acceptance: Migration runs; `GradeScheme::Scheme` model has correct associations, validations, `applied?`, `compute_hash`, and `config_matches_kind`; factory covers absolute-points, percentage, and applied traits; spec covers all validations and uniqueness of active scheme per assessment.
 ```
 
 ```admonish example "PR-9.2 — Grade scheme applier (service)"

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -502,28 +502,28 @@ Exams — Step 9: Grade Schemes (Exam-Specific Layer)
 ```
 
 ```admonish example "PR-9.1 — Grade scheme schema"
-- Scope: Create `grade_schemes` table; `GradeScheme::Scheme` model with factory and spec.
+- Scope: Create `grade_schemes` table; `Assessment::GradeScheme` model with factory and spec.
 - Design decision: bands are stored as JSONB in `config` (no separate thresholds table). Bands are always read/written as a unit, JSONB keeps versioning via `version_hash` atomic, and the schema stays flexible for future `kind` values.
 - Migration: `20260220000000_create_grade_schemes.rb`
-- Refs: [GradeScheme::Scheme](05b-grading-schemes.md#gradeschemeScheme-activerecord-model)
-- Acceptance: Migration runs; `GradeScheme::Scheme` model has correct associations, validations, `applied?`, `compute_hash`, and `config_matches_kind`; factory covers absolute-points, percentage, and applied traits; spec covers all validations and uniqueness of active scheme per assessment.
+- Refs: [Assessment::GradeScheme](05b-grading-schemes.md#assessmentgradescheme-activerecord-model)
+- Acceptance: Migration runs; `Assessment::GradeScheme` model has correct associations, validations, `applied?`, `compute_hash`, and `config_matches_kind`; factory covers absolute-points, percentage, and applied traits; spec covers all validations and uniqueness of active scheme per assessment.
 ```
 
 ```admonish example "PR-9.2 — Grade scheme applier (service)"
-- Scope: `GradeScheme::Applier` for converting exam points to grades.
+- Scope: `Assessment::GradeSchemeApplier` for converting exam points to grades.
 - Implementation: Supports absolute points and percentage-based bands; idempotent application via version_hash; respects manual overrides
-- Refs: [GradeScheme applier](05b-grading-schemes.md#gradeschemesapplier-service-object)
+- Refs: [Assessment::GradeSchemeApplier](05b-grading-schemes.md#assessmentgradeschemeapplier-service-object)
 - Acceptance: Service computes grades from points; handles both absolute and percentage schemes; version_hash prevents duplicate applications.
 ```
 
 ```admonish example "PR-9.3 — Grade scheme UI + distribution analysis"
 - Scope: UI for grade scheme configuration and application (layers on top of PR-8.4 point grid).
-- Controllers: `GradeScheme::SchemesController` (configuration, preview, apply)
+- Controllers: `Assessment::GradeSchemesController` (configuration, preview, apply)
 - UI:
   - Distribution analysis (histogram, statistics) based on entered points
   - Scheme configuration (two-point auto-generation + manual adjustment)
   - Grade preview showing how scheme maps to students
-  - Apply action (runs GradeScheme::Applier)
+  - Apply action (runs Assessment::GradeSchemeApplier)
 - Integration: Uses existing read-only point grid from PR-8.4; adds grade scheme layer
 - Refs: [Exam grading workflow](12-views.md#exam-grading-workflow)
 - Acceptance: Teachers can create and apply grade schemes; preview grade distribution; apply action creates final grades; publication uses existing PR-8.10 toggle; feature flag gates UI.

--- a/architecture/src/features/implementation-prs.md
+++ b/architecture/src/features/implementation-prs.md
@@ -502,7 +502,7 @@ Exams — Step 9: Grade Schemes (Exam-Specific Layer)
 ```
 
 ```admonish example "PR-9.1 — Grade scheme schema"
-- Scope: Create `grade_schemes` table; `Assessment::GradeScheme` model with factory and spec.
+- Scope: Create `assessment_grade_schemes` table; `Assessment::GradeScheme` model with factory and spec.
 - Design decision: bands are stored as JSONB in `config` (no separate thresholds table). Bands are always read/written as a unit, JSONB keeps versioning via `version_hash` atomic, and the schema stays flexible for future `kind` values.
 - Migration: `20260220000000_create_grade_schemes.rb`
 - Refs: [Assessment::GradeScheme](05b-grading-schemes.md#assessmentgradescheme-activerecord-model)

--- a/architecture/src/features/plan.md
+++ b/architecture/src/features/plan.md
@@ -226,11 +226,11 @@ graph TD
     `Lecture` (already campaignable from Step 2) hosts exam registration
     campaigns.
 
-    Services: Implement `GradeScheme::Applier` for converting exam
+    Services: Implement `Assessment::GradeSchemeApplier` for converting exam
     points to final grades.
 
     Controllers: `ExamsController` (CRUD, scheduling),
-    `GradeScheme::SchemesController` (scheme configuration, preview,
+    `Assessment::GradeSchemesController` (scheme configuration, preview,
     apply). Extend `Registration::CampaignsController` to support exam
     registration campaigns (lecture as campaignable, exam as
     registerable item).

--- a/config/locales/assessment/de.yml
+++ b/config/locales/assessment/de.yml
@@ -153,3 +153,5 @@ de:
           attributes:
             base:
               immutable_when_applied: "Angewandte Notenschemata können nicht geändert werden."
+            assessment:
+              must_be_pointable_and_gradable: "muss sowohl punktebasiert als auch benotbar sein (z.B. Klausur)"

--- a/config/locales/assessment/de.yml
+++ b/config/locales/assessment/de.yml
@@ -149,3 +149,7 @@ de:
           attributes:
             base:
               assessment_mismatch: "Task und Teilnahme müssen zum selben Assessment gehören"
+        assessment/grade_scheme:
+          attributes:
+            base:
+              immutable_when_applied: "Angewandte Notenschemata können nicht geändert werden."

--- a/config/locales/assessment/en.yml
+++ b/config/locales/assessment/en.yml
@@ -153,3 +153,5 @@ en:
           attributes:
             base:
               immutable_when_applied: "Applied grade schemes cannot be modified."
+            assessment:
+              must_be_pointable_and_gradable: "must be both pointable and gradable (e.g. Exam)"

--- a/config/locales/assessment/en.yml
+++ b/config/locales/assessment/en.yml
@@ -149,3 +149,7 @@ en:
           attributes:
             base:
               assessment_mismatch: "Task and participation must belong to the same assessment"
+        assessment/grade_scheme:
+          attributes:
+            base:
+              immutable_when_applied: "Applied grade schemes cannot be modified."

--- a/db/migrate/20260220000000_create_grade_schemes.rb
+++ b/db/migrate/20260220000000_create_grade_schemes.rb
@@ -1,0 +1,27 @@
+class CreateGradeSchemes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :assessment_grade_schemes, id: :uuid do |t|
+      t.uuid :assessment_id, null: false
+      t.integer :kind, null: false, default: 0
+      t.jsonb :config, null: false, default: {}
+      t.string :version_hash
+      t.datetime :applied_at
+      t.bigint :applied_by_id
+      t.boolean :active, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :assessment_grade_schemes, :assessment_id
+    add_index :assessment_grade_schemes, :applied_by_id
+    add_index :assessment_grade_schemes, :assessment_id,
+              unique: true,
+              where: "active = true",
+              name: "idx_assessment_grade_schemes_one_active"
+
+    add_foreign_key :assessment_grade_schemes, :assessment_assessments,
+                    column: :assessment_id
+    add_foreign_key :assessment_grade_schemes, :users,
+                    column: :applied_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_05_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_20_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -119,6 +119,21 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_05_000001) do
     t.index ["lecture_id"], name: "index_assessment_assessments_on_lecture_id"
   end
 
+  create_table "assessment_grade_schemes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "assessment_id", null: false
+    t.integer "kind", default: 0, null: false
+    t.jsonb "config", default: {}, null: false
+    t.string "version_hash"
+    t.datetime "applied_at"
+    t.bigint "applied_by_id"
+    t.boolean "active", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["applied_by_id"], name: "index_assessment_grade_schemes_on_applied_by_id"
+    t.index ["assessment_id"], name: "idx_assessment_grade_schemes_one_active", unique: true, where: "(active = true)"
+    t.index ["assessment_id"], name: "index_assessment_grade_schemes_on_assessment_id"
+  end
+
   create_table "assessment_participations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id", null: false
     t.bigint "user_id", null: false
@@ -135,6 +150,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_05_000001) do
     t.boolean "locked", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "note"
     t.index ["assessment_id", "user_id"], name: "index_participations_on_assessment_and_user", unique: true
     t.index ["assessment_id"], name: "index_assessment_participations_on_assessment_id"
     t.index ["grader_id"], name: "index_assessment_participations_on_grader_id"
@@ -181,6 +197,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_05_000001) do
     t.datetime "updated_at", null: false
     t.text "accepted_file_type", default: ".pdf"
     t.date "deletion_date", default: "2200-01-01", null: false
+    t.index ["deadline", "deletion_date"], name: "index_assignments_on_deadline_and_deletion_date"
     t.index ["lecture_id"], name: "index_assignments_on_lecture_id"
     t.index ["medium_id"], name: "index_assignments_on_medium_id"
   end
@@ -1368,6 +1385,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_05_000001) do
   add_foreign_key "announcements", "lectures"
   add_foreign_key "announcements", "users", column: "announcer_id"
   add_foreign_key "assessment_assessments", "lectures"
+  add_foreign_key "assessment_grade_schemes", "assessment_assessments", column: "assessment_id"
+  add_foreign_key "assessment_grade_schemes", "users", column: "applied_by_id"
   add_foreign_key "assessment_participations", "assessment_assessments", column: "assessment_id"
   add_foreign_key "assessment_participations", "tutorials"
   add_foreign_key "assessment_participations", "users"

--- a/spec/factories/assessment_grade_schemes.rb
+++ b/spec/factories/assessment_grade_schemes.rb
@@ -1,0 +1,49 @@
+FactoryBot.define do
+  factory :assessment_grade_scheme, class: "Assessment::GradeScheme" do
+    association :assessment
+    kind { :banded }
+    active { true }
+    config do
+      {
+        "bands" => [
+          { "min_points" => 54, "max_points" => 60, "grade" => "1.0" },
+          { "min_points" => 48, "max_points" => 53, "grade" => "1.3" },
+          { "min_points" => 42, "max_points" => 47, "grade" => "1.7" },
+          { "min_points" => 36, "max_points" => 41, "grade" => "2.0" },
+          { "min_points" => 33, "max_points" => 35, "grade" => "2.3" },
+          { "min_points" => 30, "max_points" => 32, "grade" => "3.0" },
+          { "min_points" => 27, "max_points" => 29, "grade" => "3.7" },
+          { "min_points" => 24, "max_points" => 26, "grade" => "4.0" },
+          { "min_points" => 0,  "max_points" => 23, "grade" => "5.0" }
+        ]
+      }
+    end
+
+    trait :percentage do
+      config do
+        {
+          "bands" => [
+            { "min_pct" => 90,  "max_pct" => 100, "grade" => "1.0" },
+            { "min_pct" => 80,  "max_pct" => 89.99, "grade" => "1.3" },
+            { "min_pct" => 70,  "max_pct" => 79.99, "grade" => "1.7" },
+            { "min_pct" => 60,  "max_pct" => 69.99, "grade" => "2.0" },
+            { "min_pct" => 55,  "max_pct" => 59.99, "grade" => "2.3" },
+            { "min_pct" => 50,  "max_pct" => 54.99, "grade" => "3.0" },
+            { "min_pct" => 45,  "max_pct" => 49.99, "grade" => "3.7" },
+            { "min_pct" => 40,  "max_pct" => 44.99, "grade" => "4.0" },
+            { "min_pct" => 0,   "max_pct" => 39.99, "grade" => "5.0" }
+          ]
+        }
+      end
+    end
+
+    trait :draft do
+      active { false }
+    end
+
+    trait :applied do
+      applied_at { 1.hour.ago }
+      association :applied_by, factory: :confirmed_user
+    end
+  end
+end

--- a/spec/factories/assessment_grade_schemes.rb
+++ b/spec/factories/assessment_grade_schemes.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     config do
       {
         "bands" => [
-          { "min_points" => 54, "max_points" => 60, "grade" => "1.0" },
-          { "min_points" => 48, "max_points" => 53, "grade" => "1.3" },
-          { "min_points" => 42, "max_points" => 47, "grade" => "1.7" },
-          { "min_points" => 36, "max_points" => 41, "grade" => "2.0" },
-          { "min_points" => 33, "max_points" => 35, "grade" => "2.3" },
-          { "min_points" => 30, "max_points" => 32, "grade" => "3.0" },
-          { "min_points" => 27, "max_points" => 29, "grade" => "3.7" },
-          { "min_points" => 24, "max_points" => 26, "grade" => "4.0" },
-          { "min_points" => 0,  "max_points" => 23, "grade" => "5.0" }
+          { "min_points" => 54, "grade" => "1.0" },
+          { "min_points" => 48, "grade" => "1.3" },
+          { "min_points" => 42, "grade" => "1.7" },
+          { "min_points" => 36, "grade" => "2.0" },
+          { "min_points" => 33, "grade" => "2.3" },
+          { "min_points" => 30, "grade" => "3.0" },
+          { "min_points" => 27, "grade" => "3.7" },
+          { "min_points" => 24, "grade" => "4.0" },
+          { "min_points" => 0,  "grade" => "5.0" }
         ]
       }
     end

--- a/spec/factories/assessment_grade_schemes.rb
+++ b/spec/factories/assessment_grade_schemes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :assessment_grade_scheme, class: "Assessment::GradeScheme" do
-    association :assessment
+    association :assessment, factory: [:assessment, :for_exam]
     kind { :banded }
     active { true }
     config do

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -34,5 +34,10 @@ FactoryBot.define do
       association :assessable, factory: :talk
       lecture { assessable.lecture }
     end
+
+    trait :for_exam do
+      association :assessable, factory: :exam
+      lecture { assessable.lecture }
+    end
   end
 end

--- a/spec/models/assessment/grade_scheme_spec.rb
+++ b/spec/models/assessment/grade_scheme_spec.rb
@@ -49,11 +49,10 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
 
     it "produces the same hash regardless of key order" do
       config = {
-        "bands" => [{ "grade" => "1.0", "min_points" => 54,
-                      "max_points" => 60 }]
+        "bands" => [{ "grade" => "1.0", "min_points" => 54 }]
       }
       reordered = {
-        "bands" => [{ "max_points" => 60, "grade" => "1.0",
+        "bands" => [{ "grade" => "1.0",
                       "min_points" => 54 }]
       }
       s1 = FactoryBot.create(:assessment_grade_scheme, config: config)
@@ -67,7 +66,7 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
 
       new_config = scheme.config.merge(
         "bands" => scheme.config["bands"] + [
-          { "min_points" => 61, "max_points" => 70, "grade" => "1.0" }
+          { "min_points" => 61, "grade" => "1.0" }
         ]
       )
       scheme.update!(config: new_config)
@@ -138,7 +137,7 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
       it "is invalid when bands mix min_points and min_pct" do
         mixed_config = {
           "bands" => [
-            { "min_points" => 54, "max_points" => 60, "grade" => "1.0" },
+            { "min_points" => 54, "grade" => "1.0" },
             { "min_pct" => 80, "max_pct" => 89.99, "grade" => "1.3" }
           ]
         }
@@ -150,8 +149,8 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
       it "is invalid when a band is missing a grade" do
         config = {
           "bands" => [
-            { "min_points" => 54, "max_points" => 60, "grade" => "1.0" },
-            { "min_points" => 0, "max_points" => 53 }
+            { "min_points" => 54, "grade" => "1.0" },
+            { "min_points" => 0 }
           ]
         }
         scheme = FactoryBot.build(:assessment_grade_scheme, config: config)

--- a/spec/models/assessment/grade_scheme_spec.rb
+++ b/spec/models/assessment/grade_scheme_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
     end
 
     describe "uniqueness of active scheme per assessment" do
-      let(:assessment) { FactoryBot.create(:assessment) }
+      let(:assessment) { FactoryBot.create(:assessment, :for_exam) }
 
       it "allows only one active scheme per assessment" do
         FactoryBot.create(:assessment_grade_scheme, assessment: assessment,
@@ -191,11 +191,36 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
       end
 
       it "allows active schemes on different assessments" do
-        other = FactoryBot.create(:assessment)
+        other = FactoryBot.create(:assessment, :for_exam)
         FactoryBot.create(:assessment_grade_scheme, assessment: assessment,
                                                     active: true)
         scheme = FactoryBot.build(:assessment_grade_scheme,
                                   assessment: other, active: true)
+        expect(scheme).to be_valid
+      end
+    end
+
+    describe "assessable_must_be_pointable_and_gradable" do
+      it "is invalid when assessable is only Pointable (Assignment)" do
+        assignment_assessment = FactoryBot.create(:assessment)
+        scheme = FactoryBot.build(:assessment_grade_scheme,
+                                  assessment: assignment_assessment)
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:assessment]).to be_present
+      end
+
+      it "is invalid when assessable is only Gradable (Talk)" do
+        talk_assessment = FactoryBot.create(:assessment, :gradable)
+        scheme = FactoryBot.build(:assessment_grade_scheme,
+                                  assessment: talk_assessment)
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:assessment]).to be_present
+      end
+
+      it "is valid when assessable is both Pointable and Gradable (Exam)" do
+        exam_assessment = FactoryBot.create(:assessment, :for_exam)
+        scheme = FactoryBot.build(:assessment_grade_scheme,
+                                  assessment: exam_assessment)
         expect(scheme).to be_valid
       end
     end

--- a/spec/models/assessment/grade_scheme_spec.rb
+++ b/spec/models/assessment/grade_scheme_spec.rb
@@ -47,10 +47,18 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
       expect(scheme.version_hash).to be_present
     end
 
-    it "matches MD5 of config JSON" do
-      scheme = FactoryBot.create(:assessment_grade_scheme)
-      expected = Digest::MD5.hexdigest(scheme.config.to_json)
-      expect(scheme.version_hash).to eq(expected)
+    it "produces the same hash regardless of key order" do
+      config = {
+        "bands" => [{ "grade" => "1.0", "min_points" => 54,
+                      "max_points" => 60 }]
+      }
+      reordered = {
+        "bands" => [{ "max_points" => 60, "grade" => "1.0",
+                      "min_points" => 54 }]
+      }
+      s1 = FactoryBot.create(:assessment_grade_scheme, config: config)
+      s2 = FactoryBot.create(:assessment_grade_scheme, config: reordered)
+      expect(s1.version_hash).to eq(s2.version_hash)
     end
 
     it "updates version_hash when config changes" do
@@ -76,6 +84,29 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
   end
 
   describe "validations" do
+    describe "immutability" do
+      it "prevents updating an applied scheme" do
+        scheme = FactoryBot.create(:assessment_grade_scheme, :applied)
+        expect do
+          scheme.update!(active: false)
+        end.to raise_error(ActiveRecord::RecordInvalid)
+        expect(scheme.errors[:base]).to be_present
+      end
+
+      it "allows updating a draft scheme" do
+        scheme = FactoryBot.create(:assessment_grade_scheme, :draft)
+        expect { scheme.update!(active: true) }.not_to raise_error
+      end
+
+      it "allows transitioning a draft to applied" do
+        scheme = FactoryBot.create(:assessment_grade_scheme, :draft)
+        user = FactoryBot.create(:confirmed_user)
+        expect do
+          scheme.update!(applied_at: Time.current, applied_by: user)
+        end.not_to raise_error
+      end
+    end
+
     describe "config presence" do
       it "is invalid without config" do
         scheme = FactoryBot.build(:assessment_grade_scheme, config: nil)
@@ -112,6 +143,18 @@ RSpec.describe(Assessment::GradeScheme, type: :model) do
           ]
         }
         scheme = FactoryBot.build(:assessment_grade_scheme, config: mixed_config)
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:config]).to be_present
+      end
+
+      it "is invalid when a band is missing a grade" do
+        config = {
+          "bands" => [
+            { "min_points" => 54, "max_points" => 60, "grade" => "1.0" },
+            { "min_points" => 0, "max_points" => 53 }
+          ]
+        }
+        scheme = FactoryBot.build(:assessment_grade_scheme, config: config)
         expect(scheme).not_to be_valid
         expect(scheme.errors[:config]).to be_present
       end

--- a/spec/models/assessment/grade_scheme_spec.rb
+++ b/spec/models/assessment/grade_scheme_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe(Assessment::GradeScheme, type: :model) do
+  describe "factory" do
+    it "creates a valid default scheme" do
+      scheme = FactoryBot.create(:assessment_grade_scheme)
+      expect(scheme).to be_valid
+      expect(scheme.kind).to eq("banded")
+      expect(scheme.active).to be(true)
+      expect(scheme.applied?).to be(false)
+    end
+
+    it "creates a percentage-based scheme" do
+      scheme = FactoryBot.create(:assessment_grade_scheme, :percentage)
+      expect(scheme).to be_valid
+      expect(scheme.config["bands"].first).to have_key("min_pct")
+    end
+
+    it "creates a draft scheme" do
+      scheme = FactoryBot.create(:assessment_grade_scheme, :draft)
+      expect(scheme.active).to be(false)
+    end
+
+    it "creates an applied scheme" do
+      scheme = FactoryBot.create(:assessment_grade_scheme, :applied)
+      expect(scheme.applied?).to be(true)
+      expect(scheme.applied_by).to be_present
+    end
+  end
+
+  describe "#applied?" do
+    it "returns false when applied_at is nil" do
+      scheme = FactoryBot.build(:assessment_grade_scheme)
+      expect(scheme.applied?).to be(false)
+    end
+
+    it "returns true when applied_at is set" do
+      scheme = FactoryBot.build(:assessment_grade_scheme,
+                                applied_at: Time.current)
+      expect(scheme.applied?).to be(true)
+    end
+  end
+
+  describe "#compute_hash" do
+    it "sets version_hash on save" do
+      scheme = FactoryBot.create(:assessment_grade_scheme)
+      expect(scheme.version_hash).to be_present
+    end
+
+    it "matches MD5 of config JSON" do
+      scheme = FactoryBot.create(:assessment_grade_scheme)
+      expected = Digest::MD5.hexdigest(scheme.config.to_json)
+      expect(scheme.version_hash).to eq(expected)
+    end
+
+    it "updates version_hash when config changes" do
+      scheme = FactoryBot.create(:assessment_grade_scheme)
+      old_hash = scheme.version_hash
+
+      new_config = scheme.config.merge(
+        "bands" => scheme.config["bands"] + [
+          { "min_points" => 61, "max_points" => 70, "grade" => "1.0" }
+        ]
+      )
+      scheme.update!(config: new_config)
+
+      expect(scheme.version_hash).not_to eq(old_hash)
+    end
+
+    it "does not change version_hash when unrelated fields change" do
+      scheme = FactoryBot.create(:assessment_grade_scheme)
+      old_hash = scheme.version_hash
+      scheme.update!(applied_at: Time.current)
+      expect(scheme.version_hash).to eq(old_hash)
+    end
+  end
+
+  describe "validations" do
+    describe "config presence" do
+      it "is invalid without config" do
+        scheme = FactoryBot.build(:assessment_grade_scheme, config: nil)
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:config]).to be_present
+      end
+    end
+
+    describe "config_matches_kind" do
+      it "is invalid when config has no bands key" do
+        scheme = FactoryBot.build(:assessment_grade_scheme, config: {})
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:config]).to be_present
+      end
+
+      it "is invalid when bands is empty" do
+        scheme = FactoryBot.build(:assessment_grade_scheme,
+                                  config: { "bands" => [] })
+        expect(scheme).not_to be_valid
+      end
+
+      it "is invalid when bands have no recognized keys" do
+        scheme = FactoryBot.build(:assessment_grade_scheme,
+                                  config: { "bands" => [{ "grade" => "1.0" }] })
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:config]).to be_present
+      end
+
+      it "is invalid when bands mix min_points and min_pct" do
+        mixed_config = {
+          "bands" => [
+            { "min_points" => 54, "max_points" => 60, "grade" => "1.0" },
+            { "min_pct" => 80, "max_pct" => 89.99, "grade" => "1.3" }
+          ]
+        }
+        scheme = FactoryBot.build(:assessment_grade_scheme, config: mixed_config)
+        expect(scheme).not_to be_valid
+        expect(scheme.errors[:config]).to be_present
+      end
+
+      it "is valid with absolute points bands" do
+        expect(FactoryBot.build(:assessment_grade_scheme)).to be_valid
+      end
+
+      it "is valid with percentage bands" do
+        expect(
+          FactoryBot.build(:assessment_grade_scheme, :percentage)
+        ).to be_valid
+      end
+    end
+
+    describe "uniqueness of active scheme per assessment" do
+      let(:assessment) { FactoryBot.create(:assessment) }
+
+      it "allows only one active scheme per assessment" do
+        FactoryBot.create(:assessment_grade_scheme, assessment: assessment,
+                                                    active: true)
+        duplicate = FactoryBot.build(:assessment_grade_scheme,
+                                     assessment: assessment, active: true)
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:assessment_id]).to be_present
+      end
+
+      it "allows multiple inactive schemes on the same assessment" do
+        FactoryBot.create(:assessment_grade_scheme, assessment: assessment,
+                                                    active: false)
+        second = FactoryBot.build(:assessment_grade_scheme,
+                                  assessment: assessment, active: false)
+        expect(second).to be_valid
+      end
+
+      it "allows active schemes on different assessments" do
+        other = FactoryBot.create(:assessment)
+        FactoryBot.create(:assessment_grade_scheme, assessment: assessment,
+                                                    active: true)
+        scheme = FactoryBot.build(:assessment_grade_scheme,
+                                  assessment: other, active: true)
+        expect(scheme).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR creates creates the `assessment_grade_schemes` table and `Assessment::GradeScheme` model.

A grade scheme holds a set of grade bands — score ranges mapped to a grade, e.g. `{ min_points: 54, max_points: 60, grade: "1.0" }`. Both absolute points and percentage formats are supported. Bands are stored as JSONB.
 The `version_hash` (MD5 of key-sorted config) enables idempotent application in PR-9.2: re-applying an unchanged scheme is a no-op. Applied schemes are immutable. 

The PR includes a factory and specs.