### PR TITLE
Add unique constraints for joins & make concurrency-safe

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -42,7 +42,8 @@ class Tutorial < ApplicationRecord
   end
 
   def add_tutor(tutor)
-    tutors << tutor unless tutors.include?(tutor)
+    tutor_tutorial_joins.create_or_find_by(tutor: tutor)
+                        .previously_new_record?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -594,11 +594,9 @@ class User < ApplicationRecord
 
   def subscribe_lecture!(lecture)
     return false unless lecture.is_a?(Lecture)
-    return false if lecture.in?(lectures)
 
-    lectures << lecture
-
-    true
+    lecture_user_joins.create_or_find_by(lecture: lecture)
+                      .previously_new_record?
   end
 
   def unsubscribe_lecture!(lecture)

--- a/db/migrate/20260403000000_add_missing_unique_constraints_to_joins.rb
+++ b/db/migrate/20260403000000_add_missing_unique_constraints_to_joins.rb
@@ -1,0 +1,19 @@
+class AddMissingUniqueConstraintsToJoins < ActiveRecord::Migration[8.0]
+  def up
+    LectureUserJoin
+      .where.not(id: LectureUserJoin.select("MIN(id)").group(:lecture_id, :user_id))
+      .delete_all
+
+    TutorTutorialJoin
+      .where.not(id: TutorTutorialJoin.select("MIN(id)").group(:tutorial_id, :tutor_id))
+      .delete_all
+
+    add_index :lecture_user_joins, [:lecture_id, :user_id], unique: true
+    add_index :tutor_tutorial_joins, [:tutorial_id, :tutor_id], unique: true
+  end
+
+  def down
+    remove_index :lecture_user_joins, [:lecture_id, :user_id]
+    remove_index :tutor_tutorial_joins, [:tutorial_id, :tutor_id]
+  end
+end

--- a/db/migrate/20260403000000_add_missing_unique_constraints_to_joins.rb
+++ b/db/migrate/20260403000000_add_missing_unique_constraints_to_joins.rb
@@ -1,12 +1,23 @@
 class AddMissingUniqueConstraintsToJoins < ActiveRecord::Migration[8.0]
   def up
+    # not executed, as the count is 0 in our production DB
+    # LectureUserJoin.where(lecture_id: nil).or(
+    #   LectureUserJoin.where(user_id: nil)
+    # ).delete_all
+
     LectureUserJoin
       .where.not(id: LectureUserJoin.select("MIN(id)").group(:lecture_id, :user_id))
       .delete_all
 
-    TutorTutorialJoin
-      .where.not(id: TutorTutorialJoin.select("MIN(id)").group(:tutorial_id, :tutor_id))
-      .delete_all
+    # not executed, as the count is 0 in our production DB
+    # TutorTutorialJoin
+    #   .where.not(id: TutorTutorialJoin.select("MIN(id)").group(:tutorial_id, :tutor_id))
+    #   .delete_all
+
+    change_column_null :lecture_user_joins, :lecture_id, false
+    change_column_null :lecture_user_joins, :user_id, false
+    # the tutorial_id and tutor_id columns already have NOT NULL constraints,
+    # so we don't need to change them
 
     add_index :lecture_user_joins, [:lecture_id, :user_id], unique: true
     add_index :tutor_tutorial_joins, [:tutorial_id, :tutor_id], unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_24_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_03_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -316,6 +316,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_24_000000) do
     t.bigint "user_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["lecture_id", "user_id"], name: "index_lecture_user_joins_on_lecture_id_and_user_id", unique: true
     t.index ["lecture_id"], name: "index_lecture_user_joins_on_lecture_id"
     t.index ["user_id"], name: "index_lecture_user_joins_on_user_id"
   end
@@ -932,6 +933,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_24_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tutor_id"], name: "index_tutor_tutorial_joins_on_tutor_id"
+    t.index ["tutorial_id", "tutor_id"], name: "index_tutor_tutorial_joins_on_tutorial_id_and_tutor_id", unique: true
     t.index ["tutorial_id"], name: "index_tutor_tutorial_joins_on_tutorial_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,8 +312,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_03_000000) do
   end
 
   create_table "lecture_user_joins", force: :cascade do |t|
-    t.bigint "lecture_id"
-    t.bigint "user_id"
+    t.bigint "lecture_id", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["lecture_id", "user_id"], name: "index_lecture_user_joins_on_lecture_id_and_user_id", unique: true

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -41,4 +41,18 @@ RSpec.describe(Tutorial, type: :model) do
 
     it_behaves_like "a registerable model"
   end
+
+  describe "#add_tutor" do
+    it "creates at most one join under concurrent calls" do
+      tutorial = create(:tutorial)
+      tutor = create(:confirmed_user)
+
+      values = run_concurrently do
+        Tutorial.find(tutorial.id).add_tutor(User.find(tutor.id))
+      end
+
+      expect(values).to contain_exactly(true, false)
+      expect(TutorTutorialJoin.where(tutorial: tutorial, tutor: tutor).count).to eq(1)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,4 +189,18 @@ RSpec.describe(User, type: :model) do
       expect(user.registration_campaigns).to include(campaign)
     end
   end
+
+  describe "#subscribe_lecture!" do
+    it "creates at most one join under concurrent calls" do
+      user = create(:confirmed_user)
+      lecture = create(:lecture)
+
+      values = run_concurrently do
+        User.find(user.id).subscribe_lecture!(Lecture.find(lecture.id))
+      end
+
+      expect(values).to contain_exactly(true, false)
+      expect(LectureUserJoin.where(user: user, lecture: lecture).count).to eq(1)
+    end
+  end
 end

--- a/spec/support/concurrent_invocation_helper.rb
+++ b/spec/support/concurrent_invocation_helper.rb
@@ -1,0 +1,29 @@
+module ConcurrentInvocationHelper
+  def run_concurrently(thread_count: 2)
+    ready = Queue.new
+    start = Queue.new
+    results = Queue.new
+
+    threads = Array.new(thread_count) do
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          start.pop
+          results << yield
+        rescue StandardError => e
+          results << e
+        end
+      end
+    end
+
+    thread_count.times { ready.pop }
+    thread_count.times { start << true }
+    threads.each(&:join)
+
+    Array.new(thread_count) { results.pop }
+  end
+end
+
+RSpec.configure do |config|
+  config.include ConcurrentInvocationHelper
+end

--- a/spec/support/concurrent_invocation_helper.rb
+++ b/spec/support/concurrent_invocation_helper.rb
@@ -1,4 +1,8 @@
+# Helper for running synchronized concurrent invocations in specs.
+
 module ConcurrentInvocationHelper
+  # Runs the given block concurrently in `thread_count` threads,
+  # synchronizing start time and returning all results (or raised exceptions).
   def run_concurrently(thread_count: 2)
     ready = Queue.new
     start = Queue.new


### PR DESCRIPTION
This PR addresses potential race conditions and ensures data integrity when creating join records between Users/Lectures, and Tutors/Tutorials.

- Add new unique constraints at DB level
- Update model methods to be concurrency-safe
- Add new concurrency test helper
