### PR TITLE
Rework Dependabot settings & enable it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -150,7 +150,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "major-infrastructure"
-    ppatterns: ["*"]
+    patterns: ["*"]
     commit-message:
       prefix: "deps (infra, major): "
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "regular-dependencies"
+    patterns: ["*"]
     commit-message:
       prefix: "deps: "
     rebase-strategy: "disabled"
@@ -62,6 +63,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "regular-dependencies"
+    patterns: ["*"]
     commit-message:
       prefix: "deps: "
     rebase-strategy: "disabled"
@@ -74,6 +76,7 @@ updates:
   - package-ecosystem: "docker"
     target-branch: "security"
     multi-ecosystem-group: "regular-infrastructure"
+    patterns: ["*"]
     directories:
       - "/docker/**/*"
     commit-message:
@@ -89,6 +92,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "regular-infrastructure"
+    patterns: ["*"]
     commit-message:
       prefix: "deps (infra): "
     rebase-strategy: "disabled"
@@ -109,6 +113,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "major-dependencies"
+    patterns: ["*"]
     commit-message:
       prefix: "deps (major): "
     rebase-strategy: "disabled"
@@ -120,6 +125,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "major-dependencies"
+    patterns: ["*"]
     commit-message:
       prefix: "deps (major): "
     rebase-strategy: "disabled"
@@ -130,6 +136,7 @@ updates:
   - package-ecosystem: "docker"
     target-branch: "security"
     multi-ecosystem-group: "major-infrastructure"
+    patterns: ["*"]
     directories:
       - "/docker/**/*"
     commit-message:
@@ -143,6 +150,7 @@ updates:
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "major-infrastructure"
+    ppatterns: ["*"]
     commit-message:
       prefix: "deps (infra, major): "
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,113 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
+# Docs:
+# https://docs.github.com/en/code-security/dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates
+# https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#approve-a-pull-request
 
 version: 2
-updates:
-  - package-ecosystem: "bundler"
-    directory: "/"
-    <<: &updater_defaults
-    target-branch: "security"
+
+multi-ecosystem-groups:
+  regular-dependencies:
     schedule:
       interval: "cron"
-      # every Monday and Thursday at 00:00
-      cronjob: "0 0 * * 1,4" 
+      # Every Monday and Thursday at 00:00
+      cronjob: "0 0 * * 1,4"
+
+  regular-infrastructure:
+    schedule:
+      interval: "cron"
+      # Every Monday and Thursday at 00:00
+      cronjob: "0 0 * * 1,4"
+
+  major-dependencies:
+    schedule:
+      interval: "cron"
+      # Every 20 days at 00:00
+      cronjob: "0 0 */20 * *"
+
+  major-infrastructure:
+    schedule:
+      interval: "cron"
+      # Every 20 days at 00:00
+      cronjob: "0 0 */20 * *"
+
+updates:
+  ##############################################################################
+  # REGULAR UPDATES
+  # - security updates
+  # - patch updates
+  # - minor updates
+  #
+  # Auto-merge candidate after CI succeeds.
+  ##############################################################################
+
+  - &regular_defaults
+    package-ecosystem: "bundler"
+    directory: "/"
+    target-branch: "security"
+    multi-ecosystem-group: "regular-dependencies"
     commit-message:
       prefix: "deps: "
-    open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
-  - <<: *updater_defaults
+  - <<: *regular_defaults
     package-ecosystem: "npm"
     directory: "/"
 
-  - <<: *updater_defaults
+  - <<: *regular_defaults
     package-ecosystem: "docker"
+    multi-ecosystem-group: "regular-infrastructure"
     directories:
       - "/docker/**/*"
+    commit-message:
+      prefix: "deps (infra): "
 
-  - <<: *updater_defaults
+  - <<: *regular_defaults
     package-ecosystem: "github-actions"
+    multi-ecosystem-group: "regular-infrastructure"
     directory: "/"
+    commit-message:
+      prefix: "deps (infra): "
+
+
+  ##############################################################################
+  # MAJOR VERSION UPDATES
+  #
+  # Manual review recommended
+  ##############################################################################
+
+  - &major_defaults
+    package-ecosystem: "bundler"
+    directory: "/"
+    target-branch: "security"
+    multi-ecosystem-group: "major-dependencies"
+    commit-message:
+      prefix: "deps (major): "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "all"
+
+  - <<: *major_defaults
+    package-ecosystem: "npm"
+    directory: "/"
+
+  - <<: *major_defaults
+    package-ecosystem: "docker"
+    multi-ecosystem-group: "major-infrastructure"
+    directories:
+      - "/docker/**/*"
+    commit-message:
+      prefix: "deps (infra, major): "
+
+  - <<: *major_defaults
+    package-ecosystem: "github-actions"
+    multi-ecosystem-group: "major-infrastructure"
+    directory: "/"
+    commit-message:
+      prefix: "deps (infra, major): "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,37 +6,25 @@ version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
-    target-branch: "next"
+    <<: &updater_defaults
+    target-branch: "security"
     schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
+      interval: "cron"
+      # every Monday and Thursday at 00:00
+      cronjob: "0 0 * * 1,4" 
+    commit-message:
+      prefix: "deps: "
     open-pull-requests-limit: 0
 
-  - package-ecosystem: "npm"
+  - <<: *updater_defaults
+    package-ecosystem: "npm"
     directory: "/"
-    target-branch: "next"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-    open-pull-requests-limit: 0
 
-  - package-ecosystem: "docker"
+  - <<: *updater_defaults
+    package-ecosystem: "docker"
     directories:
       - "/docker/**/*"
-    target-branch: "next"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-    open-pull-requests-limit: 0
 
-  - package-ecosystem: "github-actions"
+  - <<: *updater_defaults
+    package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "next"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ version: 2
 
 multi-ecosystem-groups:
   regular-dependencies:
+    target-branch: "security"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "deps: "
     schedule:
       interval: "cron"
       # Every Monday at 09:00
@@ -15,6 +19,10 @@ multi-ecosystem-groups:
       timezone: "Europe/Berlin"
 
   regular-infrastructure:
+    target-branch: "security"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "deps (infra): "
     schedule:
       interval: "cron"
       # Every Monday at 09:00
@@ -22,6 +30,10 @@ multi-ecosystem-groups:
       timezone: "Europe/Berlin"
 
   major-dependencies:
+    target-branch: "security"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "deps (major): "
     schedule:
       interval: "cron"
       # Every 20 days at 09:00
@@ -29,6 +41,10 @@ multi-ecosystem-groups:
       timezone: "Europe/Berlin"
 
   major-infrastructure:
+    target-branch: "security"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "deps (infra, major): "
     schedule:
       interval: "cron"
       # Every 20 days at 09:00
@@ -47,13 +63,9 @@ updates:
 
   - package-ecosystem: "bundler"
     directory: "/"
-    target-branch: "security"
     multi-ecosystem-group: "regular-dependencies"
     patterns: ["*"]
-    commit-message:
-      prefix: "deps: "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
         update-types:
@@ -61,28 +73,20 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "security"
     multi-ecosystem-group: "regular-dependencies"
     patterns: ["*"]
-    commit-message:
-      prefix: "deps: "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
 
   - package-ecosystem: "docker"
-    target-branch: "security"
     multi-ecosystem-group: "regular-infrastructure"
     patterns: ["*"]
     directories:
       - "/docker/**/*"
-    commit-message:
-      prefix: "deps (infra): "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
         update-types:
@@ -90,13 +94,9 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "security"
     multi-ecosystem-group: "regular-infrastructure"
     patterns: ["*"]
-    commit-message:
-      prefix: "deps (infra): "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
         update-types:
@@ -111,49 +111,33 @@ updates:
 
   - package-ecosystem: "bundler"
     directory: "/"
-    target-branch: "security"
     multi-ecosystem-group: "major-dependencies"
     patterns: ["*"]
-    commit-message:
-      prefix: "deps (major): "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     allow:
       - dependency-type: "all"
 
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "security"
     multi-ecosystem-group: "major-dependencies"
     patterns: ["*"]
-    commit-message:
-      prefix: "deps (major): "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     allow:
       - dependency-type: "all"
 
   - package-ecosystem: "docker"
-    target-branch: "security"
     multi-ecosystem-group: "major-infrastructure"
     patterns: ["*"]
     directories:
       - "/docker/**/*"
-    commit-message:
-      prefix: "deps (infra, major): "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     allow:
       - dependency-type: "all"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "security"
     multi-ecosystem-group: "major-infrastructure"
     patterns: ["*"]
-    commit-message:
-      prefix: "deps (infra, major): "
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 2
     allow:
       - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,14 @@ multi-ecosystem-groups:
   regular-dependencies:
     schedule:
       interval: "cron"
-      # Every Monday and Thursday at 00:00
-      cronjob: "0 0 * * 1,4"
+      # Every Monday at 00:00
+      cronjob: "0 0 * * 1"
 
   regular-infrastructure:
     schedule:
       interval: "cron"
-      # Every Monday and Thursday at 00:00
-      cronjob: "0 0 * * 1,4"
+      # Every Monday at 00:00
+      cronjob: "0 0 * * 1"
 
   major-dependencies:
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,8 +45,7 @@ updates:
   # Auto-merge candidate after CI succeeds.
   ##############################################################################
 
-  - &regular_defaults
-    package-ecosystem: "bundler"
+  - package-ecosystem: "bundler"
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "regular-dependencies"
@@ -59,24 +58,45 @@ updates:
         update-types:
           - "version-update:semver-major"
 
-  - <<: *regular_defaults
-    package-ecosystem: "npm"
+  - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "security"
+    multi-ecosystem-group: "regular-dependencies"
+    commit-message:
+      prefix: "deps: "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
-  - <<: *regular_defaults
-    package-ecosystem: "docker"
+  - package-ecosystem: "docker"
+    target-branch: "security"
     multi-ecosystem-group: "regular-infrastructure"
     directories:
       - "/docker/**/*"
     commit-message:
       prefix: "deps (infra): "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
-  - <<: *regular_defaults
-    package-ecosystem: "github-actions"
-    multi-ecosystem-group: "regular-infrastructure"
+  - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "security"
+    multi-ecosystem-group: "regular-infrastructure"
     commit-message:
       prefix: "deps (infra): "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
 
   ##############################################################################
@@ -85,8 +105,7 @@ updates:
   # Manual review recommended
   ##############################################################################
 
-  - &major_defaults
-    package-ecosystem: "bundler"
+  - package-ecosystem: "bundler"
     directory: "/"
     target-branch: "security"
     multi-ecosystem-group: "major-dependencies"
@@ -97,21 +116,36 @@ updates:
     allow:
       - dependency-type: "all"
 
-  - <<: *major_defaults
-    package-ecosystem: "npm"
+  - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "security"
+    multi-ecosystem-group: "major-dependencies"
+    commit-message:
+      prefix: "deps (major): "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "all"
 
-  - <<: *major_defaults
-    package-ecosystem: "docker"
+  - package-ecosystem: "docker"
+    target-branch: "security"
     multi-ecosystem-group: "major-infrastructure"
     directories:
       - "/docker/**/*"
     commit-message:
       prefix: "deps (infra, major): "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "all"
 
-  - <<: *major_defaults
-    package-ecosystem: "github-actions"
-    multi-ecosystem-group: "major-infrastructure"
+  - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "security"
+    multi-ecosystem-group: "major-infrastructure"
     commit-message:
       prefix: "deps (infra, major): "
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,26 +10,30 @@ multi-ecosystem-groups:
   regular-dependencies:
     schedule:
       interval: "cron"
-      # Every Monday at 00:00
-      cronjob: "0 0 * * 1"
+      # Every Monday at 09:00
+      cronjob: "0 9 * * 1"
+      timezone: "Europe/Berlin"
 
   regular-infrastructure:
     schedule:
       interval: "cron"
-      # Every Monday at 00:00
-      cronjob: "0 0 * * 1"
+      # Every Monday at 09:00
+      cronjob: "0 9 * * 1"
+      timezone: "Europe/Berlin"
 
   major-dependencies:
     schedule:
       interval: "cron"
-      # Every 20 days at 00:00
-      cronjob: "0 0 */20 * *"
+      # Every 20 days at 09:00
+      cronjob: "0 9 */20 * *"
+      timezone: "Europe/Berlin"
 
   major-infrastructure:
     schedule:
       interval: "cron"
-      # Every 20 days at 00:00
-      cronjob: "0 0 */20 * *"
+      # Every 20 days at 09:00
+      cronjob: "0 9 */20 * *"
+      timezone: "Europe/Berlin"
 
 updates:
   ##############################################################################


### PR DESCRIPTION
I came up with some new config for Dependabot, let me know what you think. I've separated into these PRs:

- Every Monday, we will get the following PRs:
  - Regular dependency updates concerning Gems and npm packages (patch, minor and security)
  - Regular infrastructure dependency updates concerning Docker and GitHub Actions (patch, minor and security)
- Every 20 days:
  - Dependency updates concerning Germs and npm packages (MAJOR versions)
  - Infrastructure Dependency updates concerning Docker and GitHub Actions (MAJOR versions)

The Dependabot PRs target the `security` branch.

A future PR could tackle merging specific Dependabot PRs automatically to the `security` branch.

---

Note that I don't know if this config will actually work, we'll have to try it out ;) At least, the config is syntactically correct (see the dependabot action that reported this)