### PR TITLE
Fix debug test command in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,7 +74,7 @@
     },
     "rubyLsp.addonSettings": {
         "Ruby LSP RSpec": {
-            "rspecCommand": "VITE_RUBY_PORT=3036 RAILS_ENV=test bundle exec rspec --format documentation"
+            "rspecCommand": "env VITE_RUBY_PORT=3036 RAILS_ENV=test bundle exec rspec --format documentation"
         }
     },
     "testing.coverageToolbarEnabled": true,


### PR DESCRIPTION
For our RSpec unit tests, Ruby LSP provides a debug feature that uses the command we specify in `rspecCommand` in the VSCode settings. Previously, one couldn't use this as the debug command interpreted the `VITE_RUBY_PORT` as executable program and thus failed. I put `env` in front of it to make it work.

<img width="683" height="93" alt="image" src="https://github.com/user-attachments/assets/838b2440-0600-4bbd-b711-1545463ecab9" />