### PR TITLE
Architecture book: Update docs to reflect actual code

### DIFF
--- a/architecture/src/features/02-registration.md
+++ b/architecture/src/features/02-registration.md
@@ -31,10 +31,10 @@ We use a unified system with:
 - **Allocation mode:** Enum selecting `first_come_first_served` or `preference_based`.
 - **AllocationService:** Computes allocations (preference-based) via `allocate!`.
 - **AllocationMaterializer:** Applies confirmed allocations to domain rosters.
-- **Campaign methods:** `allocate!`, `finalize!`, `allocate_and_finalize!`.
+- **Campaign methods:** `finalize!`, `reset_allocation_results!`, `unassigned_users(...)`.
 - **Policy phases:** `registration` gates intake; `finalization` gates roster materialization; `both` applies in both places.
 - **Assigned users:** Users with `confirmed` status in the registration system (`Registration::UserRegistration.confirmed`). This is registration-side data.
-- **Allocated users:** Users materialized into the domain roster after finalization (`Tutorial#students`, `Talk#speakers`, etc.). This is domain-side data. After finalization, assigned and allocated should match.
+- **Allocated users:** Users materialized into the domain roster after finalization (`Tutorial#members`, `Talk#speakers`, `Cohort#members`, etc.). This is domain-side data. After finalization, assigned and allocated should match.
 ```
 
 ```admonish tip "Related UI mockups"
@@ -62,21 +62,21 @@ We recommend that users follow one of these patterns based on their course struc
 Use this when your lecture has sub-structures (Tutorials or Talks) that need assignment.
 - **Primary Campaign:** Items are **Tutorials** or **Talks**.
     - *Outcome:* Students get a group spot AND official Lecture Roster access (via propagation).
-- **Sidecar Campaign (Optional):** Item is a **Cohort** with `purpose: :general` (e.g., "Waitlist").
+- **Sidecar Campaign (Optional):** Item is a **Cohort** with `propagate_to_lecture: false` (e.g., "Waitlist").
     - *Outcome:* Students land on a separate waitlist. They **do not** get official access until staff moves them to a group.
 
 ### Pattern 2: Enrollment Cohort (Simple Courses)
 Use this when your lecture has no sub-structures (e.g., Advanced Lecture, simple Seminar).
-- **Primary Campaign:** Item is an **Enrollment Cohort** (`purpose: :enrollment`, `propagate_to_lecture: true`).
+- **Primary Campaign:** Item is a **Cohort** with `propagate_to_lecture: true`.
     - *Outcome:* Students join the cohort AND get official Lecture Roster access (via propagation).
 - **Quick-Create:** Use the "Enable Simple Enrollment" button in Roster Overview or campaign item creation.
-    - *Outcome:* Creates the enrollment cohort automatically with correct settings.
+  - *Outcome:* Creates a cohort with propagation enabled.
 
 ### Pattern 3: Planning Cohorts (Demand Forecasting)
 Use this to gauge interest before the semester starts without granting access.
-- **Primary Campaign:** Item is a **Planning Cohort** (`purpose: :planning`, `propagate_to_lecture: false`).
+- **Primary Campaign:** Item is a **Cohort** with `propagate_to_lecture: false`.
     - *Outcome:* Students signal interest. No lecture access granted. Results used for staffing decisions.
-- **Repeatable:** Multiple planning cohorts can exist per lecture (unlike enrollment cohorts).
+- **Repeatable:** Multiple non-propagating cohorts can exist per lecture.
     - *Outcome:* Run surveys in October, November, etc. without conflicts.
 
 > **Note:** These patterns can be mixed in one campaign. Tutorial + Waitlist Cohort, or Talk + Audit Cohort are valid combinations.
@@ -101,28 +101,30 @@ The main fields and methods of `Registration::Campaign` are:
 |---------------------------|-------------------|----------------------------------------------------------------------------------------------|
 | `campaignable_type`       | DB column         | Polymorphic type for the campaign host (e.g., Lecture)                                     |
 | `campaignable_id`         | DB column         | Polymorphic ID for the campaign host                                                         |
-| `title`                   | DB column         | Human-readable campaign title                                                                 |
+| `description`             | DB column         | Human-readable campaign description                                                           |
 | `allocation_mode`         | DB column (Enum)  | Registration mode: `first_come_first_served` or `preference_based`                            |
 | `status`                  | DB column (Enum)  | Campaign state: `draft`, `open`, `closed`, `processing`, `completed`                        |
 | `registration_deadline`   | DB column         | Deadline for user registrations (registration requests)                                      |
+| `last_allocation_calculated_at` | DB column   | Timestamp of the most recent allocation run                                                  |
 | `registration_items`      | Association       | Items available for registration within this campaign                                        |
 | `user_registrations`      | Association       | User registrations (registration requests) for this campaign                                 |
 | `registration_policies`   | Association       | Eligibility and other policies attached to this campaign                                     |
 | `evaluate_policies_for(user, phase: :registration)` | Method      | Returns a structured eligibility result for the given phase (delegates to Policy Engine)                         |
 | `policies_satisfied?(user, phase: :registration)` | Method      | Boolean convenience that returns true when all applicable policies pass                                 |
 | `open_for_registrations?` | Method            | Returns true if campaign is currently accepting registrations                                 |
-| `allocate!`               | Method            | Computes allocation (preference-based) without materialization                               |
-| `finalize!`               | Method            | Enforces finalization-phase policies, then materializes the latest allocation into domain rosters                                       |
-| `allocate_and_finalize!`  | Method            | Convenience: computes allocation and then finalizes                                          |
+| `finalize!`               | Method            | Materializes confirmed results, normalizes remaining `pending` registrations to `rejected`, and marks the campaign completed |
+| `reset_allocation_results!` | Method          | Clears prior allocation output when a preference-based campaign is reopened                   |
+| `unassigned_users(preload_registrations: false)` | Method | Returns participating users who are not currently allocated to any matching registerable      |
 
 ```admonish note
 Eligibility is not a single field or method, but is determined dynamically by evaluating all active `registration_policies` for the campaign using the `evaluate_policies_for(user, phase:)` method, which delegates to the phase-aware policy engine. Use `policies_satisfied?(user, phase:)` as a boolean convenience.
 ```
 
 ```admonish tip "API at a glance"
-- `evaluate_policies_for(user, phase: :registration)` → Result (fields: `pass`, `failed_policy`, `trace`, `details`)
+- `evaluate_policies_for(user, phase: :registration)` → Result (fields: `pass`, `failed_policy`, `trace`)
 - `policies_satisfied?(user, phase: :registration)` → Boolean (`true` when all applicable policies pass)
 - `open_for_registrations?` → Boolean (campaign currently accepts registrations)
+- Allocation runs are triggered through `Registration::AllocationService` and the allocation controller flow
 
  See also: Controller endpoints in [Controller Architecture → Registration Controllers](11-controllers.md#registration-controllers).
 ```
@@ -137,14 +139,14 @@ Eligibility is not a single field or method, but is determined dynamically by ev
 #### Assigned vs Unassigned
 
 - Assigned: the student has exactly one `confirmed` `Registration::UserRegistration` in the campaign after allocation/close.
-- Unassigned: the student participated (has registrations) but has zero `confirmed` entries. On close/finalization, any remaining `pending` entries are normalized to `rejected` so the state is explicit.
+- Unassigned: in current campaign helper methods, the student participated but is not currently allocated to any of the campaign's registerables in the domain roster. This can differ from pure registration status after manual roster changes.
 - Previously Assigned: the student was once assigned (confirmed) but later removed (e.g. manually). This is tracked via the `materialized_at` timestamp on `Registration::UserRegistration`.
-- No extra tables are required. Helper methods on `Registration::Campaign` can expose `unassigned_user_ids`, `unassigned_users`, and `unassigned_count` computed from `UserRegistration` records.
+- No extra tables are required. `Registration::Campaign` exposes `unassigned_users(...)`, while allocation dashboards derive `unassigned_user_ids` and related counts from allocation statistics.
 
 ```admonish note "Status semantics"
 Statuses are mode-specific:
 - First-come-first-served (FCFS): registrations are immediately `confirmed` or `rejected`.
-- Preference-based: registrations are `pending` until allocation, then resolved to `confirmed` or `rejected` on finalize.
+- Preference-based: registrations start as `pending`; allocation confirms selected users, and finalization converts any remaining `pending` registrations to `rejected`.
 
 Do not overload `pending` to represent eligibility uncertainty in FCFS; use policy `details` (e.g., `stability`) purely for UI messaging.
 ```
@@ -153,11 +155,11 @@ Do not overload `pending` to represent eligibility uncertainty in FCFS; use poli
 
 - **Close registration:** stops intake and edits; transitions `open → closed`.
   Used to lock the window early or when the deadline passes automatically.
-- **Run allocation (preference-based only):** triggers solver; transitions `closed → processing`.
+- **Run allocation (preference-based only):** triggers `Registration::AllocationService`; transitions `closed → processing` and records `last_allocation_calculated_at`.
   FCFS campaigns skip this step (results already determined).
-- **Finalize results:** before materialization, evaluates all active policies whose phase is `finalization` or `both` for each confirmed user (via a `Registration::FinalizationGuard`). A `student_performance` policy in finalization phase requires `Certification=passed` for all confirmed users. If any user fails a finalization-phase policy (or has missing/pending certification) the process aborts and status remains `processing` (or `closed` for FCFS) for remediation. After passing guards, materializes confirmed results and transitions to `completed`. All campaigns materialize—planning cohorts simply don't propagate to the lecture roster.
+- **Finalize results:** in the current implementation, the controller runs `Registration::FinalizationGuard#check(...)` before calling `Registration::Campaign#finalize!`. Finalization materializes confirmed results, sets `materialized_at` for materialized registrations, converts remaining `pending` registrations to `rejected`, and transitions the campaign to `completed`. All campaigns materialize—non-propagating cohorts simply do not update the lecture roster.
   - **Materialization Timestamp:** During finalization, the `materialized_at` timestamp is set on the `Registration::UserRegistration` records of all confirmed users. This timestamp serves as a permanent record that the user was successfully allocated, even if they are later removed from the domain roster (e.g. manually). This allows the system to distinguish between "fresh" candidates and those who were previously assigned.
-- **Planning surveys:** Planning cohorts (with `propagate_to_lecture: false` and `purpose: :planning`) are used for interest surveys. They go through the full campaign lifecycle including finalization, but don't affect lecture rosters.
+- **Planning surveys:** Non-propagating cohorts (`propagate_to_lecture: false`) can be used for interest surveys. They go through the full campaign lifecycle including finalization, but don't affect lecture rosters.
 - **Lecture performance completeness checks:****
   - **Campaign save:** Warns if any students lack certifications (any phase with student_performance policy)
   - **Campaign open:** Hard-fails if any students have missing/pending certifications (registration or both phase)
@@ -196,7 +198,6 @@ Campaigns transition through several states to ensure data integrity and fair us
 | Attribute | Freeze Point | Modification Rules |
 |-----------|--------------|-------------------|
 | `allocation_mode` | After `draft` | Cannot change once opened. Students make decisions based on mode (early registration for FCFS vs. preference ranking). |
-| `registration_opens_at` | After `draft` | Cannot change once opened. Opening time is in the past. |
 | `registration_deadline` | Never | Can be extended anytime. Shortening is allowed but discouraged (confusing UX). |
 
 ##### Policies
@@ -210,14 +211,14 @@ Campaigns transition through several states to ensure data integrity and fair us
 | Action | Freeze Point | Modification Rules |
 |--------|--------------|-------------------|
 | Add item | Never | Can always add new items. Gives students more options without invalidating existing choices. |
-| Remove item | After `draft` | Cannot remove items with existing registrations. Students may have registered for (FCFS) or ranked (preference) that item. |
+| Remove item | After `draft` | Current implementation only allows item removal while the campaign is still `draft`. |
 
 ##### Capacity Constraints
 
 | Mode | Modification Rules |
 |------|-------------------|
 | FCFS | Can increase anytime. Can decrease only if `new_capacity >= confirmed_count` for that item. |
-| Preference-based | Can increase anytime. Can decrease only if `new_capacity >= confirmed_count` for that item. |
+| Preference-based | Can increase anytime. Current implementation does not enforce the same lower-bound validation outside FCFS; staff should avoid shrinking below already confirmed allocations. |
 
 During solver execution (~1 second), capacity modification is prevented via database row-level locks. See "Solver Execution Protection" above.
 
@@ -229,7 +230,7 @@ During solver execution (~1 second), all registerables (tutorials/talks/cohorts)
 
 #### Implementation Notes
 
-**Validation Example:**
+**Illustrative Validation Example:**
 ```ruby
 validate :allocation_mode_frozen_after_open, on: :update
 validate :policies_frozen_after_open, on: :update
@@ -243,8 +244,8 @@ end
 ```
 
 **Item Removal:**
-- Check `item.user_registrations.exists?` before allowing deletion
-- Alternative: Soft-delete (set `active: false`) instead of destroying
+- Current implementation blocks item removal outside `draft`
+- Alternative future approach: Soft-delete (set `active: false`) instead of destroying
 
 **UI Feedback:**
 - Disable/gray out frozen fields in forms
@@ -252,10 +253,12 @@ end
 - Display warning before opening campaign: "Settings will be locked after opening"
 
 ```admonish warning "Reopening Campaigns"
-When reopening a `completed` campaign (transitioning back to `open`), all freezing rules still apply. The campaign returns to accepting registrations, but fundamental settings (mode, policies, items) remain locked.
+Current implementation does not allow reopening a `completed` campaign. Reopening is only available before completion, and preference-based campaigns reset allocation results when reopening from `processing`.
 ```
 
-### Example Implementation (Phase-aware planned state)
+### Example Implementation (Illustrative planned state)
+
+The following sketch is intentionally illustrative. The current implementation splits allocation and finalization responsibilities between `Registration::Campaign`, `Registration::AllocationService`, `Registration::FinalizationGuard`, and the registration controllers.
 
 ```ruby
 module Registration
@@ -329,8 +332,8 @@ Student Registration index.
 
 - A **"Tutorial Registration" campaign** is created for a `Lecture`. It's `preference_based` and allows students to rank their preferred tutorial slots. Items point to `Tutorial`. (Admin UI: [Tutorial Show (open)](../mockups/campaigns_show_tutorial_open.html); Student UI: [Show – preference-based](../mockups/student_registration.html), [Confirmation](../mockups/student_registration_confirmation.html))
 - A **"Talk Assignment" campaign** is created for a `Lecture` (often a seminar). It's `preference_based` or `first_come_first_served` and assigns talk slots. Items point to `Talk`.
-- An **"Enrollment Campaign" ** is created for a `Lecture` (simple courses without tutorials). It's typically `first_come_first_served` and enrolls students via an enrollment cohort (`purpose: :enrollment`, propagates to lecture). (Student UI: [Show – FCFS](../mockups/student_registration_fcfs.html))
-- A **"Demand Survey" campaign** is created for a `Lecture` before the term to gauge interest. Items point to a planning cohort (`purpose: :planning`, `propagate_to_lecture: false`). Campaign finalizes normally, but cohort membership doesn't grant lecture access. Results used for staffing decisions. (Admin UI: [Interest Show (draft)](../mockups/campaigns_show_interest_draft.html))
+- An **"Enrollment Campaign" ** is created for a `Lecture` (simple courses without tutorials). It's typically `first_come_first_served` and enrolls students via a cohort with `propagate_to_lecture: true`. (Student UI: [Show – FCFS](../mockups/student_registration_fcfs.html))
+- A **"Demand Survey" campaign** is created for a `Lecture` before the term to gauge interest. Items point to a cohort with `propagate_to_lecture: false`. Campaign finalizes normally, but cohort membership doesn't grant lecture access. Results used for staffing decisions. (Admin UI: [Interest Show (draft)](../mockups/campaigns_show_interest_draft.html))
 - An **"Exam Registration" campaign** is created for an `Exam`. It is `first_come_first_served` and may include a `student_performance` policy (phase: `registration` or `both`) for advisory eligibility messaging; finalization enforces Certification=passed only if a finalization-phase `student_performance` policy exists. Items point to `Exam`. (Admin UI: [Exam Show](../mockups/campaigns_show_exam.html); Student UI: [Show – exam (FCFS)](../mockups/student_registration_fcfs_exam.html); see also [action required: institutional email](../mockups/student_registration_fcfs_exam_action_required_email.html))
 
 ---
@@ -342,14 +345,14 @@ Goal: Measure demand before a lecture starts to plan staffing (e.g., hire
 tutors) without granting lecture access.
 
 - Host: `Lecture` (campaignable).
-- Items: Planning cohort with `purpose: :planning`, `propagate_to_lecture: false`.
+- Items: Cohort with `propagate_to_lecture: false`.
 - Mode: `first_come_first_served`.
 - Capacity: Very high (effectively unlimited) to capture demand signal.
 - Timing: Open well before the term; close before main registrations.
 - Finalization: Campaign finalizes normally. Cohort roster is materialized but doesn't propagate to lecture.
 - Reporting: Query `cohort.cohort_memberships` for confirmed participants.
 - Cleanup: Planning cohorts can be deleted after export (collapsed by default in roster UI).
-- Repeatable: Multiple planning cohorts allowed per lecture (e.g., "Oct Survey", "Nov Survey").
+- Repeatable: Multiple non-propagating cohorts allowed per lecture (e.g., "Oct Survey", "Nov Survey").
 
 See the Roster chapter for how planning cohorts appear collapsed in the "Without Enrollment" section.
 ```
@@ -402,7 +405,7 @@ if tutorial.can_self_add?(current_user)
 end
 ```
 
-See the `Roster::Rosterable` concern in Rosters chapter (`03-rosters.md`) for implementation details.
+See the `Rosters::Rosterable` concern in Rosters chapter (`03-rosters.md`) for implementation details.
 
 ---
 
@@ -454,9 +457,9 @@ A selectable entry in a `Registration::Campaign`'s "catalog". Each entry points 
 ```
 
 ```admonish note "Think of it as"
-- **Restaurant Analogy:** An item on a restaurant menu. The `Registerable` is the actual dish prepared in the kitchen. The `RegistrationItem` is the line on the menu for a specific day (the campaign). You order from the menu, not by pointing at the dish in the kitchen.
+- **Restaurant Analogy:** An item on a restaurant menu. The `Registerable` is the actual dish prepared in the kitchen. The `Registration::Item` is the line on the menu for a specific day (the campaign). You order from the menu, not by pointing at the dish in the kitchen.
 
-- **Teaching Analogy:** A slot in the registration system. The `Registerable` is the actual tutorial group that meets every Monday at 10am. The `RegistrationItem` is the entry for that tutorial in this semester's "Linear Algebra" registration (the campaign). Students sign up for the slot in the system, not by walking into the classroom.
+- **Teaching Analogy:** A slot in the registration system. The `Registerable` is the actual tutorial group that meets every Monday at 10am. The `Registration::Item` is the entry for that tutorial in this semester's "Linear Algebra" registration (the campaign). Students sign up for the slot in the system, not by walking into the classroom.
 ```
 
 The main fields and methods of `Registration::Item` are:
@@ -469,7 +472,8 @@ The main fields and methods of `Registration::Item` are:
 | `registration_campaign`   | Association       | The parent `Registration::Campaign`.                                      |
 | `registerable`            | Association       | The underlying domain object (e.g., a `Tutorial` instance).              |
 | `user_registrations`      | Association       | All user registrations (registration requests) for this item.            |
-| `assigned_users`          | Method            | Returns users with confirmed registration (registration system data).    |
+| `confirmed_registrations_count` | DB column   | Counter cache for confirmed registrations on this item                    |
+| `confirmed_user_ids`      | Method            | Returns user IDs with confirmed registration (registration system data). |
 | `capacity`                | Method            | The maximum number of users, delegated from the `registerable`.          |
 
 
@@ -483,8 +487,8 @@ module Registration
              class_name: "Registration::UserRegistration",
              dependent: :destroy
 
-    def assigned_users
-      user_registrations.confirmed.includes(:user).map(&:user)
+    def confirmed_user_ids
+      user_registrations.confirmed.pluck(:user_id)
     end
   end
 end
@@ -497,12 +501,12 @@ To ensure data integrity and prevent double-booking, the following constraint ap
 - **Global Uniqueness:** Any registerable (e.g., `Tutorial`, `Talk`, `Cohort`, or `Exam`) can be in **at most one** `Registration::Campaign`.
 
 ### Usage Scenarios
-- **For a "Tutorial Registration" campaign:** A `RegistrationItem` is created for each `Tutorial` (e.g., "Tutorial A (Mon 10:00)"). The `registerable` association points to the `Tutorial` record.
-- **For a "Talk Assignment" campaign:** A `RegistrationItem` is created for each `Talk` (e.g., "Talk: Machine Learning Advances"). The `registerable` association points to the `Talk` record.
-- **For an "Enrollment Campaign" (simple courses):** A `RegistrationItem` is created for an enrollment cohort (`purpose: :enrollment`). The cohort propagates to the lecture roster automatically.
-- **For a "Demand Survey" campaign:** A `RegistrationItem` is created for a planning cohort (`purpose: :planning`). The cohort does not propagate to the lecture roster.
-- **For a "Waitlist" or special group:** A `RegistrationItem` is created for a general cohort (`purpose: :general`). Propagation is configurable.
-- **For an "Exam Registration" campaign:** A `RegistrationItem` is created for the exam itself. The `registerable` association points to the `Exam` record. The campaign's `campaignable` is the parent `Lecture`. Each exam (Hauptklausur, Nachklausur, Wiederholungsklausur) gets its own campaign hosted by the lecture, with that exam as the sole registerable item.
+- **For a "Tutorial Registration" campaign:** A `Registration::Item` is created for each `Tutorial` (e.g., "Tutorial A (Mon 10:00)"). The `registerable` association points to the `Tutorial` record.
+- **For a "Talk Assignment" campaign:** A `Registration::Item` is created for each `Talk` (e.g., "Talk: Machine Learning Advances"). The `registerable` association points to the `Talk` record.
+- **For an "Enrollment Campaign" (simple courses):** A `Registration::Item` is created for a cohort with `propagate_to_lecture: true`. The cohort propagates to the lecture roster automatically.
+- **For a "Demand Survey" campaign:** A `Registration::Item` is created for a cohort with `propagate_to_lecture: false`. The cohort does not propagate to the lecture roster.
+- **For a "Waitlist" or special group:** A `Registration::Item` is created for a cohort. Propagation is controlled by `propagate_to_lecture`.
+- **For an "Exam Registration" campaign:** A `Registration::Item` is created for the exam itself. The `registerable` association points to the `Exam` record. The campaign's `campaignable` is the parent `Lecture`. Each exam (Hauptklausur, Nachklausur, Wiederholungsklausur) gets its own campaign hosted by the lecture, with that exam as the sole registerable item.
 
 ```admonish warning "Registration::Item vs. Registration::Registerable"
 It's crucial to understand the difference between these two concepts:
@@ -511,7 +515,7 @@ It's crucial to understand the difference between these two concepts:
 
 - **`Registration::Item`** is a **proxy or wrapper** that makes a registerable object available within a specific campaign. Think of it as a "listing in a catalog." If you have a "Tutorial Registration" campaign, you create one `Registration::Item` for each `Tutorial` that students can sign up for in that campaign.
 
-Users register for a `Registration::Item`, not directly for a `Registerable`. This separation allows the same `Tutorial` to potentially be part of different campaigns over time without conflict.
+Users register for a `Registration::Item`, not directly for a `Registerable`. This separation keeps registration logic distinct from domain models, while the current implementation still enforces that a given registerable can belong to at most one campaign at a time.
 ```
 
 ---
@@ -543,7 +547,7 @@ The actual group or event a user is enrolled in, such as a specific tutorial gro
 | `capacity`                                  | Integer seat count.                                    | Yes      |
 | `materialize_allocation!(user_ids:, campaign:)` | Persists the authoritative roster for this campaign.   | Yes      |
 | `allocated_user_ids`                        | Current materialized users from domain roster (delegates to roster system). | Yes |
-| `remaining_capacity`, `full?`               | Convenience derived helpers.                           | Optional |
+| `full?`                                     | Convenience helper based on the current roster size.   | Optional |
 
 #### Example Implementation
 
@@ -561,14 +565,6 @@ module Registration
       raise NotImplementedError, "#{self.class} must implement #allocated_user_ids to delegate to roster"
     end
 
-    def remaining_capacity
-      [capacity - allocated_user_ids.size, 0].max
-    end
-
-    def full?
-      remaining_capacity.zero?
-    end
-
     def materialize_allocation!(user_ids:, campaign:)
       raise NotImplementedError, "#{self.class} must implement #materialize_allocation!"
     end
@@ -584,7 +580,7 @@ The `materialize_allocation!` method is the most critical part of the interface.
 
 This method **must be idempotent**, meaning running it multiple times with the same `user_ids` and `campaign` produces the same result. A common pattern is to first remove all roster entries associated with the given `campaign` and then add the new ones, all within a single database transaction. Concrete examples are shown in the `Tutorial` and `Talk` sections later in this document.
 
-The `allocated_user_ids` method **must be implemented** by each registerable model to delegate to its roster system. This returns the current materialized roster (domain data), as opposed to `Registration::Item#assigned_users` which returns users with confirmed registrations (registration system data). After finalization, these should match.
+The `allocated_user_ids` method **must be implemented** by each registerable model to delegate to its roster system. This returns the current materialized roster (domain data), as opposed to the confirmed registrations tracked on `Registration::Item` and `Registration::UserRegistration`. After finalization, these should match.
 
 
 #### Usage Scenarios
@@ -657,7 +653,7 @@ end
 
 In FCFS mode, registration status is determined immediately upon submission:
 
-**Controller Logic (recommended):**
+**Controller Logic (conceptual):**
 ```ruby
 # app/controllers/registration/user_registrations_controller.rb
 def create
@@ -666,7 +662,11 @@ def create
 
   return unless campaign.policies_satisfied?(current_user, phase: :registration)
 
-  status = item.remaining_capacity > 0 ? :confirmed : :rejected
+  status = if item.capacity.nil? || item.confirmed_registrations_count < item.capacity
+    :confirmed
+  else
+    :rejected
+  end
 
   Registration::UserRegistration.create!(
     user: current_user,
@@ -686,10 +686,10 @@ end
 | When decided | Immediately on create | After allocation runs |
 | Multiple items | User registers for ONE item | User ranks MULTIPLE items |
 | Solver needed | No | Yes |
-| Finalization | Optional (roster may already be live) | Required |
+| Finalization | Used to materialize results into domain rosters | Required |
 
 **Capacity Enforcement:**
-- Check `item.remaining_capacity` before creating the registration
+- Compare `item.confirmed_registrations_count` against `item.capacity` before creating the registration
 - If capacity exhausted, create with `status: :rejected` (no waitlist)
 - Alternatively, return error and don't create record at all
 
@@ -892,12 +892,12 @@ An 'eligibility checklist' processor that stops at the first failed check and pr
 | Method           | Purpose                                                              |
 |------------------|----------------------------------------------------------------------|
 | `initialize(campaign)` | Sets up the engine with the campaign whose policies will be used.    |
-| `eligible?(user)`| Evaluates policies for the user and returns a structured `Result`.   |
+| `eligible?(user, phase: :registration)` | Evaluates policies for the user and returns a structured `Result`.   |
 
 ### Behavior Highlights
 - Iterates policies in `position` order.
 - Stops at the first failure (fast fail).
-- Returns a structured `Result` object containing the pass/fail status, the policy that failed (if any), and a full trace of all evaluations.
+- Returns a structured `Result` object containing the pass/fail status, the failed policy (if any), and a full trace of all evaluations.
 - This `Result` object is used by `Registration::Campaign#evaluate_policies_for` to provide clear feedback to the UI.
 
 ```admonish tip "Lecture performance: data completeness requirement"
@@ -962,7 +962,7 @@ The 'brain' that solves the puzzle of who gets what in a preference-based campai
 - Gathers all `pending` `Registration::UserRegistration` records with their preference ranks.
 - Gathers all `Registration::Item` records with their capacities.
 - Executes a specific allocation strategy (e.g., Min-Cost Flow) to find an optimal assignment.
-- Updates the `status` of each `Registration::UserRegistration` to either `:confirmed` or `:rejected` based on the solver's output.
+- Confirms selected registrations, may create forced assignments, refreshes per-item confirmed counters, and records the latest allocation timestamp. Remaining non-selected registrations stay `pending` until finalization.
 
 ### Not Responsibilities
 
@@ -1020,7 +1020,7 @@ end
 ```
 
 ### Usage Scenarios
-- After the deadline for a `preference_based` tutorial registration campaign, a background job calls `Registration::AllocationService.new(campaign).allocate!`. The service runs the solver and updates thousands of `Registration::UserRegistration` records to either `:confirmed` or `:rejected`.
+- After the deadline for a `preference_based` tutorial registration campaign, a background job calls `Registration::AllocationService.new(campaign).allocate!`. The service runs the solver, confirms selected registrations, and leaves non-selected registrations pending until finalization.
 - An administrator manually triggers the assignment for a seminar's talk selection via a button in the UI, which in turn calls this service.
 
 ---
@@ -1044,8 +1044,9 @@ The "secretary" that takes the list of confirmed attendees from the registration
 
 ### Responsibilities
 - Gathers all `confirmed` `Registration::UserRegistration` records for the campaign.
-- Groups them by their `Registration::Item`.
+- Iterates the campaign's `Registration::Item` records and derives the confirmed user IDs for each item.
 - For each `Registration::Item`, it calls `materialize_allocation!` on the underlying `registerable` object, passing the final list of user IDs.
+- Sets `materialized_at` on the registrations that were materialized.
 - This process is the crucial hand-off from the temporary registration system to the permanent domain models.
 
 ### Example Implementation
@@ -1079,14 +1080,14 @@ end
 **_The Finalization Gatekeeper_**
 
 ```admonish info "What it represents"
-Ensures every confirmed user passes all finalization-phase policies before roster materialization. For student_performance policies, enforces certification completeness and auto-rejects failed certifications.
+Ensures every confirmed user passes all finalization-phase policies before roster materialization. Future `student_performance` integration is intended to add certification-specific enforcement here.
 ```
 
 ### Public Interface
 | Method           | Purpose |
 |------------------|---------|
 | `initialize(campaign)` | Prepare guard for a campaign. |
-| `check!`         | Raises on first violation; returns true when all confirmed users pass. Auto-rejects students with failed student performance certifications. |
+| `check(ignore_policies: false)` | Returns a `Result` describing whether finalization may proceed. |
 
 ### Example Implementation
 ```ruby
@@ -1098,14 +1099,17 @@ module Registration
       @campaign = campaign
     end
 
-    def check
+    def check(ignore_policies: false)
       if @campaign.completed?
         return failure(:already_completed, "Campaign is already completed")
       end
 
-      unless @campaign.processing?
-        return failure(:wrong_status, "Campaign must be in processing state")
+      expected_state = @campaign.preference_based? ? @campaign.processing? : @campaign.closed?
+      unless expected_state
+        return failure(:wrong_status, "Campaign must be in a finalizable state")
       end
+
+      return success if ignore_policies
 
       validate_policies
     end
@@ -1158,7 +1162,7 @@ end
 - **Policy Validation:** Checks all policies configured for the `:finalization` phase (or `:both`).
 - **Safety Net:** Ensures that users who might have become ineligible after registration (e.g., changed email) are caught before being added to the roster.
 - **Manual Resolution:** If violations are found, the guard returns a failure result with the list of invalid users. The admin must then manually reject these users or fix the issue before retrying finalization.
-- **State Check:** Ensures the campaign is in the correct state (`processing`) and not already completed.
+- **State Check:** Ensures the campaign is in the correct state (`processing` for preference-based campaigns, `closed` for FCFS campaigns) and not already completed.
 
 See also: Student Performance → Certification and Pre-flight Validation (`05-student-performance.md`).
 
@@ -1226,7 +1230,7 @@ class Tutorial < ApplicationRecord
         # persist them as the official roster for this tutorial, sourced
         # from this specific campaign.
         #
-        # The concrete implementation using the Roster::Rosterable concern is detailed
+        # The concrete implementation using the Rosters::Rosterable concern is detailed
         # in the "Allocation & Rosters" chapter.
     end
 end
@@ -1250,14 +1254,14 @@ class Talk < ApplicationRecord
         # Similar to the Tutorial, this method hands off the final list
         # of speakers to the roster management system.
         #
-        # The concrete implementation using the Roster::Rosterable concern is detailed
+        # The concrete implementation using the Rosters::Rosterable concern is detailed
         # in the "Allocation & Rosters" chapter.
     end
 end
 ```
 
 ### Cohort (New Model)
-**_A Generic Registration Target with Semantic Purpose_**
+**_A Generic Registration Target_**
 
 ```admonish info "What it represents"
 A flexible container for students within a specific context (e.g., enrollment, waitlist, planning survey).
@@ -1266,11 +1270,8 @@ A flexible container for students within a specific context (e.g., enrollment, w
 #### Responsibilities
 - Acts as a `Registerable` target for campaigns where `Tutorial`/`Talk` are not appropriate.
 - Acts as a `Rosterable` container for students.
-- **Purpose-Driven Behavior:** Three semantic types via `purpose` enum:
-  - `:enrollment` — Main entry point for simple courses (replaces direct lecture enrollment). Must propagate.
-  - `:general` — Waitlists, special groups, audit listeners. Propagation configurable.
-  - `:planning` — Demand surveys. Must not propagate.
-- **Propagation Control:** `propagate_to_lecture` flag determines if cohort membership grants lecture access.
+- **Propagation Control:** `propagate_to_lecture` determines if cohort membership grants lecture access.
+- **Campaign vs manual control:** `skip_campaigns` and `self_materialization_mode` govern whether the cohort participates in campaigns or is managed directly through roster maintenance.
 - Supports polymorphic contexts: initially `Lecture`, but designed to support generic `Grouping` containers for non-academic events.
 
 #### Schema
@@ -1278,53 +1279,33 @@ A flexible container for students within a specific context (e.g., enrollment, w
 create_table :cohorts do |t|
   t.references :context, polymorphic: true, null: false
   t.string :title, null: false
-  t.integer :purpose, default: 0, null: false # 0: general, 1: enrollment, 2: planning
-  t.boolean :propagate_to_lecture, default: true, null: false
+  t.text :description
   t.integer :capacity
+  t.boolean :propagate_to_lecture, default: false, null: false
+  t.boolean :skip_campaigns, default: false, null: false
+  t.integer :self_materialization_mode, default: 0, null: false
   t.timestamps
 end
-
-add_check_constraint :cohorts,
-  "NOT (purpose = 2 AND propagate_to_lecture = true)",
-  name: "planning_cohorts_must_not_propagate"
-
-add_check_constraint :cohorts,
-  "NOT (purpose = 1 AND propagate_to_lecture = false)",
-  name: "enrollment_cohorts_must_propagate"
 ```
 
 #### Example Implementation
 ```ruby
 class Cohort < ApplicationRecord
   include Registration::Registerable
-  include Roster::Rosterable
+  include Rosters::Rosterable
 
   belongs_to :context, polymorphic: true
 
-  enum :purpose, { general: 0, enrollment: 1, planning: 2 }
+  attr_readonly :propagate_to_lecture
 
-  validates :propagate_to_lecture, inclusion: {
-    in: [false],
-    if: :planning?,
-    message: "must be false for planning cohorts"
-  }
+  validates :title, presence: true
 
-  validates :propagate_to_lecture, inclusion: {
-    in: [true],
-    if: :enrollment?,
-    message: "must be true for enrollment cohorts"
-  }
-
-  scope :operational, -> { where.not(purpose: :planning) }
-  scope :planning, -> { where(purpose: :planning) }
-
-  def capacity
-    self[:capacity]
+  def roster_entries
+    cohort_memberships
   end
 
-  def materialize_allocation!(user_ids:, campaign:)
-    # Delegates to Rosterable implementation
-    # If propagate_to_lecture is true, also calls context.ensure_roster_membership!(user_ids)
+  def lecture
+    context if context.is_a?(Lecture)
   end
 end
 ```
@@ -1423,6 +1404,7 @@ sequenceDiagram
     actor Job as Background Job
     participant AllocationSvc as Registration::AllocationService
     participant Solver as Registration::Solvers::MinCostFlow
+    participant Guard as Registration::FinalizationGuard
     participant Materializer as Registration::AllocationMaterializer
     participant RegTarget as Registerable (e.g., Tutorial)
 
@@ -1446,17 +1428,20 @@ sequenceDiagram
 
     rect rgb(255, 245, 235)
     note over Job,RegTarget: Allocation & finalization
-    Job->>Campaign: allocate_and_finalize!
-    Campaign->>Campaign: update!(status: :closed)
-    Campaign->>AllocationSvc: new(campaign).allocate!
+    Job->>Campaign: close or auto-close at deadline
+    Job->>AllocationSvc: new(campaign).allocate!
     AllocationSvc->>Solver: new(campaign).run()
-    note right of Solver: Build graph, solve, persist statuses
-    Solver->>UserReg: update_all(status: confirmed/rejected)
-    Campaign->>Campaign: update!(status: :processing)
-    Campaign->>Campaign: finalize!
+    note right of Solver: Build graph, solve, confirm selected registrations
+    Solver->>UserReg: update selected rows to confirmed
+    AllocationSvc->>Campaign: touch(last_allocation_calculated_at), update!(status: :processing)
+    Controller->>Campaign: request finalization
+    Controller->>Guard: check(ignore_policies: false)
+    Guard-->>Controller: Result(success?: true/false)
+    Controller->>Campaign: finalize!
     Campaign->>Materializer: new(campaign).materialize!
     Materializer->>RegTarget: materialize_allocation!(user_ids, campaign)
     note right of RegTarget: Update roster (idempotent)
+    Campaign->>UserReg: update remaining pending rows to rejected
     Campaign->>Campaign: update!(status: :completed)
     end
 ```
@@ -1567,10 +1552,11 @@ sequenceDiagram
     alt finalization policies fail
         Campaign-->>Controller: Error (stays in :processing)
     else finalization policies pass
-        Campaign->>Item: materialize_allocation!(confirmed_user_ids)
-        Item->>Roster: Update domain roster
-        Roster-->>Item: Done
-        Item-->>Campaign: Done
+        Campaign->>Materializer: new(campaign).materialize!
+        Materializer->>RegTarget: materialize_allocation!(confirmed_user_ids, campaign)
+        RegTarget->>Roster: Update domain roster
+        Roster-->>RegTarget: Done
+        RegTarget-->>Campaign: Done
         Campaign->>Campaign: update!(status: :completed)
         Campaign-->>Controller: Success
     end

--- a/architecture/src/features/03-rosters.md
+++ b/architecture/src/features/03-rosters.md
@@ -24,31 +24,26 @@ $$ \text{Lecture Roster} = \bigcup_{t \in \text{History}} \text{Members}_t(\text
 2.  **Sticky Membership (Removal from Group):**
     When a student is removed from a sub-group, they remain on the Lecture Roster. They transition to an "Unassigned" state within the lecture context. This preserves their history and access rights during group switches.
 3.  **Cascading Deletion (Removal from Lecture):**
-    When a student is removed from the Lecture Roster, they are **automatically** removed from all associated sub-groups.
+  When a student is removed from the Lecture Roster through roster maintenance, they are **automatically** removed from Tutorials, Talks, and propagating Cohorts of that lecture.
 
 ### Cohort Propagation
 **Cohorts** are flexible groups with configurable propagation via the `propagate_to_lecture` flag:
 - **Propagating Cohorts** (`propagate_to_lecture: true`): Behave like Tutorials/Talks. Membership grants lecture access.
-  - Example: Enrollment cohorts (`purpose: :enrollment`) for simple courses.
+  - Example: Cohorts used as the enrollment path for simple courses.
 - **Non-Propagating Cohorts** (`propagate_to_lecture: false`): Act as "sidecars". Membership does NOT grant lecture access.
-  - Example: Waitlists, planning cohorts (`purpose: :planning`).
-
-**Purpose-Driven Behavior:**
-- **Enrollment** (`purpose: :enrollment`): Must propagate. Acts as main enrollment path for simple courses.
-- **General** (`purpose: :general`): Propagation configurable. Used for waitlists, special groups.
-- **Planning** (`purpose: :planning`): Must not propagate. Used for demand surveys.
+  - Example: Waitlists and planning cohorts.
 
 **Implementation Mechanism:**
-Propagation is implemented via database triggers or callbacks on the cohort membership table:
-1. **On Insert to `cohort_memberships`:** If `cohort.propagate_to_lecture` is true, automatically insert into `lecture_memberships` (idempotent).
-2. **On Delete from `cohort_memberships`:** No action (sticky membership preserved).
-3. **On Toggle of `propagate_to_lecture`:** When changed from false to true, bulk-insert all current cohort members into lecture roster. When changed from true to false, no removal (sticky membership).
+Propagation is implemented in roster service/concern code:
+1. **Campaign materialization:** `Rosters::Rosterable#materialize_allocation!` adds missing group members and then calls `propagate_to_lecture!(...)` for propagating groups.
+2. **Manual maintenance:** `Rosters::MaintenanceService#add_user!` and `#move_user!` call `propagate_to_lecture!(...)` after modifying a group.
+3. **Group removal:** Removing a user from a sub-group does not remove them from the lecture roster, preserving sticky membership.
 
 This ensures Cohorts seamlessly integrate with the Superset Model without requiring manual service calls.
 
 ## The Unified Model: All Materialization Flows Through Groups
 
-**Core Principle:** Every student enters the lecture roster via a **Group** (Tutorial, Talk, or Cohort). There is no direct lecture enrollment—simple courses use an **Enrollment Cohort** (`purpose: :enrollment`, `propagate_to_lecture: true`).
+**Core Principle:** In the supported workflow and UI, students enter the lecture roster via a **Group** (Tutorial, Talk, or Cohort). There is no direct lecture enrollment path in the UI; simple courses use a propagating Cohort.
 
 ### Pattern 1: Complex Courses (Tutorials/Talks)
 *   **Use Case:** Large lectures with tutorials or seminars with multiple talks.
@@ -60,15 +55,15 @@ This ensures Cohorts seamlessly integrate with the Superset Model without requir
 ### Pattern 2: Simple Courses (Enrollment Cohort)
 *   **Use Case:** Lectures without tutorials (e.g., advanced seminars, standalone courses).
 *   **Workflow:**
-    1.  **Main Campaign:** Students register for an **Enrollment Cohort** (`purpose: :enrollment`, `propagate_to_lecture: true`).
+    1.  **Main Campaign:** Students register for a **Cohort** with `propagate_to_lecture: true`.
     2.  **Quick-Create:** Teacher creates this cohort via "Enable Simple Enrollment" button in Roster Overview.
 *   **Result:** The Lecture Roster contains members of the enrollment cohort. Technically identical to Pattern 1 with one group.
 
 ### Pattern 3: Demand Forecasting (Planning Cohort)
 *   **Use Case:** Gauge interest before the semester without granting access.
 *   **Workflow:**
-    1.  **Survey Campaign:** Students register for a **Planning Cohort** (`purpose: :planning`, `propagate_to_lecture: false`).
-    2.  **Repeatable:** Multiple planning cohorts allowed per lecture (e.g., "Oct Survey", "Nov Survey").
+    1.  **Survey Campaign:** Students register for a **Cohort** with `propagate_to_lecture: false`.
+    2.  **Repeatable:** Multiple non-propagating cohorts are allowed per lecture (e.g., "Oct Survey", "Nov Survey").
 *   **Result:** Cohort roster is materialized but doesn't propagate to lecture. Used for staffing decisions.
 
 ### Mixing Patterns
@@ -84,7 +79,7 @@ It is valid to mix groups in one campaign:
 
 ---
 
-## Roster::Rosterable (Concern)
+## Rosters::Rosterable (Concern)
 **_The Universal Roster API_**
 
 ```admonish info "What it represents"
@@ -99,150 +94,115 @@ The “contract” required by the maintenance service, defining how to read and
 
 | Method | Provided/Required | Description |
 |---|---|---|
-| `roster_user_ids` | **Required (Override)** | Returns the current list of user IDs on the roster as an `Array<Integer>`. |
-| `replace_roster!(user_ids:)` | **Required (Override)** | Atomically replaces the entire roster with the given list of user IDs. |
-| `roster_entries` | **Required (Override)** | Returns an ActiveRecord relation to the join table for campaign tracking. |
-| `mark_campaign_source!(user_ids, campaign)` | **Required (Override)** | Marks the given user roster entries as sourced from the specified campaign. |
-| `allocated_user_ids` | Provided | Delegates to `roster_user_ids` to satisfy `Registration::Registerable` contract. |
+| `roster_entries` | **Required (Override)** | Returns the ActiveRecord relation for the join table used as the roster. |
+| `roster_user_id_column` | Provided / Optional Override | User foreign key on roster entries. Defaults to `:user_id`; `Talk` overrides it to `:speaker_id`. |
+| `roster_association_name` | Provided / Optional Override | Association name used for loaded-count optimizations. |
+| `allocated_user_ids` | Provided | Returns the current user IDs on the roster, satisfying the `Registration::Registerable` contract. |
 | `materialize_allocation!(user_ids:, campaign:)` | Provided | Implements the allocation materialization from `Registration::Registerable`. |
-| `add_user_to_roster!(user_id)` | Provided (private) | Adds a single user to the roster if not already present. |
-| `remove_user_from_roster!(user_id)` | Provided (private) | Removes a single user from the roster. |
+| `add_user_to_roster!(user, source_campaign = nil)` | Provided | Adds a single user to the roster. |
+| `remove_user_from_roster!(user)` | Provided | Removes a single user from the roster. |
+| `propagate_to_lecture!(user_ids)` | Provided | Propagates users to the lecture roster when the group is configured to do so. |
+| `full?`, `over_capacity?` | Provided | Capacity helpers based on the current roster. |
+| `locked?` | Provided | Returns whether manual maintenance is currently blocked. |
+| `in_campaign?`, `in_completed_campaign?` | Provided | Helpers describing campaign association state. |
+| `can_skip_campaigns?`, `can_unskip_campaigns?` | Provided | Guardrail helpers for toggling management mode. |
 | `self_materialization_mode` | Provided (enum) | Controls student self-service roster access: `disabled`, `add_only`, `remove_only`, `add_and_remove`. |
-| `can_self_add?(user)` | Provided | Checks if user can join via self-materialization. |
-| `can_self_remove?(user)` | Provided | Checks if user can leave via self-materialization. |
-| `self_add!(user)` | Provided | Student-initiated roster join (with permission check). |
-| `self_remove!(user)` | Provided | Student-initiated roster leave (with permission check). |
+| `destructible?` | Provided | Returns whether the group can be safely destroyed. |
 
 ### Behavior Highlights
-- **Explicit Contract:** The concern raises a `NotImplementedError` if an including class fails to override required methods (`#roster_user_ids`, `#replace_roster!`, `#roster_entries`, `#mark_campaign_source!`), ensuring the contract is met.
-- **Idempotent:** Calling `replace_roster!` with the same set of IDs should result in no change.
+- **Explicit Contract:** The concern requires `#roster_entries`. Optional overrides exist for nonstandard user-key or association names.
 - **Registration Integration:** Provides `allocated_user_ids` and `materialize_allocation!` to satisfy the `Registration::Registerable` interface, allowing rosters to be managed by the registration system.
-- **Campaign Tracking:** The `materialize_allocation!` method preserves manually-added roster entries while replacing campaign-sourced entries, using the `source_campaign` field on join table records.
-- **Self-Materialization:** Enables student-initiated roster changes as an alternative to campaigns or post-campaign follow-up. Default is `disabled` (staff-only access).
+- **Campaign Tracking:** The `materialize_allocation!` method adds missing users with `source_campaign_id`, removes excess users for the same campaign only, and preserves manually-added entries or entries from other campaigns.
+- **Self-Materialization:** The current implementation provides the `self_materialization_mode` enum and validation rules. Student-facing join/leave operations are not implemented in this concern yet.
 
 ### Management Mode & Campaign Integration
 The `Rosterable` concern introduces a `skip_campaigns` boolean flag to explicitly control the lifecycle of the roster.
 
-- **Campaign Mode (`skip_campaigns: false`):** The roster is managed by registration campaigns. This is the default state. Even in campaign mode, manual adjustments (moves/adds) are allowed *after* the campaign is completed.
+- **Campaign Mode (`skip_campaigns: false`):** The roster is managed by registration campaigns. This is the default state for registerables. Manual adjustments are blocked while the item is locked and become available after a completed campaign.
 - **Direct Management (`skip_campaigns: true`):** The roster is managed exclusively by staff. Users can be added or removed directly at any time. This is intended for groups that will *never* be part of a registration campaign (e.g., special "late-comers" groups or directly managed seminars).
 - **Transition Rules:**
   - **Campaign → Skip:** Only allowed if the group has **never** been part of a campaign. Once a group is used in a campaign, it is locked into campaign mode to ensure the integrity of the allocation process.
   - **Skip → Campaign:** Only allowed if the roster is currently **empty**. This prevents data inconsistency where manually added students might be overwritten or ignored by the campaign allocation logic.
 
+Enabling `self_materialization_mode` on a group that is not already in a campaign auto-enables `skip_campaigns`, so direct student access and campaign management are not enabled together.
+
 This flag serves as a safety guardrail, ensuring that items with existing memberships aren't accidentally attached to a campaign which might overwrite them.
 
 ### Example Implementation
 ```ruby
-# filepath: app/models/concerns/roster/rosterable.rb
-module Roster
+# filepath: app/models/rosters/rosterable.rb
+module Rosters
   module Rosterable
     extend ActiveSupport::Concern
 
     included do
-      enum self_materialization_mode: {
+      def roster_entries
+        raise(NotImplementedError, "#{self.class} must implement #roster_entries")
+      end
+
+      def roster_user_id_column
+        :user_id
+      end
+
+      def roster_association_name
+        :"#{self.class.name.underscore}_memberships"
+      end
+
+      enum :self_materialization_mode, {
         disabled: 0,
         add_only: 1,
         remove_only: 2,
         add_and_remove: 3
-      }, _prefix: :self_mat
+      }, prefix: true
 
-      validate :self_materialization_not_during_active_campaign
-    end
-
-    def roster_user_ids
-      raise NotImplementedError, "#{self.class.name} must implement #roster_user_ids"
-    end
-
-    def replace_roster!(user_ids:)
-      raise NotImplementedError, "#{self.class.name} must implement #replace_roster!"
+      before_validation :enforce_consistency_between_modes
+      validate :validate_skip_campaigns_switch
+      validate :validate_self_materialization_switch
     end
 
     def allocated_user_ids
-      roster_user_ids
+      roster_entries.pluck(roster_user_id_column)
     end
 
     def materialize_allocation!(user_ids:, campaign:)
       transaction do
-        current_ids = roster_user_ids
-        campaign_sourced_ids = current_ids.select do |uid|
-          roster_entries.exists?(user_id: uid, source_campaign: campaign)
-        end
+        current_ids = roster_entries.pluck(roster_user_id_column)
+        target_ids = user_ids.uniq
 
-        other_ids = current_ids - campaign_sourced_ids
-        new_ids = (other_ids + user_ids).uniq
-
-        replace_roster!(user_ids: new_ids)
-        mark_campaign_source!(user_ids, campaign)
+        add_missing_users!(target_ids, current_ids, campaign)
+        remove_excess_users!(target_ids, campaign)
+        propagate_to_lecture!(target_ids)
       end
     end
 
-    def can_self_add?(user)
-      return false if self_mat_disabled? || self_mat_remove_only?
-      return false if full?
-      !roster_user_ids.include?(user.id)
+    def add_user_to_roster!(user, source_campaign = nil)
+      roster_entries.create!(
+        roster_user_id_column => user.id,
+        :source_campaign => source_campaign
+      )
     end
 
-    def can_self_remove?(user)
-      return false if self_mat_disabled? || self_mat_add_only?
-      roster_user_ids.include?(user.id)
-    end
-
-    def self_add!(user)
-      raise "Not allowed" unless can_self_add?(user)
-      add_user_to_roster!(user.id)
-    end
-
-    def self_remove!(user)
-      raise "Not allowed" unless can_self_remove?(user)
-      remove_user_from_roster!(user.id)
+    def remove_user_from_roster!(user)
+      roster_entries.find_by(roster_user_id_column => user.id)&.destroy
     end
 
     private
 
-    def add_user_to_roster!(user_id)
-      ids = roster_user_ids
-      return if ids.include?(user_id)
-      replace_roster!(user_ids: ids + [user_id])
-    end
-
-    def remove_user_from_roster!(user_id)
-      replace_roster!(user_ids: roster_user_ids - [user_id])
-    end
-
-    def roster_entries
-      raise NotImplementedError, "#{self.class.name} must implement #roster_entries for campaign tracking"
-    end
-
-    def mark_campaign_source!(user_ids, campaign)
-      raise NotImplementedError, "#{self.class.name} must implement #mark_campaign_source! for campaign tracking"
-    end
-
-    def self_materialization_not_during_active_campaign
-      return if self_mat_disabled?
-
-      active = Registration::Item.where(registerable: self)
-        .joins(:registration_campaign)
-        .where.not(registration_campaigns: {
-          status: :completed
-        }).exists?
-
-      if active
-        errors.add(:self_materialization_mode,
-          "cannot be enabled during active campaign")
-      end
+    def add_missing_users!(target_ids, current_ids, campaign)
+      # omitted
     end
   end
 end
 ```
 
 ### Usage Scenarios
-- `Tutorial` and `Talk` both include `Roster::Rosterable`.
-- `Tutorial` implements `roster_user_ids` by reading from a new `tutorial_memberships` join table (to be created).
-- `Talk` implements `replace_roster!` using its existing `speaker_talk_joins` association.
+- `Tutorial`, `Talk`, `Cohort`, and `Lecture` all include `Rosters::Rosterable`.
+- `Tutorial`, `Cohort`, and `Lecture` use the default `user_id` roster column and mainly implement `roster_entries`.
+- `Talk` overrides `roster_user_id_column` to `:speaker_id` and `roster_association_name` to `:speaker_talk_joins`.
 
 ---
 
-## Roster::MaintenanceService
+## Rosters::MaintenanceService
 **_Staff Maintenance_**
 
 ```admonish info "What it represents"
@@ -250,77 +210,50 @@ The single, safe entry point for all staff-initiated roster changes after an all
 ```
 
 ```admonish note "Think of it as"
-An admin “move/add/remove” service with capacity checks and logging.
+An admin “move/add/remove” service with capacity checks and propagation handling.
 ```
 
 ```admonish note "How this is different from Registration::AllocationService"
 - `Registration::AllocationService` is the **automated solver** that runs once to create the initial allocation.
-- `Roster::MaintenanceService` is the **manual tool** for staff to make individual changes to rosters *after* the campaign is finished.
+- `Rosters::MaintenanceService` is the **manual tool** for staff to make individual changes to rosters after allocation and in direct-management flows.
 ```
 
 ### Public Interface
 
 | Method | Description |
 |---|---|
-| `initialize(actor:)` | Sets up the service with the acting user for auditing. |
-| `move_user!(user_id:, from:, to:, ...)` | Atomically moves a user from one `Roster::Rosterable` to another. |
-| `add_user!(user_id:, to:, ...)` | Adds a user to a `Roster::Rosterable`. |
-| `remove_user!(user_id:, from:, ...)` | Removes a user from a `Roster::Rosterable`. |
+| `add_user!(user, rosterable, force: false)` | Adds a user to a rosterable, optionally bypassing capacity checks. |
+| `remove_user!(user, rosterable)` | Removes a user from a rosterable. |
+| `move_user!(user, from_rosterable, to_rosterable, force: false)` | Atomically moves a user between two rosterables. |
 
 ### Behavior Highlights
 - **Transactional:** All operations, especially `move_user!`, are performed within a database transaction to ensure atomicity.
-- **Capacity Enforcement:** Enforces the `capacity` of the target `Roster::Rosterable` unless an `allow_overfill: true` flag is passed.
-- **Auditing Hook:** Calls a `log()` method to provide a hook for future audit trail implementation.
-- **Denormalization:** Can update denormalized counters like `Registration::Item.assigned_count` to keep dashboards in sync.
+- **Locking:** Locks one or two rosterables in a stable order to avoid race conditions during manual changes.
+- **Capacity Enforcement:** Enforces the `capacity` of the target rosterable unless a `force: true` flag is passed.
+- **Tutorial Uniqueness:** Prevents a user from being in multiple tutorials of the same lecture.
+- **Propagation:** Adding or moving into a propagating group also ensures lecture-roster membership.
+- **Lecture Removal Cascade:** Removing a user from the lecture roster removes them from tutorials, talks, and propagating cohorts of that lecture.
+- **Materialization Tracking:** Manual additions update `materialized_at` for matching registration records on items associated with the target rosterable.
 
 ### Example Implementation
 ```ruby
-# filepath: app/services/roster/maintenance_service.rb
-class Roster::MaintenanceService
-  def initialize(actor:)
-    @actor = actor
-  end
+# filepath: app/models/rosters/maintenance_service.rb
+module Rosters
+  class MaintenanceService
+    class CapacityExceededError < StandardError; end
 
-  def move_user!(user_id:, from:, to:, allow_overfill: false, reason: nil)
-    raise ArgumentError, "type mismatch" unless from.class == to.class
-    ActiveRecord::Base.transaction do
-      enforce_capacity!(to) unless allow_overfill
-      from.send(:remove_user_from_roster!, user_id)
-      to.send(:add_user_to_roster!, user_id)
-      touch_counts!(from, to)
-      log(:move, user_id: user_id, from: from, to: to, reason: reason)
+    def add_user!(user, rosterable, force: false)
+      rosterable.with_lock do
+        add_user_without_lock!(user, rosterable, force: force)
+      end
     end
-  end
 
-  def add_user!(user_id:, to:, allow_overfill: false, reason: nil)
-    ActiveRecord::Base.transaction do
-      enforce_capacity!(to) unless allow_overfill
-      to.send(:add_user_to_roster!, user_id)
-      touch_counts!(to)
-      log(:add, user_id: user_id, to: to, reason: reason)
+    def move_user!(user, from_rosterable, to_rosterable, force: false)
+      lock_rosterables_in_order(from_rosterable, to_rosterable) do
+        remove_user_without_lock!(user, from_rosterable)
+        add_user_without_lock!(user, to_rosterable, force: force)
+      end
     end
-  end
-
-  def remove_user!(user_id:, from:, reason: nil)
-    ActiveRecord::Base.transaction do
-      from.send(:remove_user_from_roster!, user_id)
-      touch_counts!(from)
-      log(:remove, user_id: user_id, from: from, reason: reason)
-    end
-  end
-
-  private
-
-  def enforce_capacity!(rosterable)
-    raise "Capacity reached" if rosterable.full?
-  end
-
-  def touch_counts!(*rosterables)
-    # Logic to find associated Registration::Items and update assigned_count
-  end
-
-  def log(action, **data)
-    # Hook for future auditing (e.g., create RosterChangeEvent record)
   end
 end
 ```
@@ -328,27 +261,27 @@ end
 ### Usage Scenarios
 - **Moving a student:** An administrator moves a student from a full tutorial to one with free space.
   ```ruby
-  service = Roster::MaintenanceService.new(actor: current_admin)
+  service = Rosters::MaintenanceService.new
   tutorial_from = Tutorial.find(1)
   tutorial_to = Tutorial.find(2)
-  student_id = 123
-  service.move_user!(user_id: student_id, from: tutorial_from, to: tutorial_to, reason: "Balancing class sizes")
+  student = User.find(123)
+  service.move_user!(student, tutorial_from, tutorial_to, force: true)
   ```
 
 - **Adding a late-comer:** A student who missed the deadline is manually added to a tutorial.
   ```ruby
-  service = Roster::MaintenanceService.new(actor: current_admin)
+  service = Rosters::MaintenanceService.new
   tutorial = Tutorial.find(5)
-  student_id = 456
-  service.add_user!(user_id: student_id, to: tutorial, reason: "Late registration approved by professor")
+  student = User.find(456)
+  service.add_user!(student, tutorial, force: true)
   ```
 
 - **Removing a dropout:** A student officially drops the course.
   ```ruby
-  service = Roster::MaintenanceService.new(actor: current_admin)
+  service = Rosters::MaintenanceService.new
   tutorial = Tutorial.find(3)
-  student_id = 789
-  service.remove_user!(user_id: student_id, from: tutorial, reason: "Student dropped course")
+  student = User.find(789)
+  service.remove_user!(student, tutorial)
   ```
 
 ---
@@ -365,46 +298,37 @@ An existing MaMpf tutorial model, enhanced to manage its student list.
 ```
 
 #### Rosterable Implementation
-The `Tutorial` model includes the `Roster::Rosterable` concern to provide a standard interface for managing its student roster via a join table.
+The `Tutorial` model includes the `Rosters::Rosterable` concern.
 
 | Method | Implementation Detail |
 |---|---|
-| `roster_user_ids` | Plucks `user_id`s from the `tutorial_memberships` join table (to be created). |
-| `replace_roster!(user_ids:)` | Deletes existing memberships and creates new ones in a transaction. |
+| `roster_entries` | Returns the `tutorial_memberships` relation. |
+| `materialize_allocation!` | Extends the default implementation by first removing the user from sibling tutorials of the same lecture. |
 
 #### Example Implementation
 ```ruby
 # filepath: app/models/tutorial.rb
 class Tutorial < ApplicationRecord
   include Registration::Registerable
-  include Roster::Rosterable
+  include Rosters::Rosterable
 
   has_many :tutorial_memberships, dependent: :destroy
-  has_many :students, through: :tutorial_memberships, source: :user
-
-  def roster_user_ids
-    tutorial_memberships.pluck(:user_id)
-  end
-
-  def replace_roster!(user_ids:)
-    TutorialMembership.transaction do
-      tutorial_memberships.delete_all
-      user_ids.each { |uid| tutorial_memberships.create!(user_id: uid) }
-    end
-  end
+  has_many :members, through: :tutorial_memberships, source: :user
 
   def roster_entries
     tutorial_memberships
   end
 
-  def mark_campaign_source!(user_ids, campaign)
-    tutorial_memberships.where(user_id: user_ids)
-                       .update_all(source_campaign_id: campaign.id)
+  def materialize_allocation!(user_ids:, campaign:)
+    transaction do
+      enforce_lecture_uniqueness!(user_ids)
+      super
+    end
   end
 end
 ```
 
-The `tutorial_memberships` table should include a `source_campaign_id` column (nullable) to track which campaign materialized each roster entry.
+The `tutorial_memberships` table already includes a `source_campaign_id` column to track which campaign materialized each roster entry.
 
 ---
 
@@ -416,46 +340,40 @@ An existing MaMpf talk model, enhanced to manage its speaker list.
 ```
 
 #### Rosterable Implementation
-The `Talk` model includes the `Roster::Rosterable` concern to provide a standard interface for managing its speakers.
+The `Talk` model includes the `Rosters::Rosterable` concern.
 
 | Method | Implementation Detail |
 |---|---|
-| `roster_user_ids` | Plucks `speaker_id`s from the `speaker_talk_joins` join table. |
-| `replace_roster!(user_ids:)` | Deletes existing joins and creates new ones in a transaction. |
+| `roster_entries` | Returns the `speaker_talk_joins` relation. |
+| `roster_user_id_column` | Overrides the default to `:speaker_id`. |
+| `roster_association_name` | Overrides the default to `:speaker_talk_joins`. |
 
 #### Example Implementation
 ```ruby
 # filepath: app/models/talk.rb
 class Talk < ApplicationRecord
   include Registration::Registerable
-  include Roster::Rosterable
+  include Rosters::Rosterable
 
   has_many :speaker_talk_joins, dependent: :destroy
   has_many :speakers, through: :speaker_talk_joins
-
-  def roster_user_ids
-    speaker_talk_joins.pluck(:speaker_id)
-  end
-
-  def replace_roster!(user_ids:)
-    SpeakerTalkJoin.transaction do
-      speaker_talk_joins.delete_all
-      user_ids.each { |uid| speaker_talk_joins.create!(speaker_id: uid) }
-    end
-  end
+  has_many :members, through: :speaker_talk_joins, source: :speaker
 
   def roster_entries
     speaker_talk_joins
   end
 
-  def mark_campaign_source!(user_ids, campaign)
-    speaker_talk_joins.where(speaker_id: user_ids)
-                      .update_all(source_campaign_id: campaign.id)
+  def roster_user_id_column
+    :speaker_id
+  end
+
+  def roster_association_name
+    :speaker_talk_joins
   end
 end
 ```
 
-The `speaker_talk_joins` table should include a `source_campaign_id` column (nullable) to track which campaign materialized each speaker assignment.
+The `speaker_talk_joins` table already includes a `source_campaign_id` column to track which campaign materialized each speaker assignment.
 
 ---
 
@@ -467,41 +385,30 @@ A generic group of students, managed via `cohort_memberships`.
 ```
 
 #### Rosterable Implementation
-The `Cohort` model includes the `Roster::Rosterable` concern.
+The `Cohort` model includes the `Rosters::Rosterable` concern.
 
 | Method | Implementation Detail |
 |---|---|
-| `roster_user_ids` | Plucks `user_id`s from the `cohort_memberships` join table. |
-| `replace_roster!(user_ids:)` | Deletes existing memberships and creates new ones. |
+| `roster_entries` | Returns the `cohort_memberships` relation. |
+| `lecture` | Returns the lecture context when the cohort belongs to a lecture. |
 
 #### Example Implementation
 ```ruby
 class Cohort < ApplicationRecord
   include Registration::Registerable
-  include Roster::Rosterable
+  include Rosters::Rosterable
 
   belongs_to :context, polymorphic: true
   has_many :cohort_memberships, dependent: :destroy
+  has_many :users, through: :cohort_memberships
   has_many :members, through: :cohort_memberships, source: :user
-
-  def roster_user_ids
-    cohort_memberships.pluck(:user_id)
-  end
-
-  def replace_roster!(user_ids:)
-    CohortMembership.transaction do
-      cohort_memberships.delete_all
-      user_ids.each { |uid| cohort_memberships.create!(user_id: uid) }
-    end
-  end
 
   def roster_entries
     cohort_memberships
   end
 
-  def mark_campaign_source!(user_ids, campaign)
-    cohort_memberships.where(user_id: user_ids)
-                      .update_all(source_campaign_id: campaign.id)
+  def lecture
+    context if context.is_a?(Lecture)
   end
 end
 ```
@@ -516,74 +423,55 @@ The lecture roster is the authoritative list of all students with access to lect
 ```
 
 #### Rosterable Implementation
-The `Lecture` model includes the `Roster::Rosterable` concern to manage the central student roster.
+The `Lecture` model includes the `Rosters::Rosterable` concern to manage the central student roster.
 
 | Method | Implementation Detail |
 |---|---|
-| `roster_user_ids` | Plucks `user_id`s from the `lecture_memberships` join table (existing). |
-| `replace_roster!(user_ids:)` | Deletes existing memberships and creates new ones in a transaction. |
+| `roster_entries` | Returns the `lecture_memberships` relation. |
+| `ensure_roster_membership!(user_ids)` | Efficiently inserts missing lecture memberships without duplicating existing rows. |
 
 #### Behavioral Notes
 - **Never Materialized Directly:** Lectures do NOT include `Registration::Registerable`. They only receive students via **Upstream Propagation** from sub-groups.
-- **Sticky Membership:** Students remain in the lecture roster even after leaving all sub-groups. Manual removal via `Roster::MaintenanceService` is required.
-- **Cascading Deletion:** When a student is removed from the lecture roster, they are automatically removed from all sub-groups (Tutorials, Talks, Cohorts).
+- **Sticky Membership:** Students remain in the lecture roster even after leaving all sub-groups. Manual removal via `Rosters::MaintenanceService` is required.
+- **Cascading Deletion:** When a student is removed from the lecture roster through maintenance, they are automatically removed from tutorials, talks, and propagating cohorts of that lecture.
 
 #### Example Implementation
 ```ruby
 class Lecture < ApplicationRecord
   include Registration::Campaignable
-  include Roster::Rosterable
+  include Rosters::Rosterable
 
   has_many :lecture_memberships, dependent: :destroy
-  has_many :students, through: :lecture_memberships, source: :user
+  has_many :members, through: :lecture_memberships, source: :user
 
   has_many :tutorials
   has_many :talks
   has_many :cohorts, as: :context
 
-  def roster_user_ids
-    lecture_memberships.pluck(:user_id)
-  end
-
-  def replace_roster!(user_ids:)
-    LectureMembership.transaction do
-      lecture_memberships.delete_all
-      user_ids.each { |uid| lecture_memberships.create!(user_id: uid) }
-    end
-  end
-
   def roster_entries
     lecture_memberships
   end
 
-  def mark_campaign_source!(user_ids, campaign)
-    lecture_memberships.where(user_id: user_ids)
-                       .update_all(source_campaign_id: campaign.id)
+  def ensure_roster_membership!(user_ids)
+    LectureMembership.insert_all(
+      user_ids.map { |uid| { user_id: uid, lecture_id: id } },
+      unique_by: [:user_id, :lecture_id]
+    )
   end
 end
 ```
 
-The `lecture_memberships` table should include a `source_campaign_id` column (nullable) to track which campaign initially granted access (via which sub-group).
+The `lecture_memberships` table already includes a `source_campaign_id` column to track which campaign initially granted access (via which sub-group).
 
-```admonish warning "Cascading Deletion Hook"
-The `Lecture` model should implement an `after_destroy` callback on `lecture_memberships` to cascade deletions to all sub-group rosters:
-
-~~~ruby
-after_destroy :cascade_to_subgroups, if: :will_save_change_to_user_id?
-
-def cascade_to_subgroups
-  tutorials.each { |t| t.roster_entries.where(user_id: user_id).destroy_all }
-  talks.each { |t| t.roster_entries.where(user_id: user_id).destroy_all }
-  cohorts.each { |c| c.roster_entries.where(user_id: user_id).destroy_all }
-end
-~~~
+```admonish warning "Lecture Removal Cascade"
+The cascade from lecture roster removal to subgroup removal is currently implemented in `Rosters::MaintenanceService`, not as an ActiveRecord callback on `LectureMembership`.
 ```
 
 ---
 
 ## ERD for Roster Implementations
 
-This diagram shows the concrete database relationships for the `Roster::Rosterable` implementations. The `Roster::Rosterable` concern provides a uniform API over these different underlying structures.
+This diagram shows the concrete database relationships for the `Rosters::Rosterable` implementations. The `Rosters::Rosterable` concern provides a uniform API over these different underlying structures.
 
 ```mermaid
 erDiagram
@@ -591,20 +479,25 @@ erDiagram
     LECTURE_MEMBERSHIP }o--|| USER : "links to"
 
     LECTURE ||--o{ TUTORIAL : "has many"
-    TUTORIAL ||--o{ TUTORIAL_MEMBERSHIP : "has (to be created)"
+    TUTORIAL ||--o{ TUTORIAL_MEMBERSHIP : "has (existing)"
     TUTORIAL_MEMBERSHIP }o--|| USER : "links to"
+    TUTORIAL_MEMBERSHIP }o--|| REGISTRATION_CAMPAIGN : "source_campaign_id"
 
     LECTURE ||--o{ TALK : "has many"
     TALK ||--o{ SPEAKER_TALK_JOIN : "has (existing)"
     SPEAKER_TALK_JOIN }o--|| USER : "links to"
+    SPEAKER_TALK_JOIN }o--|| REGISTRATION_CAMPAIGN : "source_campaign_id"
 
     LECTURE ||--o{ COHORT : "has many (context)"
-    COHORT ||--o{ COHORT_MEMBERSHIP : "has (new)"
+    COHORT ||--o{ COHORT_MEMBERSHIP : "has (existing)"
     COHORT_MEMBERSHIP }o--|| USER : "links to"
+    COHORT_MEMBERSHIP }o--|| REGISTRATION_CAMPAIGN : "source_campaign_id"
     COHORT {
         boolean propagate_to_lecture "Triggers upstream propagation"
-        int purpose "general=0, enrollment=1, planning=2"
+      boolean skip_campaigns "Direct-management mode"
+      int self_materialization_mode "disabled/add_only/remove_only/add_and_remove"
     }
+    LECTURE_MEMBERSHIP }o--|| REGISTRATION_CAMPAIGN : "source_campaign_id"
 ```
 
 **Propagation Rules:**
@@ -623,8 +516,8 @@ sequenceDiagram
     actor Admin
     participant Campaign as Registration::Campaign
     participant Materializer as Registration::AllocationMaterializer
-    participant RosterService as Roster::MaintenanceService
-    participant SubGroup as Roster::Rosterable (e.g., Tutorial)
+    participant RosterService as Rosters::MaintenanceService
+    participant SubGroup as Rosters::Rosterable (e.g., Tutorial)
     participant Lecture as Lecture Roster
 
     rect rgb(235, 245, 255)
@@ -632,17 +525,15 @@ sequenceDiagram
     Campaign->>Materializer: new(campaign).materialize!
     Materializer->>SubGroup: materialize_allocation!(user_ids:, campaign:)
     note right of SubGroup: From Registration::Registerable
-    SubGroup->>SubGroup: 1. Query current roster_user_ids
-    SubGroup->>SubGroup: 2. Identify campaign-sourced entries
-    SubGroup->>SubGroup: 3. Merge with new user_ids
-    SubGroup->>SubGroup: 4. Call replace_roster!(merged_ids)
-    SubGroup->>SubGroup: 5. Mark new entries with source_campaign_id
+    SubGroup->>SubGroup: 1. Insert missing users with source_campaign_id
+    SubGroup->>SubGroup: 2. Remove excess users for this campaign only
+    SubGroup->>SubGroup: 3. Propagate to lecture if configured
 
     alt Tutorial or Talk (always propagates)
-        SubGroup->>Lecture: Trigger: Add users to lecture roster
+      SubGroup->>Lecture: ensure_roster_membership!(user_ids)
         note right of Lecture: Upstream Propagation (automatic)
     else Cohort with propagate_to_lecture: true
-        SubGroup->>Lecture: Trigger: Add users to lecture roster
+      SubGroup->>Lecture: ensure_roster_membership!(user_ids)
         note right of Lecture: Upstream Propagation (configured)
     else Cohort with propagate_to_lecture: false
         note right of SubGroup: No propagation (planning/waitlist)
@@ -653,46 +544,50 @@ sequenceDiagram
 
     rect rgb(255, 245, 235)
     note over Admin,Lecture: Phase 2: Manual Roster Maintenance
-    Admin->>RosterService: new(actor: admin).move_user!(...)
-    RosterService->>SubGroup: from.remove_user_from_roster!(user_id)
-    RosterService->>SubGroup: to.add_user_to_roster!(user_id)
-    note right of SubGroup: Uses private methods from Roster::Rosterable concern
-    SubGroup->>Lecture: Trigger: Add user to lecture roster (if propagates)
+    Admin->>RosterService: new.move_user!(user, from, to, force: true)
+    RosterService->>SubGroup: lock source and target rosterables
+    RosterService->>SubGroup: remove_user_from_roster!(user)
+    RosterService->>SubGroup: add_user_to_roster!(user)
+    SubGroup->>Lecture: ensure_roster_membership!([user.id]) if propagates
     note right of Lecture: Sticky membership preserved
     end
 ```
 
-## Proposed Folder Structure
+  ## Current Folder Structure
 
-To keep the new components organized, the new files would be placed as follows:
+  The roster-related implementation currently lives in the following locations:
 
 ```text
 app/
 ├── models/
-│   └── concerns/
-│       └── roster/
-│           └── rosterable.rb
+│   └── rosters/
+│       ├── rosterable.rb
+│       └── maintenance_service.rb
 │
-└── services/
+└── controllers/
     └── roster/
-        └── maintenance_service.rb
+        └── maintenance_controller.rb
 ```
 
 ### Key Files
-- `app/models/concerns/roster/rosterable.rb` - Uniform roster API concern
-- `app/services/roster/maintenance_service.rb` - Manual roster modification service
+- `app/models/rosters/rosterable.rb` - Uniform roster API concern
+- `app/models/rosters/maintenance_service.rb` - Manual roster modification service
+- `app/controllers/roster/maintenance_controller.rb` - Lecture-level roster maintenance UI
 
 ---
 
 ## Database Tables
 
-The roster system doesn't introduce new database tables. Instead, it provides a uniform API over existing and to-be-created join tables:
+The roster system currently uses the following join tables:
 
-- `tutorial_memberships` (to be created) - Join table for tutorial student rosters
-- `speaker_talk_joins` (existing) - Join table for talk speaker assignments
-- `cohort_memberships` (to be created) - Join table for cohort student memberships
+- `lecture_memberships` - Join table for lecture roster membership
+- `tutorial_memberships` - Join table for tutorial student rosters
+- `speaker_talk_joins` - Join table for talk speaker assignments
+- `cohort_memberships` - Join table for cohort student memberships
+
+All four tables now include an optional `source_campaign_id` foreign key for campaign tracking.
 
 ```admonish note
-The `Roster::Rosterable` concern provides a uniform interface (`roster_user_ids`, `replace_roster!`) regardless of the underlying table structure. Column details are shown in the example implementations above.
+The `Rosters::Rosterable` concern provides a uniform interface over these different join tables through `roster_entries`, `roster_user_id_column`, and shared materialization helpers.
 ```
 


### PR DESCRIPTION
This PR updates the  architecture book for chapters 02 (Registration) and 03 (Rosters) to reflect the current implementation:

- Replace planned/conceptual API with actual method signatures and DB columns
- `purpose` enum removed from `Cohort`, `Registerable` interface simplified
- Sequence diagrams and code examples updated to match existing code