### PR TITLE
Incorporate user feedback to registration and roster management system

### DIFF
--- a/app/controllers/registration/items_controller.rb
+++ b/app/controllers/registration/items_controller.rb
@@ -79,6 +79,7 @@ module Registration
       end
 
       registerable = @item.registerable
+      authorize! :destroy, registerable
       success = false
 
       ActiveRecord::Base.transaction do

--- a/app/controllers/registration/items_controller.rb
+++ b/app/controllers/registration/items_controller.rb
@@ -78,13 +78,26 @@ module Registration
         return
       end
 
-      if @item.destroy
+      registerable = @item.registerable
+      success = false
+
+      ActiveRecord::Base.transaction do
+        success = @item.destroy
+        raise(ActiveRecord::Rollback) unless success
+
+        success = registerable.destroy
+        raise(ActiveRecord::Rollback) unless success
+      end
+
+      if success
         respond_with_flash(:notice, t("registration.item.destroyed"),
                            redirect_path: after_action_path) do
           render_campaigns_container
         end
       else
-        respond_with_flash(:alert, @item.errors.full_messages.to_sentence,
+        errors = (@item.errors.full_messages +
+                  registerable.errors.full_messages).uniq
+        respond_with_flash(:alert, errors.to_sentence,
                            redirect_path: after_action_path)
       end
     end

--- a/app/controllers/registration/policies_controller.rb
+++ b/app/controllers/registration/policies_controller.rb
@@ -1,5 +1,6 @@
 module Registration
   class PoliciesController < ApplicationController
+    helper RegistrationPolicyHelper
     before_action :set_campaign
     before_action :set_locale
     before_action :set_policy, only: [:edit, :update, :destroy, :move_up, :move_down]

--- a/app/controllers/registration/policies_controller.rb
+++ b/app/controllers/registration/policies_controller.rb
@@ -119,6 +119,16 @@ module Registration
                                             :prerequisite_campaign_id])
       end
 
+      def render_campaigns_container
+        @campaign.reload
+        turbo_stream.update("campaigns_container",
+                            partial: "registration/campaigns/card_body_index",
+                            locals: {
+                              lecture: @campaign.campaignable,
+                              expanded_campaign_id: @campaign.id
+                            })
+      end
+
       def move(direction)
         @policy.public_send("move_#{direction}")
         respond_with_flash(:notice, nil,

--- a/app/controllers/roster/maintenance_controller.rb
+++ b/app/controllers/roster/maintenance_controller.rb
@@ -76,9 +76,14 @@ module Roster
       ensure_rosterable_unlocked!
 
       user = find_user
+      already_member = @rosterable.members.exists?(user.id)
       Rosters::MaintenanceService.new.add_user!(user, @rosterable, force: true)
 
-      flash.now[:notice] = t("roster.messages.user_added")
+      flash.now[:notice] = if already_member
+        t("roster.messages.user_already_member")
+      else
+        t("roster.messages.user_added")
+      end
       flash.now[:alert] = t("roster.warnings.capacity_exceeded") if @rosterable.over_capacity?
 
       source = find_panel_source

--- a/app/controllers/roster/maintenance_controller.rb
+++ b/app/controllers/roster/maintenance_controller.rb
@@ -15,6 +15,7 @@ module Roster
 
     rescue_from "Rosters::UserAlreadyInBundleError" do |e|
       respond_with_flash(:alert, t("roster.errors.user_already_in_bundle",
+                                   user: @member_user&.info,
                                    group: e.conflicting_group.title),
                          fallback_location: fallback_path)
     end
@@ -79,9 +80,9 @@ module Roster
       added = Rosters::MaintenanceService.new.add_user!(user, @rosterable, force: true)
 
       flash.now[:notice] = if added
-        t("roster.messages.user_added")
+        t("roster.messages.user_added", user: user.info, group: @rosterable.title)
       else
-        t("roster.messages.user_already_member")
+        t("roster.messages.user_already_member", user: user.info, group: @rosterable.title)
       end
       flash.now[:alert] = t("roster.warnings.capacity_exceeded") if @rosterable.over_capacity?
 
@@ -102,7 +103,7 @@ module Roster
       user = find_user
       Rosters::MaintenanceService.new.remove_user!(user, @rosterable)
 
-      flash.now[:notice] = t("roster.messages.user_removed")
+      flash.now[:notice] = t("roster.messages.user_removed", user: user.info)
 
       render_with_streams(stream_builder.streams)
     end
@@ -132,7 +133,7 @@ module Roster
 
       Rosters::MaintenanceService.new.move_user!(user, @rosterable, target, force: true)
 
-      flash.now[:notice] = t("roster.messages.user_moved", target: target.title)
+      flash.now[:notice] = t("roster.messages.user_moved", user: user.info, target: target.title)
       flash.now[:alert] = t("roster.warnings.capacity_exceeded") if target.over_capacity?
 
       if @mparams.panel?
@@ -281,7 +282,7 @@ module Roster
         end
         raise(UserNotFoundError) unless user
 
-        user
+        @member_user = user
       end
 
       def find_panel_source

--- a/app/controllers/roster/maintenance_controller.rb
+++ b/app/controllers/roster/maintenance_controller.rb
@@ -76,13 +76,12 @@ module Roster
       ensure_rosterable_unlocked!
 
       user = find_user
-      already_member = @rosterable.members.exists?(user.id)
-      Rosters::MaintenanceService.new.add_user!(user, @rosterable, force: true)
+      added = Rosters::MaintenanceService.new.add_user!(user, @rosterable, force: true)
 
-      flash.now[:notice] = if already_member
-        t("roster.messages.user_already_member")
-      else
+      flash.now[:notice] = if added
         t("roster.messages.user_added")
+      else
+        t("roster.messages.user_already_member")
       end
       flash.now[:alert] = t("roster.warnings.capacity_exceeded") if @rosterable.over_capacity?
 

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -55,6 +55,11 @@ trix-toolbar .trix-button-row {
   flex-wrap: wrap;
 }
 
+.td-picker .invalid-feedback {
+  order: 1;
+  width: 100%;
+}
+
 .turbo-progress-bar {
   height: 3px;
   background-color: #ffc107;

--- a/app/frontend/registration/campaigns/_form.html.erb
+++ b/app/frontend/registration/campaigns/_form.html.erb
@@ -56,7 +56,7 @@
           <%= helpdesk(t("registration.campaign.helpdesk.registration_deadline"), false) %>
 
           <div
-            class="input-group td-picker"
+            class="input-group td-picker has-validation"
             id="<%= picker_id %>"
             data-controller="datetimepicker"
             data-td-target-input="nearest"

--- a/app/frontend/registration/policies/_form.html.erb
+++ b/app/frontend/registration/policies/_form.html.erb
@@ -69,14 +69,8 @@
       <div class="mb-3">
         <%= f.label :prerequisite_campaign_id, t("registration.policy.configs.prerequisite_campaign_id"), class: "form-label" %>
 
-        <% prereq_options = campaign.campaignable.registration_campaigns
-                                               .where.not(id: campaign.id).to_a %>
-
-        <% preselect = if policy.persisted?
-                         policy.prerequisite_campaign_id
-                       elsif prereq_options.one?
-                         prereq_options.first.id
-                       end %>
+        <% prereq_options = prerequisite_campaign_options(campaign) %>
+        <% preselect = prerequisite_campaign_preselect(policy, prereq_options) %>
 
         <%= f.collection_select :prerequisite_campaign_id,
                                   prereq_options,

--- a/app/frontend/registration/policies/_form.html.erb
+++ b/app/frontend/registration/policies/_form.html.erb
@@ -69,11 +69,18 @@
       <div class="mb-3">
         <%= f.label :prerequisite_campaign_id, t("registration.policy.configs.prerequisite_campaign_id"), class: "form-label" %>
 
+        <% prereq_options = campaign.campaignable.registration_campaigns
+                                               .where.not(id: campaign.id).to_a %>
+
+        <% preselect = prereq_options.one? ? prereq_options.first.id
+                                           : policy.prerequisite_campaign_id %>
+
         <%= f.collection_select :prerequisite_campaign_id,
-                                  Registration::Campaign.where.not(id: campaign.id),
+                                  prereq_options,
                                   :id,
                                   :description,
-                                  { include_blank: true },
+                                  { include_blank: t("registration.policy.hints.select_prerequisite"),
+                                    selected: preselect },
                                   class: "form-select" %>
       </div>
     </div>

--- a/app/frontend/registration/policies/_form.html.erb
+++ b/app/frontend/registration/policies/_form.html.erb
@@ -13,8 +13,7 @@
       <%= helpdesk(t("registration.policy.helpdesk.kind"), false) %>
 
       <%= f.select :kind,
-                   Registration::Policy.kinds.except("student_performance").keys
-                     .map { |k| [t("registration.policy.kinds.#{k}"), k] },
+                   available_policy_kinds(campaign, policy).map { |k| [t("registration.policy.kinds.#{k}"), k] },
                    {},
                    class: "form-select",
                    data: { action: "registration-policy-form#changeKind", registration_policy_form_target: "kindSelect" } %>

--- a/app/frontend/registration/policies/_form.html.erb
+++ b/app/frontend/registration/policies/_form.html.erb
@@ -72,8 +72,11 @@
         <% prereq_options = campaign.campaignable.registration_campaigns
                                                .where.not(id: campaign.id).to_a %>
 
-        <% preselect = prereq_options.one? ? prereq_options.first.id
-                                           : policy.prerequisite_campaign_id %>
+        <% preselect = if policy.persisted?
+                         policy.prerequisite_campaign_id
+                       elsif prereq_options.one?
+                         prereq_options.first.id
+                       end %>
 
         <%= f.collection_select :prerequisite_campaign_id,
                                   prereq_options,

--- a/app/frontend/roster/roster_drag.controller.js
+++ b/app/frontend/roster/roster_drag.controller.js
@@ -15,13 +15,16 @@ export default class extends Controller {
   tileDropInstances = [];
   pendingDrop = null;
   highlightedTile = null;
+  streamRenderListener = () => this.refreshDropZones();
 
   connect() {
     this.initDraggable();
     this.initDropZones();
+    document.addEventListener("turbo:stream-render", this.streamRenderListener);
   }
 
   disconnect() {
+    document.removeEventListener("turbo:stream-render", this.streamRenderListener);
     this.sortableInstance?.destroy();
     this.tileDropInstances.forEach(s => s.destroy());
     this.tileDropInstances = [];
@@ -80,6 +83,13 @@ export default class extends Controller {
 
       this.tileDropInstances.push(instance);
     });
+  }
+
+  refreshDropZones() {
+    if (!this.hasStudentListTarget) return;
+
+    this.clearHighlight();
+    this.initDropZones();
   }
 
   updateHighlight(dropZone) {

--- a/app/frontend/roster/roster_drag.controller.js
+++ b/app/frontend/roster/roster_drag.controller.js
@@ -86,9 +86,9 @@ export default class extends Controller {
   }
 
   refreshDropZones() {
+    this.clearHighlight();
     if (!this.hasStudentListTarget) return;
 
-    this.clearHighlight();
     this.initDropZones();
   }
 

--- a/app/frontend/roster/roster_drag.controller.js
+++ b/app/frontend/roster/roster_drag.controller.js
@@ -15,16 +15,15 @@ export default class extends Controller {
   tileDropInstances = [];
   pendingDrop = null;
   highlightedTile = null;
-  streamRenderListener = () => this.refreshDropZones();
 
   connect() {
     this.initDraggable();
     this.initDropZones();
-    document.addEventListener("turbo:stream-render", this.streamRenderListener);
+    document.addEventListener("turbo:stream-render", this.refreshDropZones);
   }
 
   disconnect() {
-    document.removeEventListener("turbo:stream-render", this.streamRenderListener);
+    document.removeEventListener("turbo:stream-render", this.refreshDropZones);
     this.sortableInstance?.destroy();
     this.tileDropInstances.forEach(s => s.destroy());
     this.tileDropInstances = [];

--- a/app/helpers/registration_policy_helper.rb
+++ b/app/helpers/registration_policy_helper.rb
@@ -6,4 +6,16 @@ module RegistrationPolicyHelper
 
     kinds.excluding("institutional_email")
   end
+
+  def prerequisite_campaign_options(campaign)
+    campaign.campaignable.registration_campaigns.where.not(id: campaign.id).to_a
+  end
+
+  def prerequisite_campaign_preselect(policy, options)
+    if policy.persisted?
+      policy.prerequisite_campaign_id
+    elsif options.one?
+      options.first.id
+    end
+  end
 end

--- a/app/helpers/registration_policy_helper.rb
+++ b/app/helpers/registration_policy_helper.rb
@@ -12,10 +12,8 @@ module RegistrationPolicyHelper
   end
 
   def prerequisite_campaign_preselect(policy, options)
-    if policy.persisted?
-      policy.prerequisite_campaign_id
-    elsif options.one?
-      options.first.id
-    end
+    return policy.prerequisite_campaign_id if policy.prerequisite_campaign_id.present?
+
+    options.first.id if options.one?
   end
 end

--- a/app/helpers/registration_policy_helper.rb
+++ b/app/helpers/registration_policy_helper.rb
@@ -1,0 +1,9 @@
+module RegistrationPolicyHelper
+  def available_policy_kinds(campaign, policy)
+    kinds = Registration::Policy.kinds.except("student_performance").keys
+    return kinds if policy.persisted?
+    return kinds unless campaign.registration_policies.institutional_email.exists?
+
+    kinds.excluding("institutional_email")
+  end
+end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -10,7 +10,8 @@ class Cohort < ApplicationRecord
 
   attr_readonly :propagate_to_lecture
 
-  validates :title, presence: true
+  validates :title, presence: true,
+                    uniqueness: { scope: [:context_type, :context_id] }
   validates :capacity, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 
   def roster_entries

--- a/app/models/registration/campaign.rb
+++ b/app/models/registration/campaign.rb
@@ -270,7 +270,7 @@ module Registration
       end
 
       def registration_deadline_future_if_open
-        return unless open?
+        return unless open? || (draft? && registration_deadline_changed?)
         return unless registration_deadline_changed? || status_changed?
         return if registration_deadline.blank?
 

--- a/app/models/registration/campaign.rb
+++ b/app/models/registration/campaign.rb
@@ -242,7 +242,7 @@ module Registration
       def release_registerables_from_campaign
         return if @registerables_to_release.blank?
 
-        ids_by_type = @registerables_to_release.group_by { |r| r.class }
+        ids_by_type = @registerables_to_release.group_by(&:class)
         ids_by_type.each do |klass, records|
           # rubocop:disable Rails/SkipsModelValidations
           klass.where(id: records.map(&:id)).update_all(skip_campaigns: true)

--- a/app/models/registration/campaign.rb
+++ b/app/models/registration/campaign.rb
@@ -50,6 +50,8 @@ module Registration
 
     before_destroy :ensure_campaign_is_draft, prepend: true
     before_destroy :ensure_not_referenced_as_prerequisite, prepend: true
+    before_destroy :collect_registerables_for_release, prepend: true
+    after_destroy :release_registerables_from_campaign
 
     def locale_with_inheritance
       campaignable.try(:locale_with_inheritance) || campaignable.try(:locale)
@@ -229,6 +231,23 @@ module Registration
                                            .uniq.join(", ")
         errors.add(:base, :referenced_as_prerequisite, descriptions: descriptions)
         throw(:abort)
+      end
+
+      def collect_registerables_for_release
+        @registerables_to_release = registration_items
+                                    .filter_map(&:registerable)
+                                    .select { |r| r.respond_to?(:skip_campaigns) }
+      end
+
+      def release_registerables_from_campaign
+        return if @registerables_to_release.blank?
+
+        ids_by_type = @registerables_to_release.group_by { |r| r.class }
+        ids_by_type.each do |klass, records|
+          # rubocop:disable Rails/SkipsModelValidations
+          klass.where(id: records.map(&:id)).update_all(skip_campaigns: true)
+          # rubocop:enable Rails/SkipsModelValidations
+        end
       end
 
       def ensure_campaign_is_draft

--- a/app/models/registration/policy.rb
+++ b/app/models/registration/policy.rb
@@ -22,6 +22,7 @@ module Registration
     validates :kind, :phase, presence: true
     validates :active, inclusion: { in: [true, false] }
     validate :campaign_is_draft, on: [:create, :update]
+    validate :validate_unique_institutional_email, on: [:create, :update]
     validate :validate_config
 
     before_destroy :ensure_campaign_is_draft
@@ -88,6 +89,19 @@ module Registration
     end
 
     private
+
+      def validate_unique_institutional_email
+        return unless institutional_email?
+        return unless registration_campaign_id
+
+        duplicate = registration_campaign.registration_policies
+                                         .institutional_email
+                                         .where.not(id: id)
+        return unless duplicate.exists?
+
+        errors.add(:kind,
+                   I18n.t("registration.policy.errors.duplicate_institutional_email"))
+      end
 
       def campaign_is_draft
         return unless registration_campaign && !registration_campaign.draft?

--- a/app/models/registration/policy.rb
+++ b/app/models/registration/policy.rb
@@ -68,7 +68,7 @@ module Registration
     end
 
     def config_summary
-      handler.summary || "-"
+      handler.summary || "—"
     end
 
     delegate :evaluate, to: :handler

--- a/app/models/registration/policy/institutional_email_handler.rb
+++ b/app/models/registration/policy/institutional_email_handler.rb
@@ -57,7 +57,7 @@ module Registration
           else
             Array(raw_domains)
           end
-          list.map { |d| (d || "").strip.downcase.delete_prefix(".").delete_prefix("@") }
+          list.map { |d| d.to_s.strip.downcase.delete_prefix(".").delete_prefix("@") }
               .reject(&:empty?)
         end
 

--- a/app/models/registration/policy/institutional_email_handler.rb
+++ b/app/models/registration/policy/institutional_email_handler.rb
@@ -24,14 +24,25 @@ module Registration
       end
 
       def validate
-        return unless domains.empty?
+        if domains.empty?
+          policy.errors.add(:allowed_domains,
+                            I18n.t("registration.policy.errors.missing_domains"))
+          return
+        end
 
-        policy.errors.add(:allowed_domains, I18n.t("registration.policy.errors.missing_domains"))
+        invalid_domains(config["allowed_domains"]).each do |token|
+          policy.errors.add(
+            :allowed_domains,
+            I18n.t("registration.policy.errors.invalid_domain_format", domain: token)
+          )
+        end
       end
 
       def summary
-        domains.join(", ")
+        domains.join(" | ")
       end
+
+      DOMAIN_FORMAT = /\A[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\z/
 
       private
 
@@ -46,7 +57,12 @@ module Registration
           else
             Array(raw_domains)
           end
-          list.map { |d| (d || "").strip.downcase.delete_prefix(".") }.reject(&:empty?)
+          list.map { |d| (d || "").strip.downcase.delete_prefix(".").delete_prefix("@") }
+              .reject(&:empty?)
+        end
+
+        def invalid_domains(raw)
+          parse_domains(raw).grep_v(DOMAIN_FORMAT)
         end
     end
   end

--- a/app/models/registration/policy/institutional_email_handler.rb
+++ b/app/models/registration/policy/institutional_email_handler.rb
@@ -39,7 +39,7 @@ module Registration
       end
 
       def summary
-        domains.join(" | ")
+        domains.presence&.join(" | ")
       end
 
       DOMAIN_FORMAT = /\A[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\z/

--- a/app/models/rosters/maintenance_service.rb
+++ b/app/models/rosters/maintenance_service.rb
@@ -48,9 +48,10 @@ module Rosters
                 "Capacity exceeded for #{rosterable.class.name} #{rosterable.id}")
         end
 
-        rosterable.add_user_to_roster!(user)
+        membership = rosterable.add_user_to_roster!(user)
         propagate_to_lecture!(user, rosterable)
         update_registration_materialization(user, rosterable)
+        membership
       end
 
       def remove_user_without_lock!(user, rosterable)

--- a/app/models/rosters/stream_builder.rb
+++ b/app/models/rosters/stream_builder.rb
@@ -100,7 +100,8 @@ module Rosters
             "tutorial-roster-side-panel",
             html: RosterSidePanelComponent.new(
               registerable: @rosterable,
-              students: @rosterable.members.order(:name)
+              students: @rosterable.members.order(:name),
+              read_only: @rosterable.locked?
             ).render_in(@view_context)
           )
         end
@@ -120,7 +121,8 @@ module Rosters
           "tutorial-roster-side-panel",
           html: RosterSidePanelComponent.new(
             registerable: @rosterable,
-            students: @rosterable.members.order(:name)
+            students: @rosterable.members.order(:name),
+            read_only: @rosterable.locked?
           ).render_in(@view_context)
         )
 

--- a/app/views/cohorts/_modal_form.html.erb
+++ b/app/views/cohorts/_modal_form.html.erb
@@ -40,7 +40,7 @@
                       class: "form-check-label" %>
       </div>
 
-      <% if cohort.persisted? %>
+      <% unless cohort.persisted? %>
         <small class="form-text text-muted d-block mt-2">
           <%= t("roster.cohorts.help.propagate_readonly_warning") %>
         </small>

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -216,14 +216,14 @@ de:
         lecture: "Vorlesung"
         lecture_signup: "Vorlesungseinschreibung"
       actions:
-        remove_from_campaign: "Aus Anmeldeverfahren entfernen"
+        remove_from_campaign: "Gruppe löschen"
       created: "Element erfolgreich hinzugefügt."
-      destroyed: "Element erfolgreich entfernt."
+      destroyed: "Gruppe erfolgreich gelöscht."
       updated: "Element erfolgreich aktualisiert."
       invalid_type: "Ungültiger Typ."
       cannot_destroy: "Element kann nicht entfernt werden, da das Anmeldeverfahren nicht im Entwurfsmodus ist."
       confirm_delete: "Bist Du sicher, dass Du dieses Element entfernen möchtest?"
-      confirm_remove: "Bist Du sicher, dass Du dieses Element aus dem Anmeldeverfahren entfernen möchtest?"
+      confirm_remove: "Bist Du sicher, dass Du diese Gruppe endgültig löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
       select_type: "Gruppenart auswählen..."
       attributes:
         capacity_optional: "Kapazität (optional)"

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -152,6 +152,7 @@ de:
       not_found: "Registrierungsrichtlinie nicht gefunden."
       errors:
         duplicate_institutional_email: "Pro Anmeldeverfahren ist nur eine Richtlinie für institutionelle E-Mails erlaubt."
+        invalid_domain_format: "Ungültiges Domain-Format: '%{domain}'. Bitte eine einfache Domain eingeben, z.B. 'uni-heidelberg.de'."
         missing_domains: "Es muss mindestens eine erlaubte Domain angegeben werden."
         missing_prerequisite_campaign: "Es muss ein vorausgesetztes Anmeldeverfahren ausgewählt werden."
         prerequisite_campaign_not_found: "Das ausgewählte vorausgesetzte Anmeldeverfahren existiert nicht."

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -7,7 +7,7 @@ de:
       create_failed: "Anmeldeverfahren konnte nicht erstellt werden."
       destroyed: "Anmeldeverfahren erfolgreich gelöscht."
       cannot_delete: "Anmeldeverfahren kann nicht gelöscht werden."
-      confirm_delete: "Bist Du sicher, dass Du dieses Anmeldeverfahren löschen möchtest?"
+      confirm_delete: "Bist Du sicher, dass Du dieses Anmeldeverfahren löschen möchtest? Die zugehörigen Gruppen werden nicht gelöscht und können danach manuell verwaltet werden."
       opened: "Anmeldung geöffnet."
       closed: "Anmeldung geschlossen."
       reopened: "Anmeldung wiedereröffnet."

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -319,7 +319,7 @@ de:
               no_items: "Das Anmeldeverfahren kann nicht geöffnet werden, da keine Einträge hinzugefügt wurden."
               already_has_real_campaign: "Es existiert bereits ein reguläres Anmeldeverfahren für diesen Kontext. Es ist nur ein reguläres Verfahren erlaubt."
             registration_deadline:
-              must_be_in_future: "muss in der Zukunft liegen, wenn das Anmeldeverfahren offen ist"
+              must_be_in_future: "muss in der Zukunft liegen"
             status:
               cannot_revert_to_draft: "kann nicht in den Entwurfsmodus zurückgesetzt werden, sobald es geöffnet wurde"
             allocation_mode:

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -151,6 +151,7 @@ de:
       confirm_delete: "Bist Du sicher, dass Du diese Richtlinie löschen möchtest?"
       not_found: "Registrierungsrichtlinie nicht gefunden."
       errors:
+        duplicate_institutional_email: "Pro Anmeldeverfahren ist nur eine Richtlinie für institutionelle E-Mails erlaubt."
         missing_domains: "Es muss mindestens eine erlaubte Domain angegeben werden."
         missing_prerequisite_campaign: "Es muss ein vorausgesetztes Anmeldeverfahren ausgewählt werden."
         prerequisite_campaign_not_found: "Das ausgewählte vorausgesetzte Anmeldeverfahren existiert nicht."

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -167,6 +167,7 @@ de:
         lecture_id: "Veranstaltung"
       hints:
         allowed_domains: "z.B. uni-heidelberg.de (erlaubt auch stud.uni-heidelberg.de)"
+        select_prerequisite: "— Anmeldeverfahren auswählen —"
       kinds:
         institutional_email: "Institutionelle E-Mail"
         prerequisite_campaign: "Vorausgesetztes Anmeldeverfahren"

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -167,6 +167,7 @@ en:
         lecture_id: "Lecture"
       hints:
         allowed_domains: "e.g. uni-heidelberg.de (also allows stud.uni-heidelberg.de)"
+        select_prerequisite: "— Select a registration process —"
       kinds:
         institutional_email: "Institutional Email"
         prerequisite_campaign: "Prerequisite Registration Process"

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -292,7 +292,7 @@ en:
         forced: "Forced Assignment"
         forced_short: "Not preferred"
         capacity: "Capacity"
-        utilization: "Utilization"
+        utilization: "Occupancy"
       errors:
         already_completed: "Registration process is already completed."
         wrong_status: "Registration process has wrong status for this action."

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -216,14 +216,14 @@ en:
         lecture: "Lecture"
         lecture_signup: "General Signup"
       actions:
-        remove_from_campaign: "Remove from campaign"
+        remove_from_campaign: "Delete group"
       created: "Item added successfully."
-      destroyed: "Item removed successfully."
+      destroyed: "Group deleted successfully."
       updated: "Item updated successfully."
       invalid_type: "Invalid type."
       cannot_destroy: "Cannot remove item because the campaign is not in draft mode."
       confirm_delete: "Are you sure you want to remove this item?"
-      confirm_remove: "Are you sure you want to remove this item from the campaign?"
+      confirm_remove: "Are you sure you want to permanently delete this group? This action cannot be undone."
       select_type: "Select a group type..."
       attributes:
         capacity_optional: "Capacity (optional)"

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -319,7 +319,7 @@ en:
               no_items: "Cannot open registration process because no items have been added."
               already_has_real_campaign: "A standard registration process already exists for this context. Only one standard registration process is allowed."
             registration_deadline:
-              must_be_in_future: "must be in the future when registration process is open"
+              must_be_in_future: "must be in the future"
             status:
               cannot_revert_to_draft: "cannot be reverted to draft once opened"
             allocation_mode:

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -152,6 +152,7 @@ en:
       not_found: "Registration policy not found."
       errors:
         duplicate_institutional_email: "Only one institutional email policy is allowed per campaign."
+        invalid_domain_format: "Invalid domain format: '%{domain}'. Enter a plain domain, e.g. 'uni-heidelberg.de'."
         missing_domains: "At least one allowed domain must be specified."
         missing_prerequisite_campaign: "A prerequisite campaign must be selected."
         prerequisite_campaign_not_found: "The selected prerequisite campaign does not exist."

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -7,7 +7,7 @@ en:
       create_failed: "Registration process could not be created."
       destroyed: "Registration process deleted successfully."
       cannot_delete: "Registration process cannot be deleted."
-      confirm_delete: "Are you sure you want to delete this registration process?"
+      confirm_delete: "Are you sure you want to delete this registration process? Its groups will not be deleted and can be managed manually afterwards."
       opened: "Registration process opened."
       closed: "Registration process closed."
       reopened: "Registration process reopened."

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -151,6 +151,7 @@ en:
       confirm_delete: "Are you sure you want to delete this policy?"
       not_found: "Registration policy not found."
       errors:
+        duplicate_institutional_email: "Only one institutional email policy is allowed per campaign."
         missing_domains: "At least one allowed domain must be specified."
         missing_prerequisite_campaign: "A prerequisite campaign must be selected."
         prerequisite_campaign_not_found: "The selected prerequisite campaign does not exist."

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -2,39 +2,39 @@ en:
   registration:
     campaign:
       errors:
-        already_finalized: "Campaign is already finalized."
-      created: "Campaign created successfully."
-      create_failed: "Campaign could not be created."
-      destroyed: "Campaign deleted successfully."
-      cannot_delete: "Campaign cannot be deleted."
-      confirm_delete: "Are you sure you want to delete this campaign?"
-      opened: "Campaign opened."
-      closed: "Campaign closed."
-      reopened: "Campaign reopened."
-      finalized: "Campaign finalized successfully."
-      cannot_reopen_completed: "Cannot reopen campaign because it has already been finalized."
-      not_found: "Registration campaign not found."
-      completed_title: "Campaign Completed"
+        already_finalized: "Registration process is already finalized."
+      created: "Registration process created successfully."
+      create_failed: "Registration process could not be created."
+      destroyed: "Registration process deleted successfully."
+      cannot_delete: "Registration process cannot be deleted."
+      confirm_delete: "Are you sure you want to delete this registration process?"
+      opened: "Registration process opened."
+      closed: "Registration process closed."
+      reopened: "Registration process reopened."
+      finalized: "Registration process finalized successfully."
+      cannot_reopen_completed: "Cannot reopen registration process because it has already been finalized."
+      not_found: "Registration process not found."
+      completed_title: "Registration Process Completed"
       completed_description: "The registration period has ended and allocations have been finalized. Please use the group management to make any adjustments."
       go_to_roster: "Go to Roster"
       dissolved_enrolled: "enrolled"
       lecture_not_found: "Lecture not found."
       default_description: "Registration"
       helpdesk:
-        campaigns: "Campaigns manage the registration process for tutorials, seminars, or exams. They define deadlines, allocation modes, and eligibility rules."
-        description: "A short description of the registration campaign (max. 100 characters). This will be displayed in overviews and tables."
+        campaigns: "Registration processes manage enrollment for tutorials, seminars, or exams. They define deadlines, allocation modes, and eligibility rules."
+        description: "A short description of the registration process (max. 100 characters). This will be displayed in overviews and tables."
         allocation_mode: "Determines the registration process. 'First-Come-First-Served': Users register for a specific item and are immediately confirmed or rejected based on capacity. 'Preference-Based': Users submit preferences for multiple items. The final distribution is calculated globally after the deadline."
         registration_deadline: "The date and time when the registration period ends. After this deadline, students can no longer register or change their preferences."
-        allocation_mode_frozen: "The allocation mode cannot be changed once the campaign has been opened or is no longer a draft."
+        allocation_mode_frozen: "The allocation mode cannot be changed once the registration process has been opened or is no longer a draft."
         first_choice: "Shows the number of students who selected this item as their first priority. This helps to gauge demand before the final allocation is calculated."
       index:
         title: "Registrations"
-        card_title: "Registration Campaigns"
-        new_campaign: "New Campaign"
-        none: "No campaigns found."
+        card_title: "Registration Processes"
+        new_campaign: "New Registration Process"
+        none: "No registration processes found."
         sections:
-          registration: "Registration Campaign"
-          no_campaign: "No Campaign"
+          registration: "Registration Process"
+          no_campaign: "No Registration Process"
         columns:
           description: "Short description"
           type: "Type"
@@ -44,12 +44,12 @@ en:
           status: "Status"
           registrations: "Registration Count"
       new:
-        title: "New Campaign"
+        title: "New Registration Process"
       edit:
-        title: "Edit Campaign"
+        title: "Edit Registration Process"
       form:
-        new_title: "New Campaign"
-        edit_title: "Edit Campaign"
+        new_title: "New Registration Process"
+        edit_title: "Edit Registration Process"
         description: "Short description"
         allocation_mode: "Allocation Mode"
         registration_opens_at: "Registration Opens At"
@@ -82,13 +82,13 @@ en:
       confirmations:
         open: "Are you sure you want to open registration? Students will be able to register immediately."
         close: "Are you sure you want to end registration? No new registrations will be accepted."
-        close_early: "The registration deadline has not passed yet. Closing the campaign now will set the deadline to the current time. Are you sure?"
+        close_early: "The registration deadline has not passed yet. Closing the registration process now will set the deadline to the current time. Are you sure?"
         reopen: "Are you sure you want to reopen registration?"
         finalize: "Are you sure you want to finalize the allocation? This will assign students to items based on their preferences and capacities. This action cannot be undone."
         force_finalize: "Are you sure? This will ignore all policy violations and commit the allocation. Even students violating policies will be included."
         reallocate: "Do you really want to recalculate the allocation? The current distribution will be overwritten and might change."
         complete_planning: "Are you sure? This will mark the planning as completed. No rosters will be modified."
-        user_registration_conflict_remove: "Are you sure to remove the registration for user with email %{email} from this campaign? You cannot undo this action."
+        user_registration_conflict_remove: "Are you sure to remove the registration for user with email %{email} from this registration process? You cannot undo this action."
       overview:
         registrations: "Registrations"
         total: "Total"
@@ -102,14 +102,14 @@ en:
           one: "Rejected %{count}"
           other: "Rejected %{count}"
       warnings:
-        no_items: "This campaign has no items yet. Students won't be able to register for anything."
+        no_items: "This registration process has no items yet. Students won't be able to register for anything."
         unlimited_items: "Warning: Some items have unlimited capacity (∞). This means there is no limit on how many students can be assigned to them."
       about:
-        toggle: "What are registration campaigns?"
-        title: "Registration Campaigns: When to Use?"
-        intro: "A registration campaign orchestrates enrollment into groups over a defined timeframe. For simple cases, you can skip campaigns and enable self-enrollment instead."
+        toggle: "What are registration processes?"
+        title: "Registration Processes: When to Use?"
+        intro: "A registration process orchestrates enrollment into groups over a defined timeframe. For simple cases, you can skip registration processes and enable self-enrollment instead."
         when_to_use_campaign:
-          title: "Use a registration campaign when..."
+          title: "Use a registration process when..."
           benefits:
             - "You want to review registrations before finalization"
             - "Eligibility rules are required (e.g., performance check, institutional email)"
@@ -122,11 +122,11 @@ en:
             - "First-come-first-served is sufficient (no preferences)"
             - "Students should be able to join/leave anytime"
             - "You want minimal administrative overhead"
-        note: "Self-enrollment can be enabled after a campaign completes to allow latecomers or group changes."
+        note: "Self-enrollment can be enabled after a registration process completes to allow latecomers or group changes."
     policy:
       helpdesk:
         policies: "Policies are rules that restrict who can register or when registrations are accepted (e.g. users with specific email domains or students who have achieved certain performance criteria)."
-        policies_frozen: "Policies cannot be modified once the campaign has been opened or is no longer a draft."
+        policies_frozen: "Policies cannot be modified once the registration process has been opened or is no longer a draft."
         kind: "The type of rule to enforce. For example, 'Institutional Email' requires users to have an email address from a specific domain."
         phase: "When the rule is checked. 'Registration': Checked when the student tries to register. 'Finalization': Checked when the final assignment is calculated (after the registration deadline has passed). 'Both': Checked at both times."
         allowed_domains: "Enter the main domains (e.g. 'uni-heidelberg.de'). Subdomains (like 'stud.uni-heidelberg.de') are automatically included. Separate multiple domains with commas."
@@ -136,7 +136,7 @@ en:
         none: "No policies configured."
       hint:
         add_after_creation: "Policies (e.g. email restrictions) can be added after creation."
-        locked: "Policies can only be edited while the campaign is in draft."
+        locked: "Policies can only be edited while the registration process is in draft."
       new:
         title: "New Policy"
       edit:
@@ -151,25 +151,25 @@ en:
       confirm_delete: "Are you sure you want to delete this policy?"
       not_found: "Registration policy not found."
       errors:
-        duplicate_institutional_email: "Only one institutional email policy is allowed per campaign."
+        duplicate_institutional_email: "Only one institutional email policy is allowed per registration process."
         invalid_domain_format: "Invalid domain format: '%{domain}'. Enter a plain domain, e.g. 'uni-heidelberg.de'."
         missing_domains: "At least one allowed domain must be specified."
-        missing_prerequisite_campaign: "A prerequisite campaign must be selected."
-        prerequisite_campaign_not_found: "The selected prerequisite campaign does not exist."
+        missing_prerequisite_campaign: "A prerequisite registration process must be selected."
+        prerequisite_campaign_not_found: "The selected prerequisite registration process does not exist."
         no_allowed_domains_configured: "No allowed domains configured."
         email_domain_not_allowed: "Email domain not allowed."
-        prerequisite_not_configured: "Prerequisite campaign not configured."
-        prerequisite_missing: "Prerequisite campaign missing."
-        prerequisite_not_met: "Prerequisite campaign not completed."
+        prerequisite_not_configured: "Prerequisite registration process not configured."
+        prerequisite_missing: "Prerequisite registration process missing."
+        prerequisite_not_met: "Prerequisite registration process not completed."
       configs:
         allowed_domains: "Allowed Domains"
-        prerequisite_campaign_id: "Prerequisite Campaign"
+        prerequisite_campaign_id: "Prerequisite Registration Process"
         lecture_id: "Lecture"
       hints:
         allowed_domains: "e.g. uni-heidelberg.de (also allows stud.uni-heidelberg.de)"
       kinds:
         institutional_email: "Institutional Email"
-        prerequisite_campaign: "Prerequisite Campaign"
+        prerequisite_campaign: "Prerequisite Registration Process"
         student_performance: "Student Performance"
       phases:
         registration: "Registration"
@@ -223,7 +223,7 @@ en:
       destroyed: "Group deleted successfully."
       updated: "Item updated successfully."
       invalid_type: "Invalid type."
-      cannot_destroy: "Cannot remove item because the campaign is not in draft mode."
+      cannot_destroy: "Cannot remove item because the registration process is not in draft mode."
       confirm_delete: "Are you sure you want to remove this item?"
       confirm_remove: "Are you sure you want to permanently delete this group? This action cannot be undone."
       select_type: "Select a group type..."
@@ -257,7 +257,7 @@ en:
       none: "No registrations found."
       preferences: "Preferences"
       actions:
-        remove_user: "Remove user from campaign"
+        remove_user: "Remove user from registration process"
     allocation:
       started: "Allocation has been calculated."
       conflicts:
@@ -293,8 +293,8 @@ en:
         capacity: "Capacity"
         utilization: "Utilization"
       errors:
-        already_completed: "Campaign is already completed."
-        wrong_status: "Campaign has wrong status for this action."
+        already_completed: "Registration process is already completed."
+        wrong_status: "Registration process has wrong status for this action."
         policy_violation: "Policy violations detected. Please review details below."
         policy_violation_title: "Policy Violations Detected"
         policy_violation_desc: "The following users violate the registration policies. You can fix these issues (e.g. by removing the registrations) or force the finalization. Note: Users who are currently unassigned due to capacity limits are not listed here, as they do not occupy a spot."
@@ -310,33 +310,33 @@ en:
         registration/campaign:
           attributes:
             base:
-              frozen: "Campaign configuration cannot be changed once it is no longer in draft mode."
-              already_finalized: "Campaign is already finalized."
-              cannot_delete_active_campaign: "Cannot delete a campaign that is not in draft mode."
-              referenced_as_prerequisite: "Cannot delete campaign because it is a prerequisite for the following campaigns: %{descriptions}."
-              prerequisite_is_draft: "Cannot open campaign because the prerequisite campaign '%{description}' is still in draft mode."
-              no_items: "Cannot open campaign because no items have been added."
-              already_has_real_campaign: "A standard registration campaign already exists for this context. Only one standard campaign is allowed."
+              frozen: "Registration process configuration cannot be changed once it is no longer in draft mode."
+              already_finalized: "Registration process is already finalized."
+              cannot_delete_active_campaign: "Cannot delete a registration process that is not in draft mode."
+              referenced_as_prerequisite: "Cannot delete registration process because it is a prerequisite for the following registration processes: %{descriptions}."
+              prerequisite_is_draft: "Cannot open registration process because the prerequisite registration process '%{description}' is still in draft mode."
+              no_items: "Cannot open registration process because no items have been added."
+              already_has_real_campaign: "A standard registration process already exists for this context. Only one standard registration process is allowed."
             registration_deadline:
-              must_be_in_future: "must be in the future when campaign is open"
+              must_be_in_future: "must be in the future when registration process is open"
             status:
               cannot_revert_to_draft: "cannot be reverted to draft once opened"
             allocation_mode:
-              frozen: "cannot be changed after campaign is opened"
+              frozen: "cannot be changed after registration process is opened"
         registration/policy:
           attributes:
             base:
-              frozen: "Configuration cannot be changed because the registration campaign is no longer in draft mode."
+              frozen: "Configuration cannot be changed because the registration process is no longer in draft mode."
         registration/item:
           attributes:
             registerable_id:
-              taken: "This item is already part of a campaign."
+              taken: "This item is already part of a registration process."
             base:
               capacity_too_low: "Capacity cannot be lower than the number of confirmed registrations (%{count})."
-              frozen: "Configuration cannot be changed because the registration campaign is no longer in draft mode."
-              registerable_not_managed_by_campaign: "The item is locked for registration campaigns."
+              frozen: "Configuration cannot be changed because the registration process is no longer in draft mode."
+              registerable_not_managed_by_campaign: "The item is locked for registration processes."
         registration/user_registration:
           attributes:
             registration_item:
-              must_belong_to_same_campaign: "must belong to the same campaign"
+              must_belong_to_same_campaign: "must belong to the same registration process"
 

--- a/config/locales/roster/de.yml
+++ b/config/locales/roster/de.yml
@@ -296,4 +296,5 @@ de:
       user_moved: "Studierende/r wurde nach %{target} verschoben."
       user_added: "Studierende/r erfolgreich hinzugefügt."
       user_added_to: "Studierende/r wurde zu %{group} hinzugefügt."
+      user_already_member: "Studierende/r ist bereits in dieser Gruppe."
       user_removed: "Studierende/r erfolgreich entfernt."

--- a/config/locales/roster/de.yml
+++ b/config/locales/roster/de.yml
@@ -276,7 +276,7 @@ de:
       target_not_found: "Zielgruppe nicht gefunden."
       target_locked: "Zielgruppe ist gesperrt."
       user_not_found: "Studierende/r nicht gefunden."
-      user_already_in_bundle: "Studierende/r ist bereits %{group} zugewiesen."
+      user_already_in_bundle: "%{user} ist bereits %{group} zugewiesen."
       item_locked: "Diese Gruppe wird durch ein aktives Anmeldeverfahren verwaltet und kann nicht manuell bearbeitet werden."
       campaign_associated: "Selbst-Einschreibung ist nicht verfügbar, da diese Gruppe Teil eines Anmeldeverfahrens ist."
       cannot_delete_in_campaign: "Kann nicht gelöscht werden, da Teil eines Anmeldeverfahrens."
@@ -293,8 +293,8 @@ de:
       setting_cannot_be_changed: 'Diese Einstellung kann nachträglich nicht mehr geändert werden.'
     messages:
       updated: "Einstellungen aktualisiert."
-      user_moved: "Studierende/r wurde nach %{target} verschoben."
-      user_added: "Studierende/r erfolgreich hinzugefügt."
-      user_added_to: "Studierende/r wurde zu %{group} hinzugefügt."
-      user_already_member: "Studierende/r ist bereits in dieser Gruppe."
-      user_removed: "Studierende/r erfolgreich entfernt."
+      user_moved: "%{user} wurde nach %{target} verschoben."
+      user_added: "%{user} wurde zu %{group} hinzugefügt."
+      user_added_to: "%{user} wurde zu %{group} hinzugefügt."
+      user_already_member: "%{user} ist bereits %{group} zugewiesen."
+      user_removed: "%{user} erfolgreich entfernt."

--- a/config/locales/roster/en.yml
+++ b/config/locales/roster/en.yml
@@ -292,4 +292,5 @@ en:
       user_moved: "Student moved to %{target}."
       user_added: "Student added successfully."
       user_added_to: "Student added to %{group}."
+      user_already_member: "Student is already in this group."
       user_removed: "Student removed successfully."

--- a/config/locales/roster/en.yml
+++ b/config/locales/roster/en.yml
@@ -10,22 +10,22 @@ en:
       awaiting_setup_short: "Setup"
       direct_management: "Direct management"
       direct_management_short: "Direct"
-      campaign_draft: "Campaign: Draft"
+      campaign_draft: "Registration Process: Draft"
       campaign_draft_short: "Draft"
-      campaign_open: "Campaign: Registration"
+      campaign_open: "Registration Process: Open"
       campaign_open_short: "Registration"
-      campaign_closed: "Campaign: Closed"
+      campaign_closed: "Registration Process: Closed"
       campaign_closed_short: "Closed"
-      campaign_processing: "Campaign: Processing"
+      campaign_processing: "Registration Process: Processing"
       campaign_processing_short: "Processing"
-      campaign_completed: "Campaign: Completed"
+      campaign_completed: "Registration Process: Completed"
       campaign_completed_short: "Completed"
-      post_campaign: "Post-campaign"
-      post_campaign_short: "Post-camp."
+      post_campaign: "Post-registration"
+      post_campaign_short: "Post-reg."
       self_enrollment: "Self-enrollment"
       no_policy_enforcement: "No policy enforcement"
       gated_by_policies: "Gated by policies: %{policies}"
-      enforced_policies: "Campaign enforced: %{policies}"
+      enforced_policies: "Registration process enforced: %{policies}"
     participants_hint: "This list contains all people enrolled in this lecture. Use the filters:<ul><li><strong>All:</strong> Shows everyone enrolled in the lecture</li><li><strong>Without group:</strong> Shows people who are enrolled but not member of any tutorial or flexible group with lecture enrollment</li></ul>"
     tabs:
       tutorial_maintenance: 'Coursework'
@@ -72,7 +72,7 @@ en:
       title: "Enrollment Strategies"
       toggle: "Enrollment Strategies"
       intro: "This guide compares the different ways to populate your groups."
-      mode_hint: "When using a registration campaign, simply add all relevant groups to it. It is possible to have multiple campaigns, but each group can only belong to one campaign. You can decide per group whether to use a campaign or manual/self-enrollment."
+      mode_hint: "When using a registration process, simply add all relevant groups to it. It is possible to have multiple registration processes, but each group can only belong to one registration process. You can decide per group whether to use a registration process or manual/self-enrollment."
       group_types:
         toggle: "Group Types"
         title: "Available Group Types"
@@ -95,7 +95,7 @@ en:
       phase1:
         title: "1. Choose Your Setup Method"
         campaigns:
-          title: "Registration Campaigns"
+          title: "Registration Processes"
           description: "Time-bounded process with rules"
           benefits:
             - "Allocation via Preferences or FCFS"
@@ -103,7 +103,7 @@ en:
             - "Review registrations before allocation"
             - "Roster entry after deadline"
         skip_campaigns:
-          title: "Skip Campaigns"
+          title: "Skip Registration Processes"
           description: "Immediate, direct access"
           benefits:
             - "Direct join only (FCFS)"
@@ -112,12 +112,12 @@ en:
             - "Immediate roster entry"
       phase2:
         title: "2. What Happens Next"
-        campaigns_during: "Adding/removing members: Locked during campaign"
+        campaigns_during: "Adding/removing members: Locked during registration process"
         campaigns_after: "Adding/removing members: Unlocked after completion"
         direct_always: "Adding/removing members: Always editable"
       phase3:
-        title: "3. Available Anytime (After Campaigns)"
-        description: "Once campaigns complete, both paths have the same options:"
+        title: "3. Available Anytime (After Registration)"
+        description: "Once registration processes complete, both paths have the same options:"
         options:
           - "Manual adjustments: Add or remove individual students"
           - "Control whether students can join or leave groups themselves"
@@ -137,7 +137,7 @@ en:
       confirm_remove: 'Are you sure you want to remove this student?'
       confirm_delete_group: 'Are you sure you want to delete this group?'
       enable_manual_management: 'Direct Management'
-      enable_campaign_management: 'Campaign Management'
+      enable_campaign_management: 'Registration Process Management'
       search: 'Search'
       filter_placeholder: 'Filter by name or email'
     drag:
@@ -184,7 +184,7 @@ en:
       empty_filtered: 'No students match the current filter.'
     candidates:
       title: 'Unplaced Registrations'
-      help: 'Students who registered in campaigns but were not allocated. Assigning them here will add them to the selected group and - depending on group type - also enroll them in the lecture.'
+      help: 'Students who registered in registration processes but were not allocated. Assigning them here will add them to the selected group and - depending on group type - also enroll them in the lecture.'
       empty: 'No unplaced registrations found.'
       no_prefs: 'No preferences'
     manual_enrollment:
@@ -215,40 +215,40 @@ en:
       apply_to_all_free_groups: 'Apply to all groups'
       confirm_bulk_update: >-
         This changes the self-enrollment mode for all groups
-        without a campaign in this lecture to '%{mode}'.
+        without a registration process in this lecture to '%{mode}'.
         Continue?
     policy_bypass_warning:
       title: "Policy Bypass Warning"
-      message: "The last campaign '%{campaign_name}' had a registration policy '%{policy_name}'. Enabling self-enrollment will allow students to join without meeting those requirements."
+      message: "The last registration process '%{campaign_name}' had a registration policy '%{policy_name}'. Enabling self-enrollment will allow students to join without meeting those requirements."
       confirm: "Enable anyway"
       cancel: "Cancel"
     unknown_policy: "Unknown policy"
-    completed_campaign: "Completed campaign"
-    skip_campaigns: 'Skip Campaigns'
-    enable_skip_campaigns_hint: 'Cannot skip campaigns because this group was part of a campaign.'
-    disable_skip_campaigns_hint: 'Cannot enable campaigns because the roster is not empty.'
+    completed_campaign: "Completed registration process"
+    skip_campaigns: 'Skip Registration Processes'
+    enable_skip_campaigns_hint: 'Cannot skip registration processes because this group was part of a registration process.'
+    disable_skip_campaigns_hint: 'Cannot enable registration processes because the roster is not empty.'
     enable_manual_management: 'Enable Direct Management'
-    view_campaign: 'View Campaign'
-    create_campaign: 'Create Campaign'
-    campaign_running: 'Campaign running'
-    campaign_draft: 'Campaign planned'
+    view_campaign: 'View Registration Process'
+    create_campaign: 'Create Registration Process'
+    campaign_running: 'Registration process running'
+    campaign_draft: 'Registration process planned'
     overbooked: 'Overbooked'
-    empty_hint: 'Use registration campaigns to enroll participants. While a campaign is active, manual assignment to groups is locked.'
+    empty_hint: 'Use registration processes to enroll participants. While a registration process is active, manual assignment to groups is locked.'
     tooltips:
       kick_from_lecture: "Removes lecture enrollment and all memberships in tutorials and groups (that have enrollment enabled)"
       kick_from_group: "Removes the student from this group. The lecture enrollment remains."
       manage_participants: "Manage Participants"
-      locked_manage: "Roster is locked during active campaign"
-      locked_manage_no_campaign: "Roster is locked (enable skip campaigns to manage directly)"
+      locked_manage: "Roster is locked during active registration process"
+      locked_manage_no_campaign: "Roster is locked (enable skip registration processes to manage directly)"
       edit_settings: "Edit Settings"
-      edit_disabled_campaign: "Cannot edit settings during active campaign"
+      edit_disabled_campaign: "Cannot edit settings during active registration process"
       delete: "Delete"
-      delete_disabled: "Cannot delete group (has participants or in campaign)"
-      self_materialization_disabled_campaign: "Self-enrollment is disabled during active campaigns"
-      self_materialization_disabled_fresh: "Enable skip campaigns first to use self-enrollment"
-      create_campaign_disabled: "Cannot create campaign (skip campaigns is enabled)"
-      skip_campaigns_enabled: "Skipping campaigns (click to use campaigns)"
-      skip_campaigns_disabled: "Using campaigns (click to skip campaigns)"
+      delete_disabled: "Cannot delete group (has participants or in registration process)"
+      self_materialization_disabled_campaign: "Self-enrollment is disabled during active registration processes"
+      self_materialization_disabled_fresh: "Enable skip registration processes first to use self-enrollment"
+      create_campaign_disabled: "Cannot create registration process (skip registration processes is enabled)"
+      skip_campaigns_enabled: "Skipping registration processes (click to use registration processes)"
+      skip_campaigns_disabled: "Using registration processes (click to skip registration processes)"
     hints:
       superset_exists: "Your course already involves tutorials or talks, so students are enrolled automatically. A separate enrollment group is usually not needed."
       talk_content_html: "Use the %{link} to manage content, tags, and media."
@@ -266,19 +266,19 @@ en:
       rosterable_not_found: 'Roster item not found.'
       invalid_type: 'Invalid group type.'
       roster_not_empty: "cannot be enabled because there are already students in the roster. Please empty the roster first."
-      campaign_running: "cannot be disabled while a campaign is running."
-      active_campaign_exists: 'Self-Enrollment cannot be enabled because an active campaign already handles enrollment.'
+      campaign_running: "cannot be disabled while a registration process is running."
+      active_campaign_exists: 'Self-Enrollment cannot be enabled because an active registration process already handles enrollment.'
       capacity_exceeded: "Group capacity exceeded."
       target_not_found: "Target group not found."
       target_locked: "Target group is locked."
       user_not_found: "Student not found."
       user_already_in_bundle: "Student is already assigned to %{group}."
-      item_locked: "This group is managed by an active registration campaign and cannot be modified manually."
-      campaign_associated: "Self-enrollment is not available because this group is part of a registration campaign."
-      cannot_delete_in_campaign: "Cannot be deleted because it is part of a registration campaign."
+      item_locked: "This group is managed by an active registration process and cannot be modified manually."
+      campaign_associated: "Self-enrollment is not available because this group is part of a registration process."
+      cannot_delete_in_campaign: "Cannot be deleted because it is part of a registration process."
       cannot_delete_not_empty: "Cannot be deleted because there are participants."
       lecture_cannot_self_materialize: "Lectures cannot use self-materialization. The lecture roster is always a superset of all groups."
-      cannot_enable_both_campaign_and_self_materialization: "Cannot enable self-enrollment while switching to campaign mode. Please disable self-enrollment first or keep skip campaigns enabled."
+      cannot_enable_both_campaign_and_self_materialization: "Cannot enable self-enrollment while switching to registration process mode. Please disable self-enrollment first or keep skip registration processes enabled."
     warnings:
       confirm_kick_from_lecture: 'This person will be completely removed from the lecture, including all memberships in groups which have automatic lecture enrollment. Memberships in groups without lecture enrollment remain unaffected. Continue?'
       confirm_kick_from_group: 'Removes the student from this group. The lecture enrollment remains. Continue?'

--- a/config/locales/roster/en.yml
+++ b/config/locales/roster/en.yml
@@ -272,7 +272,7 @@ en:
       target_not_found: "Target group not found."
       target_locked: "Target group is locked."
       user_not_found: "Student not found."
-      user_already_in_bundle: "Student is already assigned to %{group}."
+      user_already_in_bundle: "%{user} is already assigned to %{group}."
       item_locked: "This group is managed by an active registration process and cannot be modified manually."
       campaign_associated: "Self-enrollment is not available because this group is part of a registration process."
       cannot_delete_in_campaign: "Cannot be deleted because it is part of a registration process."
@@ -289,8 +289,8 @@ en:
       setting_cannot_be_changed: 'This setting cannot be changed afterwards.'
     messages:
       updated: "Settings updated."
-      user_moved: "Student moved to %{target}."
-      user_added: "Student added successfully."
-      user_added_to: "Student added to %{group}."
-      user_already_member: "Student is already in this group."
-      user_removed: "Student removed successfully."
+      user_moved: "%{user} moved to %{target}."
+      user_added: "%{user} added to %{group} successfully."
+      user_added_to: "%{user} added to %{group}."
+      user_already_member: "%{user} is already in %{group}."
+      user_removed: "%{user} removed successfully."

--- a/db/migrate/20260416000000_add_unique_title_indexes_to_tutorials_and_cohorts.rb
+++ b/db/migrate/20260416000000_add_unique_title_indexes_to_tutorials_and_cohorts.rb
@@ -1,0 +1,45 @@
+class AddUniqueTitleIndexesToTutorialsAndCohorts < ActiveRecord::Migration[8.0]
+  def up
+    deduplicate_tutorials
+    deduplicate_cohorts
+
+    add_index :tutorials, [:lecture_id, :title],
+              unique: true,
+              name: "index_tutorials_on_lecture_id_and_title_unique"
+    add_index :cohorts, [:context_type, :context_id, :title],
+              unique: true,
+              name: "index_cohorts_on_context_and_title_unique"
+  end
+
+  def down
+    remove_index :tutorials,
+                 name: "index_tutorials_on_lecture_id_and_title_unique"
+    remove_index :cohorts,
+                 name: "index_cohorts_on_context_and_title_unique"
+  end
+
+  private
+
+    def deduplicate_tutorials
+      Tutorial.group(:lecture_id, :title)
+              .having("COUNT(*) > 1")
+              .pluck(:lecture_id, :title)
+              .each do |lecture_id, title|
+        Tutorial.where(lecture_id: lecture_id, title: title)
+                .order(:id).offset(1)
+                .each { |t| t.update_column(:title, "#{title} (#{t.id})") } # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    def deduplicate_cohorts
+      Cohort.group(:context_type, :context_id, :title)
+            .having("COUNT(*) > 1")
+            .pluck(:context_type, :context_id, :title)
+            .each do |context_type, context_id, title|
+        Cohort.where(context_type: context_type, context_id: context_id,
+                     title: title)
+              .order(:id).offset(1)
+              .each { |c| c.update_column(:title, "#{title} (#{c.id})") } # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+end

--- a/db/migrate/20260416000000_add_unique_title_indexes_to_tutorials_and_cohorts.rb
+++ b/db/migrate/20260416000000_add_unique_title_indexes_to_tutorials_and_cohorts.rb
@@ -1,5 +1,6 @@
 class AddUniqueTitleIndexesToTutorialsAndCohorts < ActiveRecord::Migration[8.0]
   def up
+    fill_missing_tutorial_titles
     deduplicate_tutorials
     deduplicate_cohorts
 
@@ -9,9 +10,12 @@ class AddUniqueTitleIndexesToTutorialsAndCohorts < ActiveRecord::Migration[8.0]
     add_index :cohorts, [:context_type, :context_id, :title],
               unique: true,
               name: "index_cohorts_on_context_and_title_unique"
+
+    change_column_null :tutorials, :title, false
   end
 
   def down
+    change_column_null :tutorials, :title, true
     remove_index :tutorials,
                  name: "index_tutorials_on_lecture_id_and_title_unique"
     remove_index :cohorts,
@@ -19,6 +23,13 @@ class AddUniqueTitleIndexesToTutorialsAndCohorts < ActiveRecord::Migration[8.0]
   end
 
   private
+
+    def fill_missing_tutorial_titles
+      Tutorial.where("title IS NULL OR btrim(title) = ''")
+              .find_each do |tutorial|
+        tutorial.update_column(:title, "Tutorial #{tutorial.id}") # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
 
     def deduplicate_tutorials
       Tutorial.group(:lecture_id, :title)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_04_000012) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_16_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -163,6 +163,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_04_000012) do
     t.datetime "updated_at", null: false
     t.boolean "skip_campaigns", default: false, null: false
     t.integer "self_materialization_mode", default: 0, null: false
+    t.index ["context_type", "context_id", "title"], name: "index_cohorts_on_context_and_title_unique", unique: true
     t.index ["context_type", "context_id"], name: "index_cohorts_on_context"
     t.index ["self_materialization_mode"], name: "index_cohorts_on_self_materialization_mode"
   end
@@ -1020,6 +1021,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_04_000012) do
     t.boolean "skip_campaigns", default: false, null: false
     t.integer "self_materialization_mode", default: 0, null: false
     t.string "location"
+    t.index ["lecture_id", "title"], name: "index_tutorials_on_lecture_id_and_title_unique", unique: true
     t.index ["lecture_id"], name: "index_tutorials_on_lecture_id"
     t.index ["self_materialization_mode"], name: "index_tutorials_on_self_materialization_mode"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1013,7 +1013,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_16_000000) do
   end
 
   create_table "tutorials", force: :cascade do |t|
-    t.text "title"
+    t.text "title", null: false
     t.bigint "lecture_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/solver_playground.rake
+++ b/lib/tasks/solver_playground.rake
@@ -513,7 +513,7 @@ namespace :solver do
                                     status: :draft,
                                     allocation_mode: :first_come_first_served,
                                     description: "Stage 1: Planning",
-                                    registration_deadline: 1.week.ago)
+                                    registration_deadline: 1.week.from_now)
 
       planning_cohort = FactoryBot.create(:cohort,
                                           context: seminar,

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :cohort do
-    title { "Repeaters Linear Algebra 1" }
+    sequence(:title) { |n| "Repeaters Linear Algebra #{n}" }
     description do
       "If you failed last year's exam and don't want to go through tutorials again, register here."
     end

--- a/spec/helpers/registration_policy_helper_spec.rb
+++ b/spec/helpers/registration_policy_helper_spec.rb
@@ -37,4 +37,74 @@ RSpec.describe(RegistrationPolicyHelper, type: :helper) do
       end
     end
   end
+
+  describe "#prerequisite_campaign_options" do
+    let(:lecture) { create(:lecture) }
+    let(:campaign) { create(:registration_campaign, campaignable: lecture) }
+
+    it "excludes the current campaign" do
+      other = create(:registration_campaign, campaignable: lecture)
+      expect(helper.prerequisite_campaign_options(campaign)).to eq([other])
+    end
+
+    it "returns campaigns from the same campaignable" do
+      other_lecture = create(:lecture)
+      create(:registration_campaign, campaignable: other_lecture)
+      other = create(:registration_campaign, campaignable: lecture)
+      expect(helper.prerequisite_campaign_options(campaign)).to eq([other])
+    end
+
+    it "returns empty array when no other campaigns exist" do
+      expect(helper.prerequisite_campaign_options(campaign)).to be_empty
+    end
+  end
+
+  describe "#prerequisite_campaign_preselect" do
+    let(:lecture) { create(:lecture) }
+    let(:campaign) { create(:registration_campaign, campaignable: lecture) }
+    let(:other) { create(:registration_campaign, campaignable: lecture) }
+
+    context "when policy is persisted" do
+      let(:policy) do
+        create(:registration_policy, :prerequisite_campaign,
+               registration_campaign: campaign).tap do |p|
+          p.prerequisite_campaign_id = other.id
+          p.save!
+        end
+      end
+
+      it "returns the saved prerequisite_campaign_id regardless of options count" do
+        options = [other]
+        expect(helper.prerequisite_campaign_preselect(policy, options))
+          .to eq(other.id)
+      end
+
+      it "does not auto-pick when options list differs from saved value" do
+        third = create(:registration_campaign, campaignable: lecture)
+        options = [third]
+        expect(helper.prerequisite_campaign_preselect(policy, options))
+          .to eq(other.id)
+      end
+    end
+
+    context "when policy is new" do
+      let(:policy) { campaign.registration_policies.build }
+
+      it "auto-picks when exactly one option exists" do
+        expect(helper.prerequisite_campaign_preselect(policy, [other]))
+          .to eq(other.id)
+      end
+
+      it "returns nil when multiple options exist" do
+        third = create(:registration_campaign, campaignable: lecture)
+        expect(helper.prerequisite_campaign_preselect(policy, [other, third]))
+          .to be_nil
+      end
+
+      it "returns nil when no options exist" do
+        expect(helper.prerequisite_campaign_preselect(policy, []))
+          .to be_nil
+      end
+    end
+  end
 end

--- a/spec/helpers/registration_policy_helper_spec.rb
+++ b/spec/helpers/registration_policy_helper_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe(RegistrationPolicyHelper, type: :helper) do
+  describe "#available_policy_kinds" do
+    let(:campaign) { create(:registration_campaign) }
+
+    context "when creating a new policy" do
+      let(:policy) { campaign.registration_policies.build }
+
+      it "includes institutional_email when none exists yet" do
+        expect(helper.available_policy_kinds(campaign, policy))
+          .to include("institutional_email")
+      end
+
+      it "excludes institutional_email when one already exists" do
+        create(:registration_policy, :institutional_email,
+               registration_campaign: campaign)
+        expect(helper.available_policy_kinds(campaign, policy))
+          .not_to include("institutional_email")
+      end
+
+      it "excludes student_performance" do
+        expect(helper.available_policy_kinds(campaign, policy))
+          .not_to include("student_performance")
+      end
+    end
+
+    context "when editing an existing policy" do
+      let!(:existing) do
+        create(:registration_policy, :institutional_email,
+               registration_campaign: campaign)
+      end
+
+      it "still includes institutional_email so the current value remains selectable" do
+        expect(helper.available_policy_kinds(campaign, existing))
+          .to include("institutional_email")
+      end
+    end
+  end
+end

--- a/spec/helpers/registration_policy_helper_spec.rb
+++ b/spec/helpers/registration_policy_helper_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe(RegistrationPolicyHelper, type: :helper) do
     let(:campaign) { create(:registration_campaign, campaignable: lecture) }
     let(:other) { create(:registration_campaign, campaignable: lecture) }
 
-    context "when policy is persisted" do
+    context "when policy has a prerequisite_campaign_id set (persisted)" do
       let(:policy) do
         create(:registration_policy, :prerequisite_campaign,
                registration_campaign: campaign).tap do |p|
@@ -73,21 +73,33 @@ RSpec.describe(RegistrationPolicyHelper, type: :helper) do
         end
       end
 
-      it "returns the saved prerequisite_campaign_id regardless of options count" do
-        options = [other]
-        expect(helper.prerequisite_campaign_preselect(policy, options))
+      it "returns the saved id regardless of options count" do
+        expect(helper.prerequisite_campaign_preselect(policy, [other]))
           .to eq(other.id)
       end
 
-      it "does not auto-pick when options list differs from saved value" do
+      it "does not auto-pick a different single option" do
         third = create(:registration_campaign, campaignable: lecture)
-        options = [third]
-        expect(helper.prerequisite_campaign_preselect(policy, options))
+        expect(helper.prerequisite_campaign_preselect(policy, [third]))
           .to eq(other.id)
       end
     end
 
-    context "when policy is new" do
+    context "when policy has a prerequisite_campaign_id set (new record after validation error)" do
+      let(:policy) do
+        campaign.registration_policies.build.tap do |p|
+          p.prerequisite_campaign_id = other.id
+        end
+      end
+
+      it "preserves the user's previously chosen value" do
+        third = create(:registration_campaign, campaignable: lecture)
+        expect(helper.prerequisite_campaign_preselect(policy, [other, third]))
+          .to eq(other.id)
+      end
+    end
+
+    context "when policy is new with no prior selection" do
       let(:policy) { campaign.registration_policies.build }
 
       it "auto-picks when exactly one option exists" do

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe(Cohort, type: :model) do
       cohort = build(:cohort, capacity: nil)
       expect(cohort).to be_valid
     end
+
+    it "is invalid with duplicate title in the same context" do
+      cohort = create(:cohort)
+      duplicate = build(:cohort, context: cohort.context, title: cohort.title)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:title]).to be_present
+    end
+
+    it "allows the same title in different contexts" do
+      cohort = create(:cohort)
+      other_context = create(:lecture)
+      other_cohort = build(:cohort, context: other_context, title: cohort.title)
+      expect(other_cohort).to be_valid
+    end
   end
 
   describe "propagate_to_lecture immutability" do

--- a/spec/models/registration/allocation_dashboard_spec.rb
+++ b/spec/models/registration/allocation_dashboard_spec.rb
@@ -116,10 +116,10 @@ RSpec.describe(Registration::AllocationDashboard, type: :model) do
     it "returns active finalization policies for the campaign" do
       policy = create(:registration_policy, registration_campaign: campaign,
                                             active: true, phase: :finalization)
-      create(:registration_policy, registration_campaign: campaign, active: false,
-                                   phase: :finalization)
-      create(:registration_policy, registration_campaign: campaign, active: true,
-                                   phase: :registration)
+      create(:registration_policy, :student_performance, registration_campaign: campaign,
+                                                         active: false, phase: :finalization)
+      create(:registration_policy, :student_performance, registration_campaign: campaign,
+                                                         active: true, phase: :registration)
       expect(dashboard.finalization_policies).to eq([policy])
     end
   end

--- a/spec/models/registration/campaign_spec.rb
+++ b/spec/models/registration/campaign_spec.rb
@@ -91,6 +91,29 @@ RSpec.describe(Registration::Campaign, type: :model) do
       expect(campaign.errors.added?(:registration_deadline, :must_be_in_future)).to be(true)
     end
 
+    it "rejects a past deadline when creating a draft" do
+      campaign = build(:registration_campaign, registration_deadline: 1.day.ago)
+      expect(campaign).not_to be_valid
+      expect(campaign.errors.added?(:registration_deadline, :must_be_in_future)).to be(true)
+    end
+
+    it "rejects explicitly setting a draft deadline to the past" do
+      campaign = create(:registration_campaign)
+      campaign.registration_deadline = 1.day.ago
+      expect(campaign).not_to be_valid
+      expect(campaign.errors.added?(:registration_deadline, :must_be_in_future)).to be(true)
+    end
+
+    it "allows saving a draft when the deadline has expired but was not changed" do
+      campaign = create(:registration_campaign)
+      # Simulate deadline becoming stale without touching the field
+      campaign.class.where(id: campaign.id)
+              .update_all(registration_deadline: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
+      campaign.reload
+      campaign.description = "Updated description"
+      expect(campaign).to be_valid
+    end
+
     it "validates prerequisites are not draft if open" do
       prereq = create(:registration_campaign)
       campaign = create(:registration_campaign)

--- a/spec/models/registration/campaign_spec.rb
+++ b/spec/models/registration/campaign_spec.rb
@@ -693,4 +693,44 @@ RSpec.describe(Registration::Campaign, type: :model) do
       expect(campaign.roster_group_type).to eq("cohorts")
     end
   end
+
+  describe "destroy" do
+    let(:lecture) { create(:lecture) }
+    let(:campaign) { create(:registration_campaign, campaignable: lecture) }
+    let(:tutorial) { create(:tutorial, lecture: lecture, skip_campaigns: false) }
+    let(:cohort) { create(:cohort, context: lecture, skip_campaigns: false) }
+
+    before do
+      create(:registration_item, registration_campaign: campaign,
+                                 registerable: tutorial)
+      create(:registration_item, registration_campaign: campaign,
+                                 registerable: cohort)
+    end
+
+    it "sets skip_campaigns to true on all involved tutorials" do
+      campaign.destroy!
+      expect(tutorial.reload.skip_campaigns).to be(true)
+    end
+
+    it "sets skip_campaigns to true on all involved cohorts" do
+      campaign.destroy!
+      expect(cohort.reload.skip_campaigns).to be(true)
+    end
+
+    it "does not affect tutorials from a different campaign" do
+      other_campaign = create(:registration_campaign, campaignable: lecture)
+      other_tutorial = create(:tutorial, lecture: lecture, skip_campaigns: false)
+      create(:registration_item, registration_campaign: other_campaign,
+                                 registerable: other_tutorial)
+
+      campaign.destroy!
+      expect(other_tutorial.reload.skip_campaigns).to be(false)
+    end
+
+    it "does not destroy the groups themselves" do
+      campaign.destroy!
+      expect { tutorial.reload }.not_to raise_error
+      expect { cohort.reload }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/registration/campaign_spec.rb
+++ b/spec/models/registration/campaign_spec.rb
@@ -755,5 +755,14 @@ RSpec.describe(Registration::Campaign, type: :model) do
       expect { tutorial.reload }.not_to raise_error
       expect { cohort.reload }.not_to raise_error
     end
+
+    it "releases registerables into manual mode when a campaign is destroyed" do
+      expect { campaign.destroy }.to change(Registration::Campaign, :count).by(-1)
+
+      tutorial.reload
+      expect(tutorial.skip_campaigns).to be(true)
+      expect(tutorial).not_to be_locked
+      expect(tutorial).to be_valid
+    end
   end
 end

--- a/spec/models/registration/policy/institutional_email_handler_spec.rb
+++ b/spec/models/registration/policy/institutional_email_handler_spec.rb
@@ -51,11 +51,51 @@ RSpec.describe(Registration::Policy::InstitutionalEmailHandler, type: :model) do
       expect(policy.errors[:allowed_domains])
         .to include(I18n.t("registration.policy.errors.missing_domains"))
     end
+
+    it "silently normalizes a domain with an @ prefix" do
+      policy.config = { "allowed_domains" => "@uni.example" }
+      handler.validate
+      expect(policy.errors[:allowed_domains]).to be_empty
+    end
+
+    it "adds error for a full email address" do
+      policy.config = { "allowed_domains" => "user@uni.example" }
+      handler.validate
+      expect(policy.errors[:allowed_domains].join)
+        .to include(I18n.t("registration.policy.errors.invalid_domain_format",
+                           domain: "user@uni.example"))
+    end
+
+    it "adds error for a URL" do
+      policy.config = { "allowed_domains" => "https://uni.example" }
+      handler.validate
+      expect(policy.errors[:allowed_domains].join)
+        .to include(I18n.t("registration.policy.errors.invalid_domain_format",
+                           domain: "https://uni.example"))
+    end
+
+    it "adds error for a domain with spaces" do
+      policy.config = { "allowed_domains" => "uni heidelberg.de" }
+      handler.validate
+      expect(policy.errors[:allowed_domains]).not_to be_empty
+    end
+
+    it "adds error for a bare label without a TLD" do
+      policy.config = { "allowed_domains" => "uni-heidelberg" }
+      handler.validate
+      expect(policy.errors[:allowed_domains]).not_to be_empty
+    end
+
+    it "does not add errors for valid domains" do
+      policy.config = { "allowed_domains" => "uni-heidelberg.de, kit.edu" }
+      handler.validate
+      expect(policy.errors[:allowed_domains]).to be_empty
+    end
   end
 
   describe "#summary" do
     it "returns comma separated domains" do
-      expect(handler.summary).to eq("uni.example, test.org")
+      expect(handler.summary).to eq("uni.example | test.org")
     end
   end
 end

--- a/spec/models/registration/policy/institutional_email_handler_spec.rb
+++ b/spec/models/registration/policy/institutional_email_handler_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe(Registration::Policy::InstitutionalEmailHandler, type: :model) do
   end
 
   describe "#summary" do
-    it "returns comma separated domains" do
+    it "returns pipe separated domains" do
       expect(handler.summary).to eq("uni.example | test.org")
     end
   end

--- a/spec/models/registration/policy_spec.rb
+++ b/spec/models/registration/policy_spec.rb
@@ -81,12 +81,32 @@ RSpec.describe(Registration::Policy, type: :model) do
         expect(policy.errors[:prerequisite_campaign_id])
           .to include(I18n.t("registration.policy.errors.prerequisite_campaign_not_found"))
       end
+
+      it "prevents a second institutional_email policy in the same campaign" do
+        campaign = create(:registration_campaign)
+        create(:registration_policy, :institutional_email,
+               registration_campaign: campaign)
+        duplicate = build(:registration_policy, :institutional_email,
+                          registration_campaign: campaign)
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:kind])
+          .to include(I18n.t("registration.policy.errors.duplicate_institutional_email"))
+      end
+
+      it "allows institutional_email policies in different campaigns" do
+        create(:registration_policy, :institutional_email)
+        policy = build(:registration_policy, :institutional_email)
+        expect(policy).to be_valid
+      end
     end
 
     describe "ordering" do
       let(:campaign) { create(:registration_campaign) }
       let!(:policy1) { create(:registration_policy, registration_campaign: campaign) }
-      let!(:policy2) { create(:registration_policy, registration_campaign: campaign) }
+      let!(:policy2) do
+        create(:registration_policy, :student_performance,
+               registration_campaign: campaign)
+      end
 
       it "orders policies by position" do
         expect(policy1.position).to eq(1)
@@ -268,16 +288,16 @@ RSpec.describe(Registration::Policy, type: :model) do
       describe ".for_phase" do
         let(:campaign) { create(:registration_campaign) }
         let!(:registration_policy) do
-          create(:registration_policy, registration_campaign: campaign,
-                                       phase: :registration)
+          create(:registration_policy, :student_performance,
+                 registration_campaign: campaign, phase: :registration)
         end
         let!(:finalization_policy) do
-          create(:registration_policy, registration_campaign: campaign,
-                                       phase: :finalization)
+          create(:registration_policy, :student_performance,
+                 registration_campaign: campaign, phase: :finalization)
         end
         let!(:both_policy) do
-          create(:registration_policy, registration_campaign: campaign,
-                                       phase: :both)
+          create(:registration_policy, :student_performance,
+                 registration_campaign: campaign, phase: :both)
         end
 
         it "includes policies for the requested phase and 'both'" do

--- a/spec/requests/registration/policies_spec.rb
+++ b/spec/requests/registration/policies_spec.rb
@@ -282,8 +282,8 @@ RSpec.describe("Registration::Policies", type: :request) do
                                    kind: :institutional_email, position: 1)
     end
     let!(:policy2) do
-      create(:registration_policy, registration_campaign: campaign,
-                                   kind: :institutional_email, position: 2)
+      create(:registration_policy, :student_performance, registration_campaign: campaign,
+                                                         position: 2)
     end
 
     context "as an editor" do
@@ -318,8 +318,8 @@ RSpec.describe("Registration::Policies", type: :request) do
                                    kind: :institutional_email, position: 1)
     end
     let!(:policy2) do
-      create(:registration_policy, registration_campaign: campaign,
-                                   kind: :institutional_email, position: 2)
+      create(:registration_policy, :student_performance, registration_campaign: campaign,
+                                                         position: 2)
     end
 
     context "as an editor" do

--- a/spec/requests/roster/maintenance_spec.rb
+++ b/spec/requests/roster/maintenance_spec.rb
@@ -134,6 +134,40 @@ RSpec.describe("Roster::Maintenance", type: :request) do
         expect(flash[:alert]).to be_present
       end
 
+      it "includes user name and group name in the success flash" do
+        post add_member_tutorial_path(tutorial), params: { email: new_student.email }
+        expect(flash[:notice]).to eq(
+          I18n.t("roster.messages.user_added",
+                 user: new_student.info, group: tutorial.title)
+        )
+      end
+
+      context "when user is already in this tutorial" do
+        before { create(:tutorial_membership, tutorial: tutorial, user: new_student) }
+
+        it "includes user name and group name in the already-member flash" do
+          post add_member_tutorial_path(tutorial), params: { email: new_student.email }
+          expect(flash[:notice]).to eq(
+            I18n.t("roster.messages.user_already_member",
+                   user: new_student.info, group: tutorial.title)
+          )
+        end
+      end
+
+      context "when user is already in another tutorial of the same lecture" do
+        let!(:other_tutorial) { create(:tutorial, lecture: lecture, skip_campaigns: true) }
+
+        before { create(:tutorial_membership, tutorial: other_tutorial, user: new_student) }
+
+        it "includes user name and conflicting group in the alert" do
+          post add_member_tutorial_path(tutorial), params: { email: new_student.email }
+          expect(flash[:alert]).to eq(
+            I18n.t("roster.errors.user_already_in_bundle",
+                   user: new_student.info, group: other_tutorial.title)
+          )
+        end
+      end
+
       context "when group is locked" do
         let(:tutorial) { create(:tutorial, lecture: lecture, skip_campaigns: false) }
         let!(:campaign) do
@@ -187,6 +221,13 @@ RSpec.describe("Roster::Maintenance", type: :request) do
         expect do
           delete(remove_member_tutorial_path(tutorial, user_id: member.id))
         end.not_to(change { lecture.members.count })
+      end
+
+      it "includes user name in the flash" do
+        delete remove_member_tutorial_path(tutorial, user_id: member.id)
+        expect(flash[:notice]).to eq(
+          I18n.t("roster.messages.user_removed", user: member.info)
+        )
       end
 
       context "when group is locked" do
@@ -251,7 +292,10 @@ RSpec.describe("Roster::Maintenance", type: :request) do
       it "sets the correct flash message" do
         patch move_member_tutorial_path(source, user_id: member.id),
               params: { target_id: target.id }
-        expect(flash[:notice]).to eq(I18n.t("roster.messages.user_moved", target: target.title))
+        expect(flash[:notice]).to eq(
+          I18n.t("roster.messages.user_moved",
+                 user: member.info, target: target.title)
+        )
       end
 
       context "when target is locked" do


### PR DESCRIPTION
In this PR, we fix several bugs and correct some inconveniences that were noticed by a UI tester. Here is a list of the bugs and their corresponding fixes:

- When editing a cohort, it displayed a hint that the enrollment switch cannot be changed after creation (additionally to the switch being disabled). However, it was not displayed when a cohort was actually created. We flip this here: Hint is shown on creation, not on editing
- In the group side panel, there was also an add button (for manually adding students to the roster) for groups within campaigns. This is fixed now: no longer such a button in this case.
- When saving an email policy, there was an exception due to a missing method on the policies controller. Method was added.
- The logic behind the destroy button for groups inside campaigns was changed: It used to delete only the campaign item and not the underlying group, which resulted in a move of the group to the "free" section. Now the destroy button actually destroys the group
- It was possible to create several email policies for one campaign (with different email domains). Since they are combined via AND, this would easily generate contradictory policies. We added a validation that allows only one email policy per campaign (having several domains inside this one policy is still possible: just separate domains by comma)
- The validation for the user input for the email domain was rather weak and would allow pretty nonsensical things. It has been hardened. Also, if a user incidentally uses an @ for the domain, it is filtered out.
- In the GUI in the English locale we spoke of "campaigns" which might be not so clear - this has been changed to "Registration process" which is closer to the German "Anmeldeverfahren"
- Cohort titles did not have a uniqueness validation (inside a given lecture). Tutorial titles did have one, but no uniqueness index in the database. Now both models ha both a model side validation and a database index.
- The logic for the prerequisite campaign policy was flawed: Every campaign (globally) was selectable as prerequisite, but it should be only campaigns from the given lecture. Also, a placeholder text was missing in the dropdown. This was fixed.
- When no deadline was given in the campaign form, the datetimepicker item moved to one line below the actual datetime field (below which the error message is displayed). This was fixed.
-  In the allocation dashboard, the "utilization" column was renamed to "occupancy".
- When a student was added to a group where the student was already a member, the flash message still read "Student successfully added to group" (or so). Now it says "Student is already in the group".
- When the "unassigned sidepanel" was open and a group’s capacity was changed, Turbo refreshed the roster tiles but kept the sidepanel controller alive. Drag-and-drop then silently stopped working because roster_drag still had Sortable drop zones bound to the old tile DOM, so no drop handler fired until a full page reload.
 The fix was to make  the roster_drag controller.js rebind its drop zones after each `turbo:stream-render` and remove that listener on disconnect. That keeps the open sidepanel synchronized with refreshed group tiles.
- The flash messages in roster management for moving/adding/removing students were unpersonalized: "Student added to group". Now they are enriched with more information: "John Doe (john@doe) was added to Tutorial 1".
- When a campaign was destroyed, its groups were moved to the free are where they instantly became locked basically because the `skip_campaign` flag was left untouched by this and kept its `false` value. Now, upon destroying a campaign, the `skip_campaign` flag of its groups is set to `true` which makes them amenable to manual edits immediately. Also, in the confirmation dialog, it is now mentioned that the groups are not deleted and can be managed manually after the deletion of the campaign.
- It was possible to create a campaign with a deadline in the past (or change the deadline to a past date fr draft campaigns). Only on opening the campaign would a flash message show that tells the user that it can't open because the deadline is in the past. The corresponding model validation has been made stricter now, disallowing this. The flash message still guards against the case that a campaign becomes "stale" (by the time passing the deadline date before opening).
- Enforce that tutorials have a title on DB level.