### PR TITLE
Muesli: PR 10.2 - Performance services

### DIFF
--- a/app/models/student_performance/certification.rb
+++ b/app/models/student_performance/certification.rb
@@ -13,15 +13,16 @@ module StudentPerformance
     validates :certified_at, presence: true, unless: :pending?
 
     scope :stale, lambda {
+      record_table = Record.arel_table
+      cert_table = arel_table
+
       joins(
-        "INNER JOIN student_performance_records ON " \
-        "student_performance_records.lecture_id = " \
-        "student_performance_certifications.lecture_id " \
-        "AND student_performance_records.user_id = " \
-        "student_performance_certifications.user_id"
+        cert_table.join(record_table).on(
+          record_table[:lecture_id].eq(cert_table[:lecture_id])
+            .and(record_table[:user_id].eq(cert_table[:user_id]))
+        ).join_sources
       ).where(
-        "student_performance_records.computed_at > " \
-        "student_performance_certifications.certified_at"
+        record_table[:computed_at].gt(cert_table[:certified_at])
       )
     }
 

--- a/app/models/student_performance/certification.rb
+++ b/app/models/student_performance/certification.rb
@@ -12,6 +12,19 @@ module StudentPerformance
     validates :certified_by, presence: true, unless: :pending?
     validates :certified_at, presence: true, unless: :pending?
 
+    scope :stale, lambda {
+      joins(
+        "INNER JOIN student_performance_records ON " \
+        "student_performance_records.lecture_id = " \
+        "student_performance_certifications.lecture_id " \
+        "AND student_performance_records.user_id = " \
+        "student_performance_certifications.user_id"
+      ).where(
+        "student_performance_records.computed_at > " \
+        "student_performance_certifications.certified_at"
+      )
+    }
+
     def self.passed?(lecture:, user:)
       find_by(lecture: lecture, user: user)&.passed? || false
     end

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -1,5 +1,6 @@
 module StudentPerformance
-  # Missing top-level docstring, please formulate one yourself 😁
+  # Computes the performance metrics for students in a lecture and
+  # upserts the results into the database.
   class ComputationService
     attr_reader :lecture
 

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -1,6 +1,9 @@
 module StudentPerformance
+  # Missing top-level docstring, please formulate one yourself 😁
   class ComputationService
     attr_reader :lecture
+
+    UPSERT_BATCH_SIZE = 100
 
     def initialize(lecture:)
       @lecture = lecture
@@ -10,19 +13,26 @@ module StudentPerformance
       stats = aggregate_points(user)
       met_ids = achievement_ids_met_by(user)
 
-      upsert_record(
-        user: user,
-        points_total: stats[:points_total],
-        points_max: stats[:points_max],
-        achievements_met_ids: met_ids,
-        counts: stats[:counts]
-      )
+      upsert_records([build_row(user.id, stats, met_ids)])
     end
 
     def compute_and_upsert_all_records!
-      lecture.members.find_each do |user|
-        compute_and_upsert_record_for(user)
+      user_ids = lecture.members.pluck(:id)
+      return if user_ids.empty?
+
+      participations_by_user = prefetch_participations(user_ids)
+      points_by_participation = prefetch_task_points(
+        participations_by_user.values.flatten
+      )
+
+      rows = user_ids.map do |uid|
+        parts = participations_by_user.fetch(uid, [])
+        stats = aggregate_from_prefetched(parts, points_by_participation)
+        met_ids = achievement_ids_met_by_id(uid)
+        build_row(uid, stats, met_ids)
       end
+
+      rows.each_slice(UPSERT_BATCH_SIZE) { |batch| upsert_records(batch) }
     end
 
     private
@@ -34,32 +44,46 @@ module StudentPerformance
                          .includes(:tasks)
       end
 
-      def aggregate_points(user)
-        participations = Assessment::Participation
-                         .where(assessment_id: assessments.select(:id), user_id: user.id)
-                         .select(:id, :assessment_id, :status, :submitted_at)
+      def prefetch_participations(user_ids)
+        Assessment::Participation
+          .where(assessment_id: assessments.select(:id),
+                 user_id: user_ids)
+          .select(:id, :assessment_id, :status, :submitted_at, :user_id)
+          .group_by(&:user_id)
+      end
 
+      def prefetch_task_points(participations)
+        reviewed_ids = participations
+                       .select { |p| p.status == "reviewed" }
+                       .map(&:id)
+        return {} if reviewed_ids.empty?
+
+        Assessment::TaskPoint
+          .where(assessment_participation_id: reviewed_ids)
+          .group(:assessment_participation_id)
+          .sum(:points)
+      end
+
+      def aggregate_from_prefetched(participations, points_lookup)
         status_map = participations.group_by(&:status)
         reviewed = status_map.fetch("reviewed", [])
         exempt = status_map.fetch("exempt", [])
         pending_all = status_map.fetch("pending", [])
 
-        reviewed_ids = reviewed.map(&:id)
-        exempt_assessment_ids = exempt.to_set(&:assessment_id)
-
-        points_total = if reviewed_ids.any?
-          Assessment::TaskPoint
-            .where(assessment_participation_id: reviewed_ids)
-            .sum(:points)
-        else
-          BigDecimal("0")
+        points_total = reviewed.sum do |p|
+          points_lookup.fetch(p.id, BigDecimal("0"))
         end
 
-        non_exempt = assessments.reject { |a| exempt_assessment_ids.include?(a.id) }
+        exempt_assessment_ids = exempt.to_set(&:assessment_id)
+        non_exempt = assessments.reject do |a|
+          exempt_assessment_ids.include?(a.id)
+        end
         points_max = non_exempt.sum { |a| effective_max(a) }
 
         participated_ids = participations.to_set(&:assessment_id)
-        no_participation = assessments.count { |a| participated_ids.exclude?(a.id) }
+        no_participation = assessments.count do |a|
+          participated_ids.exclude?(a.id)
+        end
 
         pending_grading = pending_all.count { |p| p.submitted_at.present? }
         not_submitted = pending_all.count { |p| p.submitted_at.nil? } +
@@ -76,7 +100,23 @@ module StudentPerformance
         { points_total: points_total, points_max: points_max, counts: counts }
       end
 
+      def aggregate_points(user)
+        participations = Assessment::Participation
+                         .where(assessment_id: assessments.select(:id),
+                                user_id: user.id)
+                         .select(:id, :assessment_id, :status, :submitted_at,
+                                 :user_id)
+                         .to_a
+
+        points_lookup = prefetch_task_points(participations)
+        aggregate_from_prefetched(participations, points_lookup)
+      end
+
       def achievement_ids_met_by(_user)
+        []
+      end
+
+      def achievement_ids_met_by_id(_user_id)
         []
       end
 
@@ -90,32 +130,35 @@ module StudentPerformance
         (points_total / points_max * 100).round(2)
       end
 
-      def upsert_record(user:, points_total:, points_max:, achievements_met_ids:, counts:)
+      def build_row(user_id, stats, achievements_met_ids)
         now = Time.current
-        percentage = compute_percentage(points_total, points_max)
-
-        # All values are computed by this service, not user input.
-        # Uniqueness is enforced by the DB index on [lecture_id, user_id]
-        # rubocop:disable Rails/SkipsModelValidations
-        Record.upsert(
-          {
-            lecture_id: lecture.id,
-            user_id: user.id,
-            points_total_materialized: points_total,
-            points_max_materialized: points_max,
-            percentage_materialized: percentage,
-            achievements_met_ids: achievements_met_ids,
-            assessments_total_count: counts[:total],
-            assessments_reviewed_count: counts[:reviewed],
-            assessments_pending_grading_count: counts[:pending_grading],
-            assessments_not_submitted_count: counts[:not_submitted],
-            assessments_exempt_count: counts[:exempt],
-            computed_at: now,
-            updated_at: now
-          },
-          unique_by: [:lecture_id, :user_id]
+        percentage = compute_percentage(
+          stats[:points_total], stats[:points_max]
         )
-        # rubocop:enable Rails/SkipsModelValidations
+
+        {
+          lecture_id: lecture.id,
+          user_id: user_id,
+          points_total_materialized: stats[:points_total],
+          points_max_materialized: stats[:points_max],
+          percentage_materialized: percentage,
+          achievements_met_ids: achievements_met_ids,
+          assessments_total_count: stats[:counts][:total],
+          assessments_reviewed_count: stats[:counts][:reviewed],
+          assessments_pending_grading_count:
+            stats[:counts][:pending_grading],
+          assessments_not_submitted_count:
+            stats[:counts][:not_submitted],
+          assessments_exempt_count: stats[:counts][:exempt],
+          computed_at: now,
+          updated_at: now
+        }
       end
+
+      # rubocop:disable Rails/SkipsModelValidations
+      def upsert_records(rows)
+        Record.upsert_all(rows, unique_by: [:lecture_id, :user_id])
+      end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -55,7 +55,7 @@ module StudentPerformance
         points_max = non_exempt.sum(&:effective_total_points)
 
         participated_ids = participations.to_set(&:assessment_id)
-        no_participation = assessments.count { |a| !participated_ids.include?(a.id) }
+        no_participation = assessments.count { |a| participated_ids.exclude?(a.id) }
 
         counts = {
           total: assessments.size,

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -1,0 +1,82 @@
+module StudentPerformance
+  class ComputationService
+    attr_reader :lecture
+
+    def initialize(lecture:)
+      @lecture = lecture
+    end
+
+    def compute_and_upsert_record_for(user)
+      totals = aggregate_points(user)
+      met_ids = achievement_ids_met_by(user)
+
+      upsert_record(
+        user: user,
+        points_total: totals[:points_total],
+        points_max: totals[:points_max],
+        achievements_met_ids: met_ids
+      )
+    end
+
+    def compute_and_upsert_all_records!
+      lecture.members.find_each do |user|
+        compute_and_upsert_record_for(user)
+      end
+    end
+
+    private
+
+      def assessments
+        @assessments ||= Assessment::Assessment.where(lecture_id: lecture.id)
+      end
+
+      def aggregate_points(user)
+        participation_ids = Assessment::Participation
+                            .where(assessment_id: assessments.select(:id), user_id: user.id)
+                            .pluck(:id)
+
+        points_total = if participation_ids.any?
+          Assessment::TaskPoint
+            .where(assessment_participation_id: participation_ids)
+            .sum(:points)
+        else
+          BigDecimal("0")
+        end
+
+        points_max = assessments.sum do |assessment|
+          assessment.effective_total_points
+        end
+
+        { points_total: points_total, points_max: points_max }
+      end
+
+      def achievement_ids_met_by(_user)
+        []
+      end
+
+      def compute_percentage(points_total, points_max)
+        return nil if points_max.nil? || points_max.zero?
+
+        (points_total / points_max * 100).round(2)
+      end
+
+      def upsert_record(user:, points_total:, points_max:, achievements_met_ids:)
+        now = Time.current
+        percentage = compute_percentage(points_total, points_max)
+
+        Record.upsert(
+          {
+            lecture_id: lecture.id,
+            user_id: user.id,
+            points_total_materialized: points_total,
+            points_max_materialized: points_max,
+            percentage_materialized: percentage,
+            achievements_met_ids: achievements_met_ids,
+            computed_at: now,
+            updated_at: now
+          },
+          unique_by: [:lecture_id, :user_id]
+        )
+      end
+  end
+end

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -43,9 +43,7 @@ module StudentPerformance
           BigDecimal("0")
         end
 
-        points_max = assessments.sum do |assessment|
-          assessment.effective_total_points
-        end
+        points_max = assessments.sum(&:effective_total_points)
 
         { points_total: points_total, points_max: points_max }
       end
@@ -64,6 +62,9 @@ module StudentPerformance
         now = Time.current
         percentage = compute_percentage(points_total, points_max)
 
+        # All values are computed by this service, not user input.
+        # Uniqueness is enforced by the DB index on [lecture_id, user_id]
+        # rubocop:disable Rails/SkipsModelValidations
         Record.upsert(
           {
             lecture_id: lecture.id,
@@ -77,6 +78,7 @@ module StudentPerformance
           },
           unique_by: [:lecture_id, :user_id]
         )
+        # rubocop:enable Rails/SkipsModelValidations
       end
   end
 end

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -28,7 +28,9 @@ module StudentPerformance
     private
 
       def assessments
-        @assessments ||= Assessment::Assessment.where(lecture_id: lecture.id)
+        @assessments ||= Assessment::Assessment
+                         .where(lecture_id: lecture.id)
+                         .includes(:tasks)
       end
 
       def aggregate_points(user)
@@ -52,7 +54,7 @@ module StudentPerformance
         end
 
         non_exempt = assessments.reject { |a| exempt_assessment_ids.include?(a.id) }
-        points_max = non_exempt.sum(&:effective_total_points)
+        points_max = non_exempt.sum { |a| effective_max(a) }
 
         participated_ids = participations.to_set(&:assessment_id)
         no_participation = assessments.count { |a| participated_ids.exclude?(a.id) }
@@ -69,6 +71,10 @@ module StudentPerformance
 
       def achievement_ids_met_by(_user)
         []
+      end
+
+      def effective_max(assessment)
+        assessment.total_points || assessment.tasks.sum(&:max_points)
       end
 
       def compute_percentage(points_total, points_max)

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -29,18 +29,20 @@ module StudentPerformance
 
       def assessments
         @assessments ||= Assessment::Assessment
-                         .where(lecture_id: lecture.id)
+                         .where(lecture_id: lecture.id,
+                                assessable_type: "Assignment")
                          .includes(:tasks)
       end
 
       def aggregate_points(user)
         participations = Assessment::Participation
                          .where(assessment_id: assessments.select(:id), user_id: user.id)
-                         .select(:id, :assessment_id, :status)
+                         .select(:id, :assessment_id, :status, :submitted_at)
 
         status_map = participations.group_by(&:status)
         reviewed = status_map.fetch("reviewed", [])
         exempt = status_map.fetch("exempt", [])
+        pending_all = status_map.fetch("pending", [])
 
         reviewed_ids = reviewed.map(&:id)
         exempt_assessment_ids = exempt.to_set(&:assessment_id)
@@ -59,10 +61,15 @@ module StudentPerformance
         participated_ids = participations.to_set(&:assessment_id)
         no_participation = assessments.count { |a| participated_ids.exclude?(a.id) }
 
+        pending_grading = pending_all.count { |p| p.submitted_at.present? }
+        not_submitted = pending_all.count { |p| p.submitted_at.nil? } +
+                        no_participation
+
         counts = {
           total: assessments.size,
           reviewed: reviewed.size,
-          pending: status_map.fetch("pending", []).size + no_participation,
+          pending_grading: pending_grading,
+          not_submitted: not_submitted,
           exempt: exempt.size
         }
 
@@ -100,7 +107,8 @@ module StudentPerformance
             achievements_met_ids: achievements_met_ids,
             assessments_total_count: counts[:total],
             assessments_reviewed_count: counts[:reviewed],
-            assessments_pending_count: counts[:pending],
+            assessments_pending_grading_count: counts[:pending_grading],
+            assessments_not_submitted_count: counts[:not_submitted],
             assessments_exempt_count: counts[:exempt],
             computed_at: now,
             updated_at: now

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -7,14 +7,15 @@ module StudentPerformance
     end
 
     def compute_and_upsert_record_for(user)
-      totals = aggregate_points(user)
+      stats = aggregate_points(user)
       met_ids = achievement_ids_met_by(user)
 
       upsert_record(
         user: user,
-        points_total: totals[:points_total],
-        points_max: totals[:points_max],
-        achievements_met_ids: met_ids
+        points_total: stats[:points_total],
+        points_max: stats[:points_max],
+        achievements_met_ids: met_ids,
+        counts: stats[:counts]
       )
     end
 
@@ -31,21 +32,36 @@ module StudentPerformance
       end
 
       def aggregate_points(user)
-        participation_ids = Assessment::Participation
-                            .where(assessment_id: assessments.select(:id), user_id: user.id)
-                            .pluck(:id)
+        participations = Assessment::Participation
+                         .where(assessment_id: assessments.select(:id), user_id: user.id)
+                         .select(:id, :assessment_id, :status)
 
-        points_total = if participation_ids.any?
+        status_map = participations.group_by(&:status)
+        reviewed = status_map.fetch("reviewed", [])
+        exempt = status_map.fetch("exempt", [])
+
+        reviewed_ids = reviewed.map(&:id)
+        exempt_assessment_ids = exempt.map(&:assessment_id).to_set
+
+        points_total = if reviewed_ids.any?
           Assessment::TaskPoint
-            .where(assessment_participation_id: participation_ids)
+            .where(assessment_participation_id: reviewed_ids)
             .sum(:points)
         else
           BigDecimal("0")
         end
 
-        points_max = assessments.sum(&:effective_total_points)
+        non_exempt = assessments.reject { |a| exempt_assessment_ids.include?(a.id) }
+        points_max = non_exempt.sum(&:effective_total_points)
 
-        { points_total: points_total, points_max: points_max }
+        counts = {
+          total: assessments.size,
+          reviewed: reviewed.size,
+          pending: status_map.fetch("pending", []).size,
+          exempt: exempt.size
+        }
+
+        { points_total: points_total, points_max: points_max, counts: counts }
       end
 
       def achievement_ids_met_by(_user)
@@ -58,7 +74,7 @@ module StudentPerformance
         (points_total / points_max * 100).round(2)
       end
 
-      def upsert_record(user:, points_total:, points_max:, achievements_met_ids:)
+      def upsert_record(user:, points_total:, points_max:, achievements_met_ids:, counts:)
         now = Time.current
         percentage = compute_percentage(points_total, points_max)
 
@@ -73,6 +89,10 @@ module StudentPerformance
             points_max_materialized: points_max,
             percentage_materialized: percentage,
             achievements_met_ids: achievements_met_ids,
+            assessments_total_count: counts[:total],
+            assessments_reviewed_count: counts[:reviewed],
+            assessments_pending_count: counts[:pending],
+            assessments_exempt_count: counts[:exempt],
             computed_at: now,
             updated_at: now
           },

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -41,7 +41,7 @@ module StudentPerformance
         exempt = status_map.fetch("exempt", [])
 
         reviewed_ids = reviewed.map(&:id)
-        exempt_assessment_ids = exempt.map(&:assessment_id).to_set
+        exempt_assessment_ids = exempt.to_set(&:assessment_id)
 
         points_total = if reviewed_ids.any?
           Assessment::TaskPoint

--- a/app/models/student_performance/computation_service.rb
+++ b/app/models/student_performance/computation_service.rb
@@ -54,10 +54,13 @@ module StudentPerformance
         non_exempt = assessments.reject { |a| exempt_assessment_ids.include?(a.id) }
         points_max = non_exempt.sum(&:effective_total_points)
 
+        participated_ids = participations.to_set(&:assessment_id)
+        no_participation = assessments.count { |a| !participated_ids.include?(a.id) }
+
         counts = {
           total: assessments.size,
           reviewed: reviewed.size,
-          pending: status_map.fetch("pending", []).size,
+          pending: status_map.fetch("pending", []).size + no_participation,
           exempt: exempt.size
         }
 

--- a/app/models/student_performance/evaluator.rb
+++ b/app/models/student_performance/evaluator.rb
@@ -50,7 +50,7 @@ module StudentPerformance
       def achievements_met?(record)
         return true if required_achievement_ids.empty?
 
-        have = Array(record.achievements_met_ids).map(&:to_i).to_set
+        have = Array(record.achievements_met_ids).to_set(&:to_i)
         need = required_achievement_ids.to_set
         have >= need
       end

--- a/app/models/student_performance/evaluator.rb
+++ b/app/models/student_performance/evaluator.rb
@@ -1,0 +1,66 @@
+module StudentPerformance
+  class Evaluator
+    Result = Struct.new(:proposed_status, :details, keyword_init: true)
+
+    attr_reader :rule
+
+    def initialize(rule)
+      @rule = rule
+    end
+
+    def evaluate(record)
+      return Result.new(proposed_status: :failed, details: {}) unless record
+
+      meets_points = points_met?(record)
+      meets_achievements = achievements_met?(record)
+      proposed = meets_points && meets_achievements ? :passed : :failed
+
+      Result.new(
+        proposed_status: proposed,
+        details: {
+          meets_points: meets_points,
+          meets_achievements: meets_achievements,
+          points_total: record.points_total_materialized,
+          points_max: record.points_max_materialized,
+          percentage: record.percentage_materialized,
+          required_points: required_points_threshold,
+          required_percentage: rule.min_percentage,
+          achievement_ids_met: record.achievements_met_ids,
+          achievement_ids_required: required_achievement_ids
+        }
+      )
+    end
+
+    def bulk_evaluate(records)
+      records.index_with { |record| evaluate(record) }
+    end
+
+    private
+
+      def points_met?(record)
+        if rule.min_points_absolute.present?
+          (record.points_total_materialized || 0) >= rule.min_points_absolute
+        elsif rule.min_percentage.present?
+          (record.percentage_materialized || 0) >= rule.min_percentage
+        else
+          true
+        end
+      end
+
+      def achievements_met?(record)
+        return true if required_achievement_ids.empty?
+
+        have = Array(record.achievements_met_ids).map(&:to_i).to_set
+        need = required_achievement_ids.to_set
+        have >= need
+      end
+
+      def required_achievement_ids
+        @required_achievement_ids ||= rule.required_achievements.pluck(:id)
+      end
+
+      def required_points_threshold
+        rule.min_points_absolute
+      end
+  end
+end

--- a/app/workers/certification_stale_check_job.rb
+++ b/app/workers/certification_stale_check_job.rb
@@ -1,0 +1,25 @@
+class CertificationStaleCheckJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: 1
+
+  def perform(lecture_id)
+    lecture = Lecture.find(lecture_id)
+
+    StudentPerformance::ComputationService
+      .new(lecture: lecture)
+      .compute_and_upsert_all_records!
+
+    stale = StudentPerformance::Certification
+            .where(lecture: lecture)
+            .stale
+
+    return if stale.none?
+
+    Rails.logger.info(
+      "[CertificationStaleCheck] lecture_id=#{lecture_id} " \
+      "stale_count=#{stale.count} " \
+      "user_ids=#{stale.pluck(:user_id).join(",")}"
+    )
+  end
+end

--- a/app/workers/performance_record_update_job.rb
+++ b/app/workers/performance_record_update_job.rb
@@ -1,0 +1,17 @@
+class PerformanceRecordUpdateJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: 3
+
+  def perform(lecture_id, user_id = nil)
+    lecture = Lecture.find(lecture_id)
+    service = StudentPerformance::ComputationService.new(lecture: lecture)
+
+    if user_id
+      user = User.find(user_id)
+      service.compute_and_upsert_record_for(user)
+    else
+      service.compute_and_upsert_all_records!
+    end
+  end
+end

--- a/db/migrate/20260226000001_add_assessment_counts_to_performance_records.rb
+++ b/db/migrate/20260226000001_add_assessment_counts_to_performance_records.rb
@@ -1,4 +1,4 @@
-class AddAssessmentCountsToPerformanceRecords < ActiveRecord::Migration[7.2]
+class AddAssessmentCountsToPerformanceRecords < ActiveRecord::Migration[8.0]
   def change
     change_table :student_performance_records, bulk: true do |t|
       t.integer :assessments_total_count, default: 0, null: false

--- a/db/migrate/20260226000001_add_assessment_counts_to_performance_records.rb
+++ b/db/migrate/20260226000001_add_assessment_counts_to_performance_records.rb
@@ -3,7 +3,8 @@ class AddAssessmentCountsToPerformanceRecords < ActiveRecord::Migration[8.0]
     change_table :student_performance_records, bulk: true do |t|
       t.integer :assessments_total_count, default: 0, null: false
       t.integer :assessments_reviewed_count, default: 0, null: false
-      t.integer :assessments_pending_count, default: 0, null: false
+      t.integer :assessments_pending_grading_count, default: 0, null: false
+      t.integer :assessments_not_submitted_count, default: 0, null: false
       t.integer :assessments_exempt_count, default: 0, null: false
     end
   end

--- a/db/migrate/20260226000001_add_assessment_counts_to_performance_records.rb
+++ b/db/migrate/20260226000001_add_assessment_counts_to_performance_records.rb
@@ -1,0 +1,10 @@
+class AddAssessmentCountsToPerformanceRecords < ActiveRecord::Migration[7.2]
+  def change
+    change_table :student_performance_records, bulk: true do |t|
+      t.integer :assessments_total_count, default: 0, null: false
+      t.integer :assessments_reviewed_count, default: 0, null: false
+      t.integer :assessments_pending_count, default: 0, null: false
+      t.integer :assessments_exempt_count, default: 0, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -841,7 +841,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_26_000001) do
     t.datetime "updated_at", null: false
     t.integer "assessments_total_count", default: 0, null: false
     t.integer "assessments_reviewed_count", default: 0, null: false
-    t.integer "assessments_pending_count", default: 0, null: false
+    t.integer "assessments_pending_grading_count", default: 0, null: false
+    t.integer "assessments_not_submitted_count", default: 0, null: false
     t.integer "assessments_exempt_count", default: 0, null: false
     t.index ["lecture_id", "user_id"], name: "index_performance_records_on_lecture_and_user", unique: true
     t.index ["user_id"], name: "index_student_performance_records_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_26_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_26_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -839,6 +839,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_26_000000) do
     t.datetime "computed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "assessments_total_count", default: 0, null: false
+    t.integer "assessments_reviewed_count", default: 0, null: false
+    t.integer "assessments_pending_count", default: 0, null: false
+    t.integer "assessments_exempt_count", default: 0, null: false
     t.index ["lecture_id", "user_id"], name: "index_performance_records_on_lecture_and_user", unique: true
     t.index ["user_id"], name: "index_student_performance_records_on_user_id"
   end

--- a/spec/factories/student_performance_records.rb
+++ b/spec/factories/student_performance_records.rb
@@ -9,7 +9,8 @@ FactoryBot.define do
     achievements_met_ids { [] }
     assessments_total_count { 0 }
     assessments_reviewed_count { 0 }
-    assessments_pending_count { 0 }
+    assessments_pending_grading_count { 0 }
+    assessments_not_submitted_count { 0 }
     assessments_exempt_count { 0 }
     computed_at { Time.current }
   end

--- a/spec/factories/student_performance_records.rb
+++ b/spec/factories/student_performance_records.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     points_max_materialized { 100 }
     percentage_materialized { 0 }
     achievements_met_ids { [] }
+    assessments_total_count { 0 }
+    assessments_reviewed_count { 0 }
+    assessments_pending_count { 0 }
+    assessments_exempt_count { 0 }
     computed_at { Time.current }
   end
 end

--- a/spec/models/student_performance/certification_spec.rb
+++ b/spec/models/student_performance/certification_spec.rb
@@ -143,4 +143,44 @@ RSpec.describe(StudentPerformance::Certification, type: :model) do
         .to be(false)
     end
   end
+
+  describe ".stale" do
+    let(:lecture) { FactoryBot.create(:lecture) }
+    let(:user) { FactoryBot.create(:confirmed_user) }
+    let(:certifier) { FactoryBot.create(:confirmed_user) }
+
+    it "includes certifications where record was computed after certification" do
+      FactoryBot.create(:student_performance_record,
+                        lecture: lecture, user: user,
+                        computed_at: 1.hour.ago)
+      cert = FactoryBot.create(:student_performance_certification, :passed,
+                               lecture: lecture, user: user,
+                               certified_by: certifier,
+                               certified_at: 2.hours.ago)
+
+      expect(described_class.stale).to include(cert)
+    end
+
+    it "excludes certifications where record was computed before certification" do
+      FactoryBot.create(:student_performance_record,
+                        lecture: lecture, user: user,
+                        computed_at: 2.hours.ago)
+      cert = FactoryBot.create(:student_performance_certification, :passed,
+                               lecture: lecture, user: user,
+                               certified_by: certifier,
+                               certified_at: 1.hour.ago)
+
+      expect(described_class.stale).not_to include(cert)
+    end
+
+    it "excludes pending certifications without certified_at" do
+      FactoryBot.create(:student_performance_record,
+                        lecture: lecture, user: user,
+                        computed_at: 1.hour.ago)
+      cert = FactoryBot.create(:student_performance_certification,
+                               lecture: lecture, user: user)
+
+      expect(described_class.stale).not_to include(cert)
+    end
+  end
 end

--- a/spec/models/student_performance/computation_service_spec.rb
+++ b/spec/models/student_performance/computation_service_spec.rb
@@ -311,6 +311,78 @@ RSpec.describe(StudentPerformance::ComputationService) do
         expect(record.assessments_exempt_count).to eq(1)
       end
     end
+
+    context "when assessment has no participation record" do
+      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+
+      let(:assessment1) do
+        create(:assessment, :with_points, assessable: assignment1,
+                                          lecture: lecture)
+      end
+
+      let(:assessment2) do
+        create(:assessment, :with_points, assessable: assignment2,
+                                          lecture: lecture)
+      end
+
+      before do
+        create(:assessment_task, assessment: assessment1, max_points: 10)
+        create(:assessment_task, assessment: assessment2, max_points: 20)
+
+        create(:assessment_participation, :reviewed,
+               assessment: assessment1, user: user)
+      end
+
+      it "counts the missing participation as pending" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.assessments_total_count).to eq(2)
+        expect(record.assessments_reviewed_count).to eq(1)
+        expect(record.assessments_pending_count).to eq(1)
+        expect(record.assessments_exempt_count).to eq(0)
+      end
+
+      it "still includes the assessment in points_max" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_max_materialized).to eq(30)
+      end
+    end
+
+    context "when participation is absent" do
+      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+
+      let(:assessment1) do
+        create(:assessment, :with_points, assessable: assignment1,
+                                          lecture: lecture)
+      end
+
+      let(:assessment2) do
+        create(:assessment, :with_points, assessable: assignment2,
+                                          lecture: lecture)
+      end
+
+      before do
+        create(:assessment_task, assessment: assessment1, max_points: 10)
+        create(:assessment_task, assessment: assessment2, max_points: 20)
+
+        create(:assessment_participation, :reviewed,
+               assessment: assessment1, user: user)
+        create(:assessment_participation, :absent,
+               assessment: assessment2, user: user)
+      end
+
+      it "does not count absent as pending" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.assessments_total_count).to eq(2)
+        expect(record.assessments_reviewed_count).to eq(1)
+        expect(record.assessments_pending_count).to eq(0)
+        expect(record.assessments_exempt_count).to eq(0)
+      end
+    end
   end
 
   describe "#compute_and_upsert_all_records!" do

--- a/spec/models/student_performance/computation_service_spec.rb
+++ b/spec/models/student_performance/computation_service_spec.rb
@@ -1,0 +1,228 @@
+require "rails_helper"
+
+RSpec.describe(StudentPerformance::ComputationService) do
+  let(:lecture) { create(:lecture, :released_for_all) }
+  let(:user) { create(:confirmed_user) }
+
+  before do
+    create(:lecture_membership, user: user, lecture: lecture)
+  end
+
+  describe "#compute_and_upsert_record_for" do
+    subject(:compute) { described_class.new(lecture: lecture).compute_and_upsert_record_for(user) }
+
+    context "when user has no assessment participations" do
+      it "creates a record with zero points" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_total_materialized).to eq(0)
+      end
+
+      it "sets points_max to zero when no assessments exist" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_max_materialized).to eq(0)
+      end
+
+      it "sets percentage to nil when points_max is zero" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.percentage_materialized).to be_nil
+      end
+
+      it "sets empty achievements_met_ids" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.achievements_met_ids).to eq([])
+      end
+    end
+
+    context "when user has participations with task points" do
+      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assessment) do
+        create(:assessment, :with_points, assessable: assignment,
+                                          lecture: lecture)
+      end
+
+      let!(:task1) { create(:assessment_task, assessment: assessment, max_points: 10) }
+      let!(:task2) { create(:assessment_task, assessment: assessment, max_points: 20) }
+
+      let!(:participation) do
+        create(:assessment_participation, assessment: assessment, user: user)
+      end
+
+      let!(:tp1) do
+        create(:assessment_task_point, task: task1,
+                                       assessment_participation: participation,
+                                       points: 8)
+      end
+
+      let!(:tp2) do
+        create(:assessment_task_point, task: task2,
+                                       assessment_participation: participation,
+                                       points: 15)
+      end
+
+      it "aggregates points_total from task points" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_total_materialized).to eq(23)
+      end
+
+      it "computes points_max from task max_points" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_max_materialized).to eq(30)
+      end
+
+      it "computes percentage correctly" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.percentage_materialized).to eq(76.67)
+      end
+
+      it "sets computed_at" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.computed_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context "with multiple assessments" do
+      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+
+      let(:assessment1) do
+        create(:assessment, :with_points, assessable: assignment1,
+                                          lecture: lecture)
+      end
+
+      let(:assessment2) do
+        create(:assessment, :with_points, assessable: assignment2,
+                                          lecture: lecture)
+      end
+
+      let!(:task_a) { create(:assessment_task, assessment: assessment1, max_points: 10) }
+      let!(:task_b) { create(:assessment_task, assessment: assessment2, max_points: 40) }
+
+      let!(:participation1) do
+        create(:assessment_participation, assessment: assessment1, user: user)
+      end
+
+      let!(:participation2) do
+        create(:assessment_participation, assessment: assessment2, user: user)
+      end
+
+      let!(:tp_a) do
+        create(:assessment_task_point, task: task_a,
+                                       assessment_participation: participation1,
+                                       points: 7)
+      end
+
+      let!(:tp_b) do
+        create(:assessment_task_point, task: task_b,
+                                       assessment_participation: participation2,
+                                       points: 30)
+      end
+
+      it "sums points across all assessments" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_total_materialized).to eq(37)
+        expect(record.points_max_materialized).to eq(50)
+        expect(record.percentage_materialized).to eq(74.0)
+      end
+    end
+
+    context "when called twice (upsert)" do
+      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assessment) do
+        create(:assessment, :with_points, assessable: assignment, lecture: lecture)
+      end
+
+      let!(:task1) { create(:assessment_task, assessment: assessment, max_points: 10) }
+      let!(:task2) { create(:assessment_task, assessment: assessment, max_points: 20) }
+
+      let!(:participation) do
+        create(:assessment_participation, assessment: assessment, user: user)
+      end
+
+      it "updates the existing record instead of creating a duplicate" do
+        create(:assessment_task_point, task: task1,
+                                       assessment_participation: participation,
+                                       points: 5)
+
+        described_class.new(lecture: lecture).compute_and_upsert_record_for(user)
+        expect(StudentPerformance::Record.where(lecture: lecture, user: user).count).to eq(1)
+
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_total_materialized).to eq(5)
+
+        create(:assessment_task_point, task: task2,
+                                       assessment_participation: participation,
+                                       points: 13)
+
+        described_class.new(lecture: lecture).compute_and_upsert_record_for(user)
+        expect(StudentPerformance::Record.where(lecture: lecture, user: user).count).to eq(1)
+
+        record.reload
+        expect(record.points_total_materialized).to eq(18)
+      end
+    end
+
+    context "when assessment has total_points override" do
+      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assessment) do
+        create(:assessment, :with_points, assessable: assignment,
+                                          lecture: lecture, total_points: 50)
+      end
+
+      let!(:task) { create(:assessment_task, assessment: assessment, max_points: 10) }
+
+      it "uses effective_total_points for points_max" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_max_materialized).to eq(50)
+      end
+    end
+  end
+
+  describe "#compute_and_upsert_all_records!" do
+    let(:user2) { create(:confirmed_user) }
+    let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+    let(:assessment) do
+      create(:assessment, :with_points, assessable: assignment, lecture: lecture)
+    end
+
+    let!(:task) { create(:assessment_task, assessment: assessment, max_points: 20) }
+
+    before do
+      create(:lecture_membership, user: user2, lecture: lecture)
+
+      p1 = create(:assessment_participation, assessment: assessment, user: user)
+      create(:assessment_task_point, task: task,
+                                     assessment_participation: p1,
+                                     points: 15)
+
+      p2 = create(:assessment_participation, assessment: assessment, user: user2)
+      create(:assessment_task_point, task: task,
+                                     assessment_participation: p2,
+                                     points: 10)
+    end
+
+    it "creates records for all lecture members" do
+      described_class.new(lecture: lecture).compute_and_upsert_all_records!
+      expect(StudentPerformance::Record.where(lecture: lecture).count).to eq(2)
+    end
+
+    it "computes correct points per user" do
+      described_class.new(lecture: lecture).compute_and_upsert_all_records!
+
+      record1 = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+      record2 = StudentPerformance::Record.find_by(lecture: lecture, user: user2)
+
+      expect(record1.points_total_materialized).to eq(15)
+      expect(record2.points_total_materialized).to eq(10)
+    end
+  end
+end

--- a/spec/models/student_performance/computation_service_spec.rb
+++ b/spec/models/student_performance/computation_service_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe(StudentPerformance::ComputationService) do
       let!(:task2) { create(:assessment_task, assessment: assessment, max_points: 20) }
 
       let!(:participation) do
-        create(:assessment_participation, assessment: assessment, user: user)
+        create(:assessment_participation, :reviewed,
+               assessment: assessment, user: user)
       end
 
       let!(:tp1) do
@@ -106,11 +107,13 @@ RSpec.describe(StudentPerformance::ComputationService) do
       let!(:task_b) { create(:assessment_task, assessment: assessment2, max_points: 40) }
 
       let!(:participation1) do
-        create(:assessment_participation, assessment: assessment1, user: user)
+        create(:assessment_participation, :reviewed,
+               assessment: assessment1, user: user)
       end
 
       let!(:participation2) do
-        create(:assessment_participation, assessment: assessment2, user: user)
+        create(:assessment_participation, :reviewed,
+               assessment: assessment2, user: user)
       end
 
       let!(:tp_a) do
@@ -144,7 +147,8 @@ RSpec.describe(StudentPerformance::ComputationService) do
       let!(:task2) { create(:assessment_task, assessment: assessment, max_points: 20) }
 
       let!(:participation) do
-        create(:assessment_participation, assessment: assessment, user: user)
+        create(:assessment_participation, :reviewed,
+               assessment: assessment, user: user)
       end
 
       it "updates the existing record instead of creating a duplicate" do
@@ -185,6 +189,128 @@ RSpec.describe(StudentPerformance::ComputationService) do
         expect(record.points_max_materialized).to eq(50)
       end
     end
+
+    context "when participation is pending" do
+      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assessment) do
+        create(:assessment, :with_points, assessable: assignment,
+                                          lecture: lecture)
+      end
+
+      let!(:task) { create(:assessment_task, assessment: assessment, max_points: 10) }
+
+      let!(:participation) do
+        create(:assessment_participation, :pending,
+               assessment: assessment, user: user)
+      end
+
+      let!(:tp) do
+        create(:assessment_task_point, task: task,
+                                       assessment_participation: participation,
+                                       points: 8)
+      end
+
+      it "excludes pending task points from points_total" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_total_materialized).to eq(0)
+      end
+
+      it "still includes the assessment in points_max" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_max_materialized).to eq(10)
+      end
+    end
+
+    context "when participation is exempt" do
+      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+
+      let(:assessment1) do
+        create(:assessment, :with_points, assessable: assignment1,
+                                          lecture: lecture)
+      end
+
+      let(:assessment2) do
+        create(:assessment, :with_points, assessable: assignment2,
+                                          lecture: lecture)
+      end
+
+      let!(:task1) { create(:assessment_task, assessment: assessment1, max_points: 20) }
+      let!(:task2) { create(:assessment_task, assessment: assessment2, max_points: 30) }
+
+      let!(:reviewed_participation) do
+        create(:assessment_participation, :reviewed,
+               assessment: assessment1, user: user)
+      end
+
+      let!(:exempt_participation) do
+        create(:assessment_participation, :exempt,
+               assessment: assessment2, user: user)
+      end
+
+      let!(:tp) do
+        create(:assessment_task_point, task: task1,
+                                       assessment_participation: reviewed_participation,
+                                       points: 15)
+      end
+
+      it "excludes exempt assessment from points_max" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.points_max_materialized).to eq(20)
+      end
+
+      it "computes percentage without the exempt assessment" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.percentage_materialized).to eq(75.0)
+      end
+    end
+
+    context "assessment counts" do
+      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment3) { create(:assignment, :with_lecture, lecture: lecture) }
+
+      let(:assessment1) do
+        create(:assessment, :with_points, assessable: assignment1,
+                                          lecture: lecture)
+      end
+
+      let(:assessment2) do
+        create(:assessment, :with_points, assessable: assignment2,
+                                          lecture: lecture)
+      end
+
+      let(:assessment3) do
+        create(:assessment, :with_points, assessable: assignment3,
+                                          lecture: lecture)
+      end
+
+      before do
+        create(:assessment_task, assessment: assessment1, max_points: 10)
+        create(:assessment_task, assessment: assessment2, max_points: 10)
+        create(:assessment_task, assessment: assessment3, max_points: 10)
+
+        create(:assessment_participation, :reviewed,
+               assessment: assessment1, user: user)
+        create(:assessment_participation, :pending,
+               assessment: assessment2, user: user)
+        create(:assessment_participation, :exempt,
+               assessment: assessment3, user: user)
+      end
+
+      it "stores all assessment counts" do
+        compute
+        record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
+        expect(record.assessments_total_count).to eq(3)
+        expect(record.assessments_reviewed_count).to eq(1)
+        expect(record.assessments_pending_count).to eq(1)
+        expect(record.assessments_exempt_count).to eq(1)
+      end
+    end
   end
 
   describe "#compute_and_upsert_all_records!" do
@@ -199,12 +325,14 @@ RSpec.describe(StudentPerformance::ComputationService) do
     before do
       create(:lecture_membership, user: user2, lecture: lecture)
 
-      p1 = create(:assessment_participation, assessment: assessment, user: user)
+      p1 = create(:assessment_participation, :reviewed,
+                  assessment: assessment, user: user)
       create(:assessment_task_point, task: task,
                                      assessment_participation: p1,
                                      points: 15)
 
-      p2 = create(:assessment_participation, assessment: assessment, user: user2)
+      p2 = create(:assessment_participation, :reviewed,
+                  assessment: assessment, user: user2)
       create(:assessment_task_point, task: task,
                                      assessment_participation: p2,
                                      points: 10)

--- a/spec/models/student_performance/computation_service_spec.rb
+++ b/spec/models/student_performance/computation_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe(StudentPerformance::ComputationService) do
       let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let!(:task1) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
@@ -49,19 +49,19 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let!(:participation) do
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment, user: user)
+                          assessment: assessment, user: user)
       end
 
       let!(:tp1) do
         FactoryBot.create(:assessment_task_point, task: task1,
-                                       assessment_participation: participation,
-                                       points: 8)
+                                                  assessment_participation: participation,
+                                                  points: 8)
       end
 
       let!(:tp2) do
         FactoryBot.create(:assessment_task_point, task: task2,
-                                       assessment_participation: participation,
-                                       points: 15)
+                                                  assessment_participation: participation,
+                                                  points: 15)
       end
 
       it "aggregates points_total from task points" do
@@ -95,12 +95,12 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let(:assessment1) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment1,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let(:assessment2) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment2,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let!(:task_a) { FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 10) }
@@ -108,24 +108,24 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let!(:participation1) do
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment1, user: user)
+                          assessment: assessment1, user: user)
       end
 
       let!(:participation2) do
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment2, user: user)
+                          assessment: assessment2, user: user)
       end
 
       let!(:tp_a) do
         FactoryBot.create(:assessment_task_point, task: task_a,
-                                       assessment_participation: participation1,
-                                       points: 7)
+                                                  assessment_participation: participation1,
+                                                  points: 7)
       end
 
       let!(:tp_b) do
         FactoryBot.create(:assessment_task_point, task: task_b,
-                                       assessment_participation: participation2,
-                                       points: 30)
+                                                  assessment_participation: participation2,
+                                                  points: 30)
       end
 
       it "sums points across all assessments" do
@@ -148,13 +148,13 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let!(:participation) do
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment, user: user)
+                          assessment: assessment, user: user)
       end
 
       it "updates the existing record instead of creating a duplicate" do
         FactoryBot.create(:assessment_task_point, task: task1,
-                                       assessment_participation: participation,
-                                       points: 5)
+                                                  assessment_participation: participation,
+                                                  points: 5)
 
         described_class.new(lecture: lecture).compute_and_upsert_record_for(user)
         expect(StudentPerformance::Record.where(lecture: lecture, user: user).count).to eq(1)
@@ -163,8 +163,8 @@ RSpec.describe(StudentPerformance::ComputationService) do
         expect(record.points_total_materialized).to eq(5)
 
         FactoryBot.create(:assessment_task_point, task: task2,
-                                       assessment_participation: participation,
-                                       points: 13)
+                                                  assessment_participation: participation,
+                                                  points: 13)
 
         described_class.new(lecture: lecture).compute_and_upsert_record_for(user)
         expect(StudentPerformance::Record.where(lecture: lecture, user: user).count).to eq(1)
@@ -178,7 +178,7 @@ RSpec.describe(StudentPerformance::ComputationService) do
       let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment,
-                                          lecture: lecture, total_points: 50)
+                                                     lecture: lecture, total_points: 50)
       end
 
       let!(:task) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
@@ -194,20 +194,20 @@ RSpec.describe(StudentPerformance::ComputationService) do
       let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let!(:task) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
 
       let!(:participation) do
         FactoryBot.create(:assessment_participation, :pending,
-               assessment: assessment, user: user)
+                          assessment: assessment, user: user)
       end
 
       let!(:tp) do
         FactoryBot.create(:assessment_task_point, task: task,
-                                       assessment_participation: participation,
-                                       points: 8)
+                                                  assessment_participation: participation,
+                                                  points: 8)
       end
 
       it "excludes pending task points from points_total" do
@@ -229,12 +229,12 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let(:assessment1) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment1,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let(:assessment2) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment2,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let!(:task1) { FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 20) }
@@ -242,18 +242,18 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let!(:reviewed_participation) do
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment1, user: user)
+                          assessment: assessment1, user: user)
       end
 
       let!(:exempt_participation) do
         FactoryBot.create(:assessment_participation, :exempt,
-               assessment: assessment2, user: user)
+                          assessment: assessment2, user: user)
       end
 
       let!(:tp) do
         FactoryBot.create(:assessment_task_point, task: task1,
-                                       assessment_participation: reviewed_participation,
-                                       points: 15)
+                                                  assessment_participation: reviewed_participation,
+                                                  points: 15)
       end
 
       it "excludes exempt assessment from points_max" do
@@ -276,17 +276,17 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let(:assessment1) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment1,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let(:assessment2) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment2,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let(:assessment3) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment3,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       before do
@@ -295,11 +295,11 @@ RSpec.describe(StudentPerformance::ComputationService) do
         FactoryBot.create(:assessment_task, assessment: assessment3, max_points: 10)
 
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment1, user: user)
+                          assessment: assessment1, user: user)
         FactoryBot.create(:assessment_participation, :pending,
-               assessment: assessment2, user: user)
+                          assessment: assessment2, user: user)
         FactoryBot.create(:assessment_participation, :exempt,
-               assessment: assessment3, user: user)
+                          assessment: assessment3, user: user)
       end
 
       it "stores all assessment counts" do
@@ -318,12 +318,12 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let(:assessment1) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment1,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let(:assessment2) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment2,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       before do
@@ -331,7 +331,7 @@ RSpec.describe(StudentPerformance::ComputationService) do
         FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 20)
 
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment1, user: user)
+                          assessment: assessment1, user: user)
       end
 
       it "counts the missing participation as pending" do
@@ -356,12 +356,12 @@ RSpec.describe(StudentPerformance::ComputationService) do
 
       let(:assessment1) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment1,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       let(:assessment2) do
         FactoryBot.create(:assessment, :with_points, assessable: assignment2,
-                                          lecture: lecture)
+                                                     lecture: lecture)
       end
 
       before do
@@ -369,9 +369,9 @@ RSpec.describe(StudentPerformance::ComputationService) do
         FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 20)
 
         FactoryBot.create(:assessment_participation, :reviewed,
-               assessment: assessment1, user: user)
+                          assessment: assessment1, user: user)
         FactoryBot.create(:assessment_participation, :absent,
-               assessment: assessment2, user: user)
+                          assessment: assessment2, user: user)
       end
 
       it "does not count absent as pending" do
@@ -398,16 +398,16 @@ RSpec.describe(StudentPerformance::ComputationService) do
       FactoryBot.create(:lecture_membership, user: user2, lecture: lecture)
 
       p1 = FactoryBot.create(:assessment_participation, :reviewed,
-                  assessment: assessment, user: user)
+                             assessment: assessment, user: user)
       FactoryBot.create(:assessment_task_point, task: task,
-                                     assessment_participation: p1,
-                                     points: 15)
+                                                assessment_participation: p1,
+                                                points: 15)
 
       p2 = FactoryBot.create(:assessment_participation, :reviewed,
-                  assessment: assessment, user: user2)
+                             assessment: assessment, user: user2)
       FactoryBot.create(:assessment_task_point, task: task,
-                                     assessment_participation: p2,
-                                     points: 10)
+                                                assessment_participation: p2,
+                                                points: 10)
     end
 
     it "creates records for all lecture members" do

--- a/spec/models/student_performance/computation_service_spec.rb
+++ b/spec/models/student_performance/computation_service_spec.rb
@@ -307,8 +307,51 @@ RSpec.describe(StudentPerformance::ComputationService) do
         record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
         expect(record.assessments_total_count).to eq(3)
         expect(record.assessments_reviewed_count).to eq(1)
-        expect(record.assessments_pending_count).to eq(1)
+        expect(record.assessments_pending_grading_count).to eq(1)
+        expect(record.assessments_not_submitted_count).to eq(0)
         expect(record.assessments_exempt_count).to eq(1)
+      end
+    end
+
+    context "when pending participation has no submitted_at" do
+      let(:assignment1) do
+        FactoryBot.create(:assignment, :with_lecture, lecture: lecture)
+      end
+
+      let(:assignment2) do
+        FactoryBot.create(:assignment, :with_lecture, lecture: lecture)
+      end
+
+      let(:assessment1) do
+        FactoryBot.create(:assessment, :with_points, assessable: assignment1,
+                                                     lecture: lecture)
+      end
+
+      let(:assessment2) do
+        FactoryBot.create(:assessment, :with_points, assessable: assignment2,
+                                                     lecture: lecture)
+      end
+
+      before do
+        FactoryBot.create(:assessment_task,
+                          assessment: assessment1, max_points: 10)
+        FactoryBot.create(:assessment_task,
+                          assessment: assessment2, max_points: 10)
+
+        FactoryBot.create(:assessment_participation, :reviewed,
+                          assessment: assessment1, user: user)
+        FactoryBot.create(:assessment_participation,
+                          assessment: assessment2, user: user,
+                          status: :pending, submitted_at: nil)
+      end
+
+      it "counts it as not submitted rather than pending grading" do
+        compute
+        record = StudentPerformance::Record.find_by(
+          lecture: lecture, user: user
+        )
+        expect(record.assessments_pending_grading_count).to eq(0)
+        expect(record.assessments_not_submitted_count).to eq(1)
       end
     end
 
@@ -334,12 +377,13 @@ RSpec.describe(StudentPerformance::ComputationService) do
                           assessment: assessment1, user: user)
       end
 
-      it "counts the missing participation as pending" do
+      it "counts the missing participation as not submitted" do
         compute
         record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
         expect(record.assessments_total_count).to eq(2)
         expect(record.assessments_reviewed_count).to eq(1)
-        expect(record.assessments_pending_count).to eq(1)
+        expect(record.assessments_pending_grading_count).to eq(0)
+        expect(record.assessments_not_submitted_count).to eq(1)
         expect(record.assessments_exempt_count).to eq(0)
       end
 
@@ -374,12 +418,13 @@ RSpec.describe(StudentPerformance::ComputationService) do
                           assessment: assessment2, user: user)
       end
 
-      it "does not count absent as pending" do
+      it "does not count absent as pending or not submitted" do
         compute
         record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
         expect(record.assessments_total_count).to eq(2)
         expect(record.assessments_reviewed_count).to eq(1)
-        expect(record.assessments_pending_count).to eq(0)
+        expect(record.assessments_pending_grading_count).to eq(0)
+        expect(record.assessments_not_submitted_count).to eq(0)
         expect(record.assessments_exempt_count).to eq(0)
       end
     end

--- a/spec/models/student_performance/computation_service_spec.rb
+++ b/spec/models/student_performance/computation_service_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe(StudentPerformance::ComputationService) do
-  let(:lecture) { create(:lecture, :released_for_all) }
-  let(:user) { create(:confirmed_user) }
+  let(:lecture) { FactoryBot.create(:lecture, :released_for_all) }
+  let(:user) { FactoryBot.create(:confirmed_user) }
 
   before do
-    create(:lecture_membership, user: user, lecture: lecture)
+    FactoryBot.create(:lecture_membership, user: user, lecture: lecture)
   end
 
   describe "#compute_and_upsert_record_for" do
@@ -38,28 +38,28 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when user has participations with task points" do
-      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
-        create(:assessment, :with_points, assessable: assignment,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment,
                                           lecture: lecture)
       end
 
-      let!(:task1) { create(:assessment_task, assessment: assessment, max_points: 10) }
-      let!(:task2) { create(:assessment_task, assessment: assessment, max_points: 20) }
+      let!(:task1) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
+      let!(:task2) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 20) }
 
       let!(:participation) do
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment, user: user)
       end
 
       let!(:tp1) do
-        create(:assessment_task_point, task: task1,
+        FactoryBot.create(:assessment_task_point, task: task1,
                                        assessment_participation: participation,
                                        points: 8)
       end
 
       let!(:tp2) do
-        create(:assessment_task_point, task: task2,
+        FactoryBot.create(:assessment_task_point, task: task2,
                                        assessment_participation: participation,
                                        points: 15)
       end
@@ -90,40 +90,40 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "with multiple assessments" do
-      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
-      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment1) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
 
       let(:assessment1) do
-        create(:assessment, :with_points, assessable: assignment1,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment1,
                                           lecture: lecture)
       end
 
       let(:assessment2) do
-        create(:assessment, :with_points, assessable: assignment2,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment2,
                                           lecture: lecture)
       end
 
-      let!(:task_a) { create(:assessment_task, assessment: assessment1, max_points: 10) }
-      let!(:task_b) { create(:assessment_task, assessment: assessment2, max_points: 40) }
+      let!(:task_a) { FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 10) }
+      let!(:task_b) { FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 40) }
 
       let!(:participation1) do
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment1, user: user)
       end
 
       let!(:participation2) do
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment2, user: user)
       end
 
       let!(:tp_a) do
-        create(:assessment_task_point, task: task_a,
+        FactoryBot.create(:assessment_task_point, task: task_a,
                                        assessment_participation: participation1,
                                        points: 7)
       end
 
       let!(:tp_b) do
-        create(:assessment_task_point, task: task_b,
+        FactoryBot.create(:assessment_task_point, task: task_b,
                                        assessment_participation: participation2,
                                        points: 30)
       end
@@ -138,21 +138,21 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when called twice (upsert)" do
-      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
-        create(:assessment, :with_points, assessable: assignment, lecture: lecture)
+        FactoryBot.create(:assessment, :with_points, assessable: assignment, lecture: lecture)
       end
 
-      let!(:task1) { create(:assessment_task, assessment: assessment, max_points: 10) }
-      let!(:task2) { create(:assessment_task, assessment: assessment, max_points: 20) }
+      let!(:task1) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
+      let!(:task2) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 20) }
 
       let!(:participation) do
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment, user: user)
       end
 
       it "updates the existing record instead of creating a duplicate" do
-        create(:assessment_task_point, task: task1,
+        FactoryBot.create(:assessment_task_point, task: task1,
                                        assessment_participation: participation,
                                        points: 5)
 
@@ -162,7 +162,7 @@ RSpec.describe(StudentPerformance::ComputationService) do
         record = StudentPerformance::Record.find_by(lecture: lecture, user: user)
         expect(record.points_total_materialized).to eq(5)
 
-        create(:assessment_task_point, task: task2,
+        FactoryBot.create(:assessment_task_point, task: task2,
                                        assessment_participation: participation,
                                        points: 13)
 
@@ -175,13 +175,13 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when assessment has total_points override" do
-      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
-        create(:assessment, :with_points, assessable: assignment,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment,
                                           lecture: lecture, total_points: 50)
       end
 
-      let!(:task) { create(:assessment_task, assessment: assessment, max_points: 10) }
+      let!(:task) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
 
       it "uses effective_total_points for points_max" do
         compute
@@ -191,21 +191,21 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when participation is pending" do
-      let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
       let(:assessment) do
-        create(:assessment, :with_points, assessable: assignment,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment,
                                           lecture: lecture)
       end
 
-      let!(:task) { create(:assessment_task, assessment: assessment, max_points: 10) }
+      let!(:task) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 10) }
 
       let!(:participation) do
-        create(:assessment_participation, :pending,
+        FactoryBot.create(:assessment_participation, :pending,
                assessment: assessment, user: user)
       end
 
       let!(:tp) do
-        create(:assessment_task_point, task: task,
+        FactoryBot.create(:assessment_task_point, task: task,
                                        assessment_participation: participation,
                                        points: 8)
       end
@@ -224,34 +224,34 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when participation is exempt" do
-      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
-      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment1) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
 
       let(:assessment1) do
-        create(:assessment, :with_points, assessable: assignment1,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment1,
                                           lecture: lecture)
       end
 
       let(:assessment2) do
-        create(:assessment, :with_points, assessable: assignment2,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment2,
                                           lecture: lecture)
       end
 
-      let!(:task1) { create(:assessment_task, assessment: assessment1, max_points: 20) }
-      let!(:task2) { create(:assessment_task, assessment: assessment2, max_points: 30) }
+      let!(:task1) { FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 20) }
+      let!(:task2) { FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 30) }
 
       let!(:reviewed_participation) do
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment1, user: user)
       end
 
       let!(:exempt_participation) do
-        create(:assessment_participation, :exempt,
+        FactoryBot.create(:assessment_participation, :exempt,
                assessment: assessment2, user: user)
       end
 
       let!(:tp) do
-        create(:assessment_task_point, task: task1,
+        FactoryBot.create(:assessment_task_point, task: task1,
                                        assessment_participation: reviewed_participation,
                                        points: 15)
       end
@@ -270,35 +270,35 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "assessment counts" do
-      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
-      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
-      let(:assignment3) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment1) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment3) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
 
       let(:assessment1) do
-        create(:assessment, :with_points, assessable: assignment1,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment1,
                                           lecture: lecture)
       end
 
       let(:assessment2) do
-        create(:assessment, :with_points, assessable: assignment2,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment2,
                                           lecture: lecture)
       end
 
       let(:assessment3) do
-        create(:assessment, :with_points, assessable: assignment3,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment3,
                                           lecture: lecture)
       end
 
       before do
-        create(:assessment_task, assessment: assessment1, max_points: 10)
-        create(:assessment_task, assessment: assessment2, max_points: 10)
-        create(:assessment_task, assessment: assessment3, max_points: 10)
+        FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 10)
+        FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 10)
+        FactoryBot.create(:assessment_task, assessment: assessment3, max_points: 10)
 
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment1, user: user)
-        create(:assessment_participation, :pending,
+        FactoryBot.create(:assessment_participation, :pending,
                assessment: assessment2, user: user)
-        create(:assessment_participation, :exempt,
+        FactoryBot.create(:assessment_participation, :exempt,
                assessment: assessment3, user: user)
       end
 
@@ -313,24 +313,24 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when assessment has no participation record" do
-      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
-      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment1) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
 
       let(:assessment1) do
-        create(:assessment, :with_points, assessable: assignment1,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment1,
                                           lecture: lecture)
       end
 
       let(:assessment2) do
-        create(:assessment, :with_points, assessable: assignment2,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment2,
                                           lecture: lecture)
       end
 
       before do
-        create(:assessment_task, assessment: assessment1, max_points: 10)
-        create(:assessment_task, assessment: assessment2, max_points: 20)
+        FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 10)
+        FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 20)
 
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment1, user: user)
       end
 
@@ -351,26 +351,26 @@ RSpec.describe(StudentPerformance::ComputationService) do
     end
 
     context "when participation is absent" do
-      let(:assignment1) { create(:assignment, :with_lecture, lecture: lecture) }
-      let(:assignment2) { create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment1) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
+      let(:assignment2) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
 
       let(:assessment1) do
-        create(:assessment, :with_points, assessable: assignment1,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment1,
                                           lecture: lecture)
       end
 
       let(:assessment2) do
-        create(:assessment, :with_points, assessable: assignment2,
+        FactoryBot.create(:assessment, :with_points, assessable: assignment2,
                                           lecture: lecture)
       end
 
       before do
-        create(:assessment_task, assessment: assessment1, max_points: 10)
-        create(:assessment_task, assessment: assessment2, max_points: 20)
+        FactoryBot.create(:assessment_task, assessment: assessment1, max_points: 10)
+        FactoryBot.create(:assessment_task, assessment: assessment2, max_points: 20)
 
-        create(:assessment_participation, :reviewed,
+        FactoryBot.create(:assessment_participation, :reviewed,
                assessment: assessment1, user: user)
-        create(:assessment_participation, :absent,
+        FactoryBot.create(:assessment_participation, :absent,
                assessment: assessment2, user: user)
       end
 
@@ -386,26 +386,26 @@ RSpec.describe(StudentPerformance::ComputationService) do
   end
 
   describe "#compute_and_upsert_all_records!" do
-    let(:user2) { create(:confirmed_user) }
-    let(:assignment) { create(:assignment, :with_lecture, lecture: lecture) }
+    let(:user2) { FactoryBot.create(:confirmed_user) }
+    let(:assignment) { FactoryBot.create(:assignment, :with_lecture, lecture: lecture) }
     let(:assessment) do
-      create(:assessment, :with_points, assessable: assignment, lecture: lecture)
+      FactoryBot.create(:assessment, :with_points, assessable: assignment, lecture: lecture)
     end
 
-    let!(:task) { create(:assessment_task, assessment: assessment, max_points: 20) }
+    let!(:task) { FactoryBot.create(:assessment_task, assessment: assessment, max_points: 20) }
 
     before do
-      create(:lecture_membership, user: user2, lecture: lecture)
+      FactoryBot.create(:lecture_membership, user: user2, lecture: lecture)
 
-      p1 = create(:assessment_participation, :reviewed,
+      p1 = FactoryBot.create(:assessment_participation, :reviewed,
                   assessment: assessment, user: user)
-      create(:assessment_task_point, task: task,
+      FactoryBot.create(:assessment_task_point, task: task,
                                      assessment_participation: p1,
                                      points: 15)
 
-      p2 = create(:assessment_participation, :reviewed,
+      p2 = FactoryBot.create(:assessment_participation, :reviewed,
                   assessment: assessment, user: user2)
-      create(:assessment_task_point, task: task,
+      FactoryBot.create(:assessment_task_point, task: task,
                                      assessment_participation: p2,
                                      points: 10)
     end

--- a/spec/models/student_performance/evaluator_spec.rb
+++ b/spec/models/student_performance/evaluator_spec.rb
@@ -1,0 +1,250 @@
+require "rails_helper"
+
+RSpec.describe(StudentPerformance::Evaluator) do
+  let(:lecture) { create(:lecture, :released_for_all) }
+
+  describe "#evaluate" do
+    context "with a percentage-based rule" do
+      let(:rule) do
+        create(:student_performance_rule, :active, :with_percentage,
+               lecture: lecture, min_percentage: 50)
+      end
+
+      let(:evaluator) { described_class.new(rule) }
+
+      it "proposes :passed when percentage meets threshold" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        points_total_materialized: 60,
+                        points_max_materialized: 100,
+                        percentage_materialized: 60)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:passed)
+        expect(result.details[:meets_points]).to be(true)
+      end
+
+      it "proposes :passed when percentage equals threshold" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        percentage_materialized: 50)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:passed)
+      end
+
+      it "proposes :failed when percentage is below threshold" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        percentage_materialized: 49.99)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+        expect(result.details[:meets_points]).to be(false)
+      end
+
+      it "proposes :failed when percentage is nil" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        percentage_materialized: nil)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+      end
+    end
+
+    context "with an absolute points rule" do
+      let(:rule) do
+        create(:student_performance_rule, :active, :with_absolute_points,
+               lecture: lecture, min_points_absolute: 60)
+      end
+
+      let(:evaluator) { described_class.new(rule) }
+
+      it "proposes :passed when points meet threshold" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        points_total_materialized: 75)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:passed)
+        expect(result.details[:meets_points]).to be(true)
+        expect(result.details[:required_points]).to eq(60)
+      end
+
+      it "proposes :failed when points are below threshold" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        points_total_materialized: 59)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+      end
+    end
+
+    context "with a rule that has no points threshold" do
+      let(:rule) do
+        create(:student_performance_rule, :active, lecture: lecture)
+      end
+
+      let(:evaluator) { described_class.new(rule) }
+
+      it "proposes :passed regardless of points" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        points_total_materialized: 0,
+                        percentage_materialized: 0)
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:passed)
+        expect(result.details[:meets_points]).to be(true)
+      end
+    end
+
+    context "with required achievements" do
+      let(:achievement1) { create(:achievement, :boolean, lecture: lecture) }
+      let(:achievement2) { create(:achievement, :numeric, lecture: lecture) }
+
+      let(:rule) do
+        create(:student_performance_rule, :active, lecture: lecture)
+      end
+
+      before do
+        create(:student_performance_rule_achievement,
+               rule: rule, achievement: achievement1)
+        create(:student_performance_rule_achievement,
+               rule: rule, achievement: achievement2)
+      end
+
+      let(:evaluator) { described_class.new(rule) }
+
+      it "proposes :passed when all achievements are met" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        achievements_met_ids: [achievement1.id, achievement2.id])
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:passed)
+        expect(result.details[:meets_achievements]).to be(true)
+      end
+
+      it "proposes :failed when some achievements are missing" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        achievements_met_ids: [achievement1.id])
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+        expect(result.details[:meets_achievements]).to be(false)
+      end
+
+      it "proposes :failed when no achievements are met" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        achievements_met_ids: [])
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+      end
+    end
+
+    context "with both points and achievements required" do
+      let(:achievement) { create(:achievement, :boolean, lecture: lecture) }
+
+      let(:rule) do
+        create(:student_performance_rule, :active, :with_percentage,
+               lecture: lecture, min_percentage: 50)
+      end
+
+      before do
+        create(:student_performance_rule_achievement,
+               rule: rule, achievement: achievement)
+      end
+
+      let(:evaluator) { described_class.new(rule) }
+
+      it "proposes :passed only when both are met" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        percentage_materialized: 60,
+                        achievements_met_ids: [achievement.id])
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:passed)
+      end
+
+      it "proposes :failed when points met but achievements not" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        percentage_materialized: 60,
+                        achievements_met_ids: [])
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+      end
+
+      it "proposes :failed when achievements met but points not" do
+        record = create(:student_performance_record,
+                        lecture: lecture,
+                        percentage_materialized: 40,
+                        achievements_met_ids: [achievement.id])
+
+        result = evaluator.evaluate(record)
+        expect(result.proposed_status).to eq(:failed)
+      end
+    end
+
+    context "when record is nil" do
+      let(:rule) do
+        create(:student_performance_rule, :active, lecture: lecture)
+      end
+
+      let(:evaluator) { described_class.new(rule) }
+
+      it "proposes :failed with empty details" do
+        result = evaluator.evaluate(nil)
+        expect(result.proposed_status).to eq(:failed)
+        expect(result.details).to eq({})
+      end
+    end
+
+    it "includes all expected detail keys" do
+      rule = create(:student_performance_rule, :active, :with_percentage,
+                    lecture: lecture, min_percentage: 50)
+      record = create(:student_performance_record,
+                      lecture: lecture, percentage_materialized: 60)
+
+      result = described_class.new(rule).evaluate(record)
+      expected_keys = [:meets_points, :meets_achievements, :points_total, :points_max, :percentage,
+                       :required_points, :required_percentage, :achievement_ids_met, :achievement_ids_required]
+      expect(result.details.keys).to match_array(expected_keys)
+    end
+  end
+
+  describe "#bulk_evaluate" do
+    let(:rule) do
+      create(:student_performance_rule, :active, :with_percentage,
+             lecture: lecture, min_percentage: 50)
+    end
+
+    let(:evaluator) { described_class.new(rule) }
+
+    let!(:passing_record) do
+      create(:student_performance_record,
+             lecture: lecture, percentage_materialized: 80)
+    end
+
+    let!(:failing_record) do
+      create(:student_performance_record,
+             lecture: lecture, percentage_materialized: 30)
+    end
+
+    it "returns a hash mapping records to results" do
+      results = evaluator.bulk_evaluate([passing_record, failing_record])
+
+      expect(results.keys).to match_array([passing_record, failing_record])
+      expect(results[passing_record].proposed_status).to eq(:passed)
+      expect(results[failing_record].proposed_status).to eq(:failed)
+    end
+  end
+end

--- a/spec/models/student_performance/evaluator_spec.rb
+++ b/spec/models/student_performance/evaluator_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe(StudentPerformance::Evaluator) do
     context "with a percentage-based rule" do
       let(:rule) do
         FactoryBot.create(:student_performance_rule, :active, :with_percentage,
-               lecture: lecture, min_percentage: 50)
+                          lecture: lecture, min_percentage: 50)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed when percentage meets threshold" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        points_total_materialized: 60,
-                        points_max_materialized: 100,
-                        percentage_materialized: 60)
+                                   lecture: lecture,
+                                   points_total_materialized: 60,
+                                   points_max_materialized: 100,
+                                   percentage_materialized: 60)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:passed)
@@ -26,8 +26,8 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :passed when percentage equals threshold" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        percentage_materialized: 50)
+                                   lecture: lecture,
+                                   percentage_materialized: 50)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:passed)
@@ -35,8 +35,8 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when percentage is below threshold" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        percentage_materialized: 49.99)
+                                   lecture: lecture,
+                                   percentage_materialized: 49.99)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -45,8 +45,8 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when percentage is nil" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        percentage_materialized: nil)
+                                   lecture: lecture,
+                                   percentage_materialized: nil)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -56,15 +56,15 @@ RSpec.describe(StudentPerformance::Evaluator) do
     context "with an absolute points rule" do
       let(:rule) do
         FactoryBot.create(:student_performance_rule, :active, :with_absolute_points,
-               lecture: lecture, min_points_absolute: 60)
+                          lecture: lecture, min_points_absolute: 60)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed when points meet threshold" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        points_total_materialized: 75)
+                                   lecture: lecture,
+                                   points_total_materialized: 75)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:passed)
@@ -74,8 +74,8 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when points are below threshold" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        points_total_materialized: 59)
+                                   lecture: lecture,
+                                   points_total_materialized: 59)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -91,9 +91,9 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :passed regardless of points" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        points_total_materialized: 0,
-                        percentage_materialized: 0)
+                                   lecture: lecture,
+                                   points_total_materialized: 0,
+                                   percentage_materialized: 0)
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:passed)
@@ -111,17 +111,17 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       before do
         FactoryBot.create(:student_performance_rule_achievement,
-               rule: rule, achievement: achievement1)
+                          rule: rule, achievement: achievement1)
         FactoryBot.create(:student_performance_rule_achievement,
-               rule: rule, achievement: achievement2)
+                          rule: rule, achievement: achievement2)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed when all achievements are met" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        achievements_met_ids: [achievement1.id, achievement2.id])
+                                   lecture: lecture,
+                                   achievements_met_ids: [achievement1.id, achievement2.id])
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:passed)
@@ -130,8 +130,8 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when some achievements are missing" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        achievements_met_ids: [achievement1.id])
+                                   lecture: lecture,
+                                   achievements_met_ids: [achievement1.id])
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -140,8 +140,8 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when no achievements are met" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        achievements_met_ids: [])
+                                   lecture: lecture,
+                                   achievements_met_ids: [])
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -153,21 +153,21 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       let(:rule) do
         FactoryBot.create(:student_performance_rule, :active, :with_percentage,
-               lecture: lecture, min_percentage: 50)
+                          lecture: lecture, min_percentage: 50)
       end
 
       before do
         FactoryBot.create(:student_performance_rule_achievement,
-               rule: rule, achievement: achievement)
+                          rule: rule, achievement: achievement)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed only when both are met" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        percentage_materialized: 60,
-                        achievements_met_ids: [achievement.id])
+                                   lecture: lecture,
+                                   percentage_materialized: 60,
+                                   achievements_met_ids: [achievement.id])
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:passed)
@@ -175,9 +175,9 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when points met but achievements not" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        percentage_materialized: 60,
-                        achievements_met_ids: [])
+                                   lecture: lecture,
+                                   percentage_materialized: 60,
+                                   achievements_met_ids: [])
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -185,9 +185,9 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
       it "proposes :failed when achievements met but points not" do
         record = FactoryBot.create(:student_performance_record,
-                        lecture: lecture,
-                        percentage_materialized: 40,
-                        achievements_met_ids: [achievement.id])
+                                   lecture: lecture,
+                                   percentage_materialized: 40,
+                                   achievements_met_ids: [achievement.id])
 
         result = evaluator.evaluate(record)
         expect(result.proposed_status).to eq(:failed)
@@ -210,9 +210,9 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
     it "includes all expected detail keys" do
       rule = FactoryBot.create(:student_performance_rule, :active, :with_percentage,
-                    lecture: lecture, min_percentage: 50)
+                               lecture: lecture, min_percentage: 50)
       record = FactoryBot.create(:student_performance_record,
-                      lecture: lecture, percentage_materialized: 60)
+                                 lecture: lecture, percentage_materialized: 60)
 
       result = described_class.new(rule).evaluate(record)
       expected_keys = [:meets_points, :meets_achievements, :points_total, :points_max,
@@ -225,19 +225,19 @@ RSpec.describe(StudentPerformance::Evaluator) do
   describe "#bulk_evaluate" do
     let(:rule) do
       FactoryBot.create(:student_performance_rule, :active, :with_percentage,
-             lecture: lecture, min_percentage: 50)
+                        lecture: lecture, min_percentage: 50)
     end
 
     let(:evaluator) { described_class.new(rule) }
 
     let!(:passing_record) do
       FactoryBot.create(:student_performance_record,
-             lecture: lecture, percentage_materialized: 80)
+                        lecture: lecture, percentage_materialized: 80)
     end
 
     let!(:failing_record) do
       FactoryBot.create(:student_performance_record,
-             lecture: lecture, percentage_materialized: 30)
+                        lecture: lecture, percentage_materialized: 30)
     end
 
     it "returns a hash mapping records to results" do

--- a/spec/models/student_performance/evaluator_spec.rb
+++ b/spec/models/student_performance/evaluator_spec.rb
@@ -215,8 +215,9 @@ RSpec.describe(StudentPerformance::Evaluator) do
                       lecture: lecture, percentage_materialized: 60)
 
       result = described_class.new(rule).evaluate(record)
-      expected_keys = [:meets_points, :meets_achievements, :points_total, :points_max, :percentage,
-                       :required_points, :required_percentage, :achievement_ids_met, :achievement_ids_required]
+      expected_keys = [:meets_points, :meets_achievements, :points_total, :points_max,
+                       :percentage, :required_points, :required_percentage,
+                       :achievement_ids_met, :achievement_ids_required]
       expect(result.details.keys).to match_array(expected_keys)
     end
   end

--- a/spec/models/student_performance/evaluator_spec.rb
+++ b/spec/models/student_performance/evaluator_spec.rb
@@ -1,19 +1,19 @@
 require "rails_helper"
 
 RSpec.describe(StudentPerformance::Evaluator) do
-  let(:lecture) { create(:lecture, :released_for_all) }
+  let(:lecture) { FactoryBot.create(:lecture, :released_for_all) }
 
   describe "#evaluate" do
     context "with a percentage-based rule" do
       let(:rule) do
-        create(:student_performance_rule, :active, :with_percentage,
+        FactoryBot.create(:student_performance_rule, :active, :with_percentage,
                lecture: lecture, min_percentage: 50)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed when percentage meets threshold" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         points_total_materialized: 60,
                         points_max_materialized: 100,
@@ -25,7 +25,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :passed when percentage equals threshold" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         percentage_materialized: 50)
 
@@ -34,7 +34,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when percentage is below threshold" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         percentage_materialized: 49.99)
 
@@ -44,7 +44,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when percentage is nil" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         percentage_materialized: nil)
 
@@ -55,14 +55,14 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
     context "with an absolute points rule" do
       let(:rule) do
-        create(:student_performance_rule, :active, :with_absolute_points,
+        FactoryBot.create(:student_performance_rule, :active, :with_absolute_points,
                lecture: lecture, min_points_absolute: 60)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed when points meet threshold" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         points_total_materialized: 75)
 
@@ -73,7 +73,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when points are below threshold" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         points_total_materialized: 59)
 
@@ -84,13 +84,13 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
     context "with a rule that has no points threshold" do
       let(:rule) do
-        create(:student_performance_rule, :active, lecture: lecture)
+        FactoryBot.create(:student_performance_rule, :active, lecture: lecture)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed regardless of points" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         points_total_materialized: 0,
                         percentage_materialized: 0)
@@ -102,24 +102,24 @@ RSpec.describe(StudentPerformance::Evaluator) do
     end
 
     context "with required achievements" do
-      let(:achievement1) { create(:achievement, :boolean, lecture: lecture) }
-      let(:achievement2) { create(:achievement, :numeric, lecture: lecture) }
+      let(:achievement1) { FactoryBot.create(:achievement, :boolean, lecture: lecture) }
+      let(:achievement2) { FactoryBot.create(:achievement, :numeric, lecture: lecture) }
 
       let(:rule) do
-        create(:student_performance_rule, :active, lecture: lecture)
+        FactoryBot.create(:student_performance_rule, :active, lecture: lecture)
       end
 
       before do
-        create(:student_performance_rule_achievement,
+        FactoryBot.create(:student_performance_rule_achievement,
                rule: rule, achievement: achievement1)
-        create(:student_performance_rule_achievement,
+        FactoryBot.create(:student_performance_rule_achievement,
                rule: rule, achievement: achievement2)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed when all achievements are met" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         achievements_met_ids: [achievement1.id, achievement2.id])
 
@@ -129,7 +129,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when some achievements are missing" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         achievements_met_ids: [achievement1.id])
 
@@ -139,7 +139,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when no achievements are met" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         achievements_met_ids: [])
 
@@ -149,22 +149,22 @@ RSpec.describe(StudentPerformance::Evaluator) do
     end
 
     context "with both points and achievements required" do
-      let(:achievement) { create(:achievement, :boolean, lecture: lecture) }
+      let(:achievement) { FactoryBot.create(:achievement, :boolean, lecture: lecture) }
 
       let(:rule) do
-        create(:student_performance_rule, :active, :with_percentage,
+        FactoryBot.create(:student_performance_rule, :active, :with_percentage,
                lecture: lecture, min_percentage: 50)
       end
 
       before do
-        create(:student_performance_rule_achievement,
+        FactoryBot.create(:student_performance_rule_achievement,
                rule: rule, achievement: achievement)
       end
 
       let(:evaluator) { described_class.new(rule) }
 
       it "proposes :passed only when both are met" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         percentage_materialized: 60,
                         achievements_met_ids: [achievement.id])
@@ -174,7 +174,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when points met but achievements not" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         percentage_materialized: 60,
                         achievements_met_ids: [])
@@ -184,7 +184,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
       end
 
       it "proposes :failed when achievements met but points not" do
-        record = create(:student_performance_record,
+        record = FactoryBot.create(:student_performance_record,
                         lecture: lecture,
                         percentage_materialized: 40,
                         achievements_met_ids: [achievement.id])
@@ -196,7 +196,7 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
     context "when record is nil" do
       let(:rule) do
-        create(:student_performance_rule, :active, lecture: lecture)
+        FactoryBot.create(:student_performance_rule, :active, lecture: lecture)
       end
 
       let(:evaluator) { described_class.new(rule) }
@@ -209,9 +209,9 @@ RSpec.describe(StudentPerformance::Evaluator) do
     end
 
     it "includes all expected detail keys" do
-      rule = create(:student_performance_rule, :active, :with_percentage,
+      rule = FactoryBot.create(:student_performance_rule, :active, :with_percentage,
                     lecture: lecture, min_percentage: 50)
-      record = create(:student_performance_record,
+      record = FactoryBot.create(:student_performance_record,
                       lecture: lecture, percentage_materialized: 60)
 
       result = described_class.new(rule).evaluate(record)
@@ -224,19 +224,19 @@ RSpec.describe(StudentPerformance::Evaluator) do
 
   describe "#bulk_evaluate" do
     let(:rule) do
-      create(:student_performance_rule, :active, :with_percentage,
+      FactoryBot.create(:student_performance_rule, :active, :with_percentage,
              lecture: lecture, min_percentage: 50)
     end
 
     let(:evaluator) { described_class.new(rule) }
 
     let!(:passing_record) do
-      create(:student_performance_record,
+      FactoryBot.create(:student_performance_record,
              lecture: lecture, percentage_materialized: 80)
     end
 
     let!(:failing_record) do
-      create(:student_performance_record,
+      FactoryBot.create(:student_performance_record,
              lecture: lecture, percentage_materialized: 30)
     end
 

--- a/spec/workers/certification_stale_check_job_spec.rb
+++ b/spec/workers/certification_stale_check_job_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe(CertificationStaleCheckJob, type: :worker) do
+  let(:lecture) { create(:lecture, :released_for_all) }
+  let(:user) { create(:confirmed_user) }
+  let(:certifier) { create(:confirmed_user) }
+
+  before do
+    create(:lecture_membership, user: user, lecture: lecture)
+  end
+
+  describe "#perform" do
+    it "recomputes performance records for the lecture" do
+      service = instance_double(StudentPerformance::ComputationService)
+      allow(StudentPerformance::ComputationService)
+        .to receive(:new).with(lecture: lecture).and_return(service)
+      allow(service).to receive(:compute_and_upsert_all_records!)
+
+      described_class.new.perform(lecture.id)
+
+      expect(service).to have_received(:compute_and_upsert_all_records!)
+    end
+
+    context "when a certification is stale" do
+      before do
+        service = instance_double(StudentPerformance::ComputationService)
+        allow(StudentPerformance::ComputationService)
+          .to receive(:new).with(lecture: lecture).and_return(service)
+        allow(service).to receive(:compute_and_upsert_all_records!)
+
+        create(:student_performance_record,
+               lecture: lecture, user: user,
+               computed_at: 1.hour.ago)
+
+        create(:student_performance_certification, :passed,
+               lecture: lecture, user: user,
+               certified_by: certifier,
+               certified_at: 2.hours.ago)
+      end
+
+      it "logs stale certifications" do
+        allow(Rails.logger).to receive(:info)
+
+        described_class.new.perform(lecture.id)
+
+        expect(Rails.logger).to have_received(:info).with(
+          a_string_matching(/stale_count=1/)
+        )
+      end
+    end
+
+    context "when no certification is stale" do
+      before do
+        service = instance_double(StudentPerformance::ComputationService)
+        allow(StudentPerformance::ComputationService)
+          .to receive(:new).with(lecture: lecture).and_return(service)
+        allow(service).to receive(:compute_and_upsert_all_records!)
+
+        create(:student_performance_record,
+               lecture: lecture, user: user,
+               computed_at: 2.hours.ago)
+
+        create(:student_performance_certification, :passed,
+               lecture: lecture, user: user,
+               certified_by: certifier,
+               certified_at: 1.hour.ago)
+      end
+
+      it "does not log anything about staleness" do
+        allow(Rails.logger).to receive(:info)
+
+        described_class.new.perform(lecture.id)
+
+        expect(Rails.logger).not_to have_received(:info).with(
+          a_string_matching(/CertificationStaleCheck/)
+        )
+      end
+    end
+  end
+
+  describe "sidekiq_options" do
+    it "uses the default queue" do
+      expect(described_class.sidekiq_options["queue"]).to eq(:default)
+    end
+
+    it "retries once" do
+      expect(described_class.sidekiq_options["retry"]).to eq(1)
+    end
+  end
+end

--- a/spec/workers/certification_stale_check_job_spec.rb
+++ b/spec/workers/certification_stale_check_job_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe(CertificationStaleCheckJob, type: :worker) do
-  let(:lecture) { create(:lecture, :released_for_all) }
-  let(:user) { create(:confirmed_user) }
-  let(:certifier) { create(:confirmed_user) }
+  let(:lecture) { FactoryBot.create(:lecture, :released_for_all) }
+  let(:user) { FactoryBot.create(:confirmed_user) }
+  let(:certifier) { FactoryBot.create(:confirmed_user) }
 
   before do
-    create(:lecture_membership, user: user, lecture: lecture)
+    FactoryBot.create(:lecture_membership, user: user, lecture: lecture)
   end
 
   describe "#perform" do
@@ -28,11 +28,11 @@ RSpec.describe(CertificationStaleCheckJob, type: :worker) do
           .to receive(:new).with(lecture: lecture).and_return(service)
         allow(service).to receive(:compute_and_upsert_all_records!)
 
-        create(:student_performance_record,
+        FactoryBot.create(:student_performance_record,
                lecture: lecture, user: user,
                computed_at: 1.hour.ago)
 
-        create(:student_performance_certification, :passed,
+        FactoryBot.create(:student_performance_certification, :passed,
                lecture: lecture, user: user,
                certified_by: certifier,
                certified_at: 2.hours.ago)
@@ -56,11 +56,11 @@ RSpec.describe(CertificationStaleCheckJob, type: :worker) do
           .to receive(:new).with(lecture: lecture).and_return(service)
         allow(service).to receive(:compute_and_upsert_all_records!)
 
-        create(:student_performance_record,
+        FactoryBot.create(:student_performance_record,
                lecture: lecture, user: user,
                computed_at: 2.hours.ago)
 
-        create(:student_performance_certification, :passed,
+        FactoryBot.create(:student_performance_certification, :passed,
                lecture: lecture, user: user,
                certified_by: certifier,
                certified_at: 1.hour.ago)

--- a/spec/workers/certification_stale_check_job_spec.rb
+++ b/spec/workers/certification_stale_check_job_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe(CertificationStaleCheckJob, type: :worker) do
         allow(service).to receive(:compute_and_upsert_all_records!)
 
         FactoryBot.create(:student_performance_record,
-               lecture: lecture, user: user,
-               computed_at: 1.hour.ago)
+                          lecture: lecture, user: user,
+                          computed_at: 1.hour.ago)
 
         FactoryBot.create(:student_performance_certification, :passed,
-               lecture: lecture, user: user,
-               certified_by: certifier,
-               certified_at: 2.hours.ago)
+                          lecture: lecture, user: user,
+                          certified_by: certifier,
+                          certified_at: 2.hours.ago)
       end
 
       it "logs stale certifications" do
@@ -57,13 +57,13 @@ RSpec.describe(CertificationStaleCheckJob, type: :worker) do
         allow(service).to receive(:compute_and_upsert_all_records!)
 
         FactoryBot.create(:student_performance_record,
-               lecture: lecture, user: user,
-               computed_at: 2.hours.ago)
+                          lecture: lecture, user: user,
+                          computed_at: 2.hours.ago)
 
         FactoryBot.create(:student_performance_certification, :passed,
-               lecture: lecture, user: user,
-               certified_by: certifier,
-               certified_at: 1.hour.ago)
+                          lecture: lecture, user: user,
+                          certified_by: certifier,
+                          certified_at: 1.hour.ago)
       end
 
       it "does not log anything about staleness" do

--- a/spec/workers/performance_record_update_job_spec.rb
+++ b/spec/workers/performance_record_update_job_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe(PerformanceRecordUpdateJob, type: :worker) do
-  let(:lecture) { create(:lecture, :released_for_all) }
-  let(:user) { create(:confirmed_user) }
+  let(:lecture) { FactoryBot.create(:lecture, :released_for_all) }
+  let(:user) { FactoryBot.create(:confirmed_user) }
 
   before do
-    create(:lecture_membership, user: user, lecture: lecture)
+    FactoryBot.create(:lecture_membership, user: user, lecture: lecture)
   end
 
   describe "#perform" do
@@ -22,10 +22,10 @@ RSpec.describe(PerformanceRecordUpdateJob, type: :worker) do
     end
 
     context "without user_id" do
-      let(:user2) { create(:confirmed_user) }
+      let(:user2) { FactoryBot.create(:confirmed_user) }
 
       before do
-        create(:lecture_membership, user: user2, lecture: lecture)
+        FactoryBot.create(:lecture_membership, user: user2, lecture: lecture)
       end
 
       it "computes records for all lecture members" do

--- a/spec/workers/performance_record_update_job_spec.rb
+++ b/spec/workers/performance_record_update_job_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe(PerformanceRecordUpdateJob, type: :worker) do
+  let(:lecture) { create(:lecture, :released_for_all) }
+  let(:user) { create(:confirmed_user) }
+
+  before do
+    create(:lecture_membership, user: user, lecture: lecture)
+  end
+
+  describe "#perform" do
+    context "with user_id" do
+      it "computes a record for the given user" do
+        described_class.new.perform(lecture.id, user.id)
+
+        record = StudentPerformance::Record.find_by(
+          lecture: lecture, user: user
+        )
+        expect(record).to be_present
+        expect(record.computed_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context "without user_id" do
+      let(:user2) { create(:confirmed_user) }
+
+      before do
+        create(:lecture_membership, user: user2, lecture: lecture)
+      end
+
+      it "computes records for all lecture members" do
+        described_class.new.perform(lecture.id)
+
+        expect(
+          StudentPerformance::Record.where(lecture: lecture).count
+        ).to eq(2)
+      end
+    end
+
+    it "delegates to ComputationService for single user" do
+      service = instance_double(StudentPerformance::ComputationService)
+      allow(StudentPerformance::ComputationService)
+        .to receive(:new).with(lecture: lecture).and_return(service)
+      expect(service).to receive(:compute_and_upsert_record_for).with(user)
+
+      described_class.new.perform(lecture.id, user.id)
+    end
+
+    it "delegates to ComputationService for full lecture" do
+      service = instance_double(StudentPerformance::ComputationService)
+      allow(StudentPerformance::ComputationService)
+        .to receive(:new).with(lecture: lecture).and_return(service)
+      expect(service).to receive(:compute_and_upsert_all_records!)
+
+      described_class.new.perform(lecture.id)
+    end
+  end
+
+  describe "sidekiq_options" do
+    it "uses the default queue" do
+      expect(described_class.sidekiq_options["queue"]).to eq(:default)
+    end
+
+    it "retries 3 times" do
+      expect(described_class.sidekiq_options["retry"]).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Step 10.2 backend for Student Performance computation. It

- introduces `ComputationService` to aggregate assessment points and materialize per-user performance records
- adds `Evaluator` for rule-based performance checks
- adds background jobs to update records and mark stale certifications
- extends performance records with assessment count fields (`total`/`reviewed`/`pending`/`exempt`)
