### PR TITLE
security: Harden pdf upload

### DIFF
--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -20,9 +20,10 @@ class PdfUploader < Shrine
         temp_file = Tempfile.new
         temp_folder = Dir.mktmpdir
         structure_path = "#{temp_folder}/structure.mampf"
-        cmd = "pdftk #{file.path} dump_data_utf8 output #{temp_file.path} && " \
-              "pdftk #{file.path} unpack_files output #{temp_folder}"
-        exit_status = system(cmd)
+        exit_status = system("pdftk", file.path, "dump_data_utf8", "output",
+                             temp_file.path) &&
+                      system("pdftk", file.path, "unpack_files", "output",
+                             temp_folder)
         if exit_status
           meta = File.read(temp_file)
           # extract number of pages from pdftk output

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -31,7 +31,8 @@ class PdfUploader < Shrine
             exit_status = run_pdftk(file.path, "dump_data_utf8", "output",
                                     temp_file.path) &&
                           run_pdftk(file.path, "unpack_files", "output",
-                                    temp_folder) &&
+                                    temp_folder,
+                                    file_size_limit: MAX_STRUCTURE_BYTES) &&
                           valid_unpacked_structure?(temp_folder)
             if exit_status
               meta = File.read(temp_file)
@@ -106,9 +107,13 @@ class PdfUploader < Shrine
       Dir.mktmpdir("pdftk-", UNPACK_ROOT.to_s, &)
     end
 
-    def run_pdftk(*)
-      pid = Process.spawn("pdftk", *, out: File::NULL, err: File::NULL,
-                                      pgroup: true)
+    def run_pdftk(*arguments, file_size_limit: nil)
+      spawn_options = { out: File::NULL, err: File::NULL, pgroup: true }
+      if file_size_limit
+        spawn_options[:rlimit_fsize] = [file_size_limit, file_size_limit]
+      end
+
+      pid = Process.spawn("pdftk", *arguments, spawn_options)
       _pid, status = Timeout.timeout(PDFTK_TIMEOUT) { Process.wait2(pid) }
       status.success?
     rescue SystemCallError

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -111,6 +111,8 @@ class PdfUploader < Shrine
                                       pgroup: true)
       _pid, status = Timeout.timeout(PDFTK_TIMEOUT) { Process.wait2(pid) }
       status.success?
+    rescue SystemCallError
+      false
     rescue Timeout::Error
       terminate_process_group(pid)
       false

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -36,7 +36,8 @@ class PdfUploader < Shrine
             if exit_status
               meta = File.read(temp_file)
               # extract number of pages from pdftk output
-              pages = /NumberOfPages: (\d*)/.match(meta)[1].to_i
+              page_match = /NumberOfPages: (\d*)/.match(meta)
+              pages = page_match[1].to_i if page_match
               # extract lines that correspond to MaMpf-Label entries from LaTEX
               # package mampf.sty
               structure = if File.file?(structure_path)
@@ -47,16 +48,18 @@ class PdfUploader < Shrine
               structure ||= ""
               bookmarks = structure.scan(/MaMpf-Label\|(.*?)\n/).flatten
               result = []
-              bookmarks.each_with_index do |b, i|
+              bookmarks.each do |b|
                 # extract bookmark data
                 # line may look like this:
                 # defn:erster-Tag|Definition|1.1|Erster Tag|1
                 data = /(.*?)\|(.*?)\|(.*?)\|(.*?)\|(.*)\|(.*)\|(.*)\|(.*)/.match(b)
+                next unless data
+
                 details = { "destination" => data[1], "sort" => data[2],
                             "label" => data[3], "description" => data[4],
                             "chapter" => data[5], "section" => data[6],
                             "subsection" => data[7], "page" => data[8],
-                            "counter" => i }
+                            "counter" => result.length }
                 details["sort"] = "Markierung" if details["sort"].blank?
                 result.push(details)
               end

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -1,9 +1,17 @@
+require "fileutils"
 require "image_processing/mini_magick"
+require "timeout"
 
 # PdfUploader Class
 class PdfUploader < Shrine
+  MAX_FILE_SIZE = 50 * 1024 * 1024
+  PDFTK_TIMEOUT = 10
+  MAX_STRUCTURE_BYTES = 256 * 1024
+  STRUCTURE_FILE_NAME = "structure.mampf".freeze
+  UNPACK_ROOT = Rails.root.join("tmp/pdf_uploader")
+
   # shrine plugins
-  plugin :upload_endpoint
+  plugin :upload_endpoint, max_size: MAX_FILE_SIZE
   plugin :add_metadata
   plugin :determine_mime_type
   plugin :validation_helpers
@@ -17,52 +25,55 @@ class PdfUploader < Shrine
   add_metadata do |io, context|
     if context[:action] == :upload
       Shrine.with_file(io) do |file|
-        temp_file = Tempfile.new
-        temp_folder = Dir.mktmpdir
-        structure_path = "#{temp_folder}/structure.mampf"
-        exit_status = system("pdftk", file.path, "dump_data_utf8", "output",
-                             temp_file.path) &&
-                      system("pdftk", file.path, "unpack_files", "output",
-                             temp_folder)
-        if exit_status
-          meta = File.read(temp_file)
-          # extract number of pages from pdftk output
-          pages = /NumberOfPages: (\d*)/.match(meta)[1].to_i
-          # extract lines that correspond to MaMpf-Label entries from LaTEX
-          # package mampf.sty
-          structure = if File.file?(structure_path)
-            File.open(structure_path, "r") do |io_stream|
-              io_stream.read.encode("UTF-8", invalid: :replace)
+        Tempfile.create do |temp_file|
+          with_unpack_folder do |temp_folder|
+            structure_path = "#{temp_folder}/structure.mampf"
+            exit_status = run_pdftk(file.path, "dump_data_utf8", "output",
+                                    temp_file.path) &&
+                          run_pdftk(file.path, "unpack_files", "output",
+                                    temp_folder) &&
+                          valid_unpacked_structure?(temp_folder)
+            if exit_status
+              meta = File.read(temp_file)
+              # extract number of pages from pdftk output
+              pages = /NumberOfPages: (\d*)/.match(meta)[1].to_i
+              # extract lines that correspond to MaMpf-Label entries from LaTEX
+              # package mampf.sty
+              structure = if File.file?(structure_path)
+                File.open(structure_path, "r") do |io_stream|
+                  io_stream.read.encode("UTF-8", invalid: :replace)
+                end
+              end
+              structure ||= ""
+              bookmarks = structure.scan(/MaMpf-Label\|(.*?)\n/).flatten
+              result = []
+              bookmarks.each_with_index do |b, i|
+                # extract bookmark data
+                # line may look like this:
+                # defn:erster-Tag|Definition|1.1|Erster Tag|1
+                data = /(.*?)\|(.*?)\|(.*?)\|(.*?)\|(.*)\|(.*)\|(.*)\|(.*)/.match(b)
+                details = { "destination" => data[1], "sort" => data[2],
+                            "label" => data[3], "description" => data[4],
+                            "chapter" => data[5], "section" => data[6],
+                            "subsection" => data[7], "page" => data[8],
+                            "counter" => i }
+                details["sort"] = "Markierung" if details["sort"].blank?
+                result.push(details)
+              end
+              linked_media = structure.scan(/MaMpf-Link\|(.*?)\n/)
+                                      .flatten.map(&:to_i) - [0]
+              mampf_sty_version = structure.scan(/MaMpf-Version\|(.*?)\n/).flatten
+                                           .first
+              { "pages" => pages,
+                "destinations" => result.pluck("destination"),
+                "bookmarks" => result,
+                "linked_media" => linked_media,
+                "version" => mampf_sty_version }
+            else
+              { "pages" => nil, "destinations" => nil, "bookmarks" => nil,
+                "version" => nil }
             end
           end
-          structure ||= ""
-          bookmarks = structure.scan(/MaMpf-Label\|(.*?)\n/).flatten
-          result = []
-          bookmarks.each_with_index do |b, i|
-            # extract bookmark data
-            # line may look like this:
-            # defn:erster-Tag|Definition|1.1|Erster Tag|1
-            data = /(.*?)\|(.*?)\|(.*?)\|(.*?)\|(.*)\|(.*)\|(.*)\|(.*)/.match(b)
-            details = { "destination" => data[1], "sort" => data[2],
-                        "label" => data[3], "description" => data[4],
-                        "chapter" => data[5], "section" => data[6],
-                        "subsection" => data[7], "page" => data[8],
-                        "counter" => i }
-            details["sort"] = "Markierung" if details["sort"].blank?
-            result.push(details)
-          end
-          linked_media = structure.scan(/MaMpf-Link\|(.*?)\n/)
-                                  .flatten.map(&:to_i) - [0]
-          mampf_sty_version = structure.scan(/MaMpf-Version\|(.*?)\n/).flatten
-                                       .first
-          { "pages" => pages,
-            "destinations" => result.pluck("destination"),
-            "bookmarks" => result,
-            "linked_media" => linked_media,
-            "version" => mampf_sty_version }
-        else
-          { "pages" => nil, "destinations" => nil, "bookmarks" => nil,
-            "version" => nil }
         end
       end
     end
@@ -71,6 +82,9 @@ class PdfUploader < Shrine
   Attacher.validate do
     validate_mime_type_inclusion ["application/pdf"],
                                  message: "falscher MIME-Typ"
+    validate_max_size MAX_FILE_SIZE,
+                      message: I18n.t("submission.manuscript_size_too_big",
+                                      max_size: "50 MB")
   end
 
   # extract a screenshot from pdf and store it beside the pdf
@@ -80,4 +94,47 @@ class PdfUploader < Shrine
                                             .resize_to_limit!(400, 565)
     { screenshot: screenshot }
   end
+
+  private
+
+    def with_unpack_folder(&)
+      FileUtils.mkdir_p(UNPACK_ROOT)
+
+      Dir.mktmpdir("pdftk-", UNPACK_ROOT.to_s, &)
+    end
+
+    def run_pdftk(*)
+      pid = Process.spawn("pdftk", *, out: File::NULL, err: File::NULL,
+                                      pgroup: true)
+      _pid, status = Timeout.timeout(PDFTK_TIMEOUT) { Process.wait2(pid) }
+      status.success?
+    rescue Timeout::Error
+      terminate_process_group(pid)
+      false
+    end
+
+    def terminate_process_group(pid)
+      Process.kill("TERM", -pid)
+      Timeout.timeout(1) { Process.wait(pid) }
+    rescue Timeout::Error
+      force_kill_process_group(pid)
+    rescue Errno::ECHILD, Errno::ESRCH
+      nil
+    end
+
+    def force_kill_process_group(pid)
+      Process.kill("KILL", -pid)
+      Process.wait(pid)
+    rescue Errno::ECHILD, Errno::ESRCH
+      nil
+    end
+
+    def valid_unpacked_structure?(temp_folder)
+      unpacked_files = Dir.children(temp_folder)
+      return true if unpacked_files.empty?
+      return false unless unpacked_files == [STRUCTURE_FILE_NAME]
+
+      File.size(File.join(temp_folder, STRUCTURE_FILE_NAME)) <=
+        MAX_STRUCTURE_BYTES
+    end
 end

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -13,7 +13,7 @@ class PdfUploader < Shrine
   # shrine plugins
   plugin :upload_endpoint, max_size: MAX_FILE_SIZE
   plugin :add_metadata
-  plugin :determine_mime_type
+  plugin :determine_mime_type, analyzer: :marcel
   plugin :validation_helpers
   plugin :pretty_location
   plugin :derivatives, versions_compatibility: true

--- a/spec/uploaders/pdf_uploader_spec.rb
+++ b/spec/uploaders/pdf_uploader_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe(PdfUploader) do
+  describe "metadata extraction" do
+    it "passes file paths to pdftk without invoking a shell" do
+      uploader = described_class.new(:store)
+      file = Tempfile.new(["manuscript; touch hacked", ".pdf"])
+      file.binmode
+      file.write(File.binread("#{SPEC_FILES}/manuscript.pdf"))
+      file.rewind
+
+      expect(uploader).to receive(:system) do |*args|
+        expect(args[0...4]).to eq(["pdftk", file.path, "dump_data_utf8", "output"])
+        File.write(args[4], "NumberOfPages: 7\n")
+        true
+      end.ordered
+
+      expect(uploader).to receive(:system).with("pdftk", file.path,
+                                                "unpack_files", "output",
+                                                kind_of(String)).ordered
+                                          .and_return(true)
+
+      metadata = uploader.send(:extract_metadata, file, action: :upload)
+
+      expect(metadata["pages"]).to eq(7)
+    ensure
+      file.close!
+    end
+  end
+end

--- a/spec/uploaders/pdf_uploader_spec.rb
+++ b/spec/uploaders/pdf_uploader_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe(PdfUploader) do
 
       expect(uploader.send(:run_pdftk, "input.pdf", "dump_data_utf8")).to be(false)
     end
+
+    it "returns false when pdftk cannot be spawned" do
+      uploader = described_class.new(:store)
+
+      allow(Process).to receive(:spawn).and_raise(Errno::ENOENT)
+
+      expect(uploader.send(:run_pdftk, "input.pdf", "dump_data_utf8")).to be(false)
+    end
   end
 
   describe "unpacked structure validation" do

--- a/spec/uploaders/pdf_uploader_spec.rb
+++ b/spec/uploaders/pdf_uploader_spec.rb
@@ -96,6 +96,28 @@ RSpec.describe(PdfUploader) do
 
       expect(uploader.send(:run_pdftk, "input.pdf", "dump_data_utf8")).to be(false)
     end
+
+    it "applies a child file-size limit when unpacking attachments" do
+      uploader = described_class.new(:store)
+      status = instance_double(Process::Status, success?: true)
+
+      expect(Process).to receive(:spawn) do |*args|
+        options = args.last
+        expect(options[:rlimit_fsize])
+          .to eq([PdfUploader::MAX_STRUCTURE_BYTES,
+                  PdfUploader::MAX_STRUCTURE_BYTES])
+        1234
+      end
+      allow(Timeout).to receive(:timeout).with(PdfUploader::PDFTK_TIMEOUT)
+                                         .and_yield
+      allow(Process).to receive(:wait2).with(1234).and_return([1234, status])
+
+      result = uploader.send(:run_pdftk, "input.pdf", "unpack_files",
+                             "output", "/tmp/pdf-dir",
+                             file_size_limit: PdfUploader::MAX_STRUCTURE_BYTES)
+
+      expect(result).to be(true)
+    end
   end
 
   describe "unpacked structure validation" do

--- a/spec/uploaders/pdf_uploader_spec.rb
+++ b/spec/uploaders/pdf_uploader_spec.rb
@@ -29,6 +29,52 @@ RSpec.describe(PdfUploader) do
     ensure
       file.close!
     end
+
+    it "returns nil pages when pdftk output omits NumberOfPages" do
+      uploader = described_class.new(:store)
+      file = Tempfile.new(["manuscript", ".pdf"])
+      file.binmode
+      file.write(File.binread("#{SPEC_FILES}/manuscript.pdf"))
+      file.rewind
+
+      allow(uploader).to receive(:run_pdftk) do |*args|
+        File.write(args[3], "InfoKey: Title\n") if args[1] == "dump_data_utf8"
+        true
+      end
+
+      metadata = uploader.send(:extract_metadata, file, action: :upload)
+
+      expect(metadata["pages"]).to be_nil
+    ensure
+      file.close!
+    end
+
+    it "skips malformed MaMpf-Label rows" do
+      uploader = described_class.new(:store)
+      file = Tempfile.new(["manuscript", ".pdf"])
+      file.binmode
+      file.write(File.binread("#{SPEC_FILES}/manuscript.pdf"))
+      file.rewind
+
+      allow(uploader).to receive(:run_pdftk) do |*args|
+        if args[1] == "dump_data_utf8"
+          File.write(args[3], "NumberOfPages: 7\n")
+        else
+          File.write(File.join(args[3], "structure.mampf"),
+                     "MaMpf-Label|broken\n" \
+                     "MaMpf-Label|dest|Sort|1.1|Desc|1|1.1|1.1.0|7\n")
+        end
+        true
+      end
+
+      metadata = uploader.send(:extract_metadata, file, action: :upload)
+
+      expect(metadata["bookmarks"].size).to eq(1)
+      expect(metadata["bookmarks"].first["destination"]).to eq("dest")
+      expect(metadata["bookmarks"].first["counter"]).to eq(0)
+    ensure
+      file.close!
+    end
   end
 
   describe "pdftk execution" do

--- a/spec/uploaders/pdf_uploader_spec.rb
+++ b/spec/uploaders/pdf_uploader_spec.rb
@@ -9,22 +9,72 @@ RSpec.describe(PdfUploader) do
       file.write(File.binread("#{SPEC_FILES}/manuscript.pdf"))
       file.rewind
 
-      expect(uploader).to receive(:system) do |*args|
-        expect(args[0...4]).to eq(["pdftk", file.path, "dump_data_utf8", "output"])
-        File.write(args[4], "NumberOfPages: 7\n")
+      expect(uploader).to receive(:run_pdftk) do |*args|
+        expect(args[0...3]).to eq([file.path, "dump_data_utf8", "output"])
+        File.write(args[3], "NumberOfPages: 7\n")
         true
       end.ordered
 
-      expect(uploader).to receive(:system).with("pdftk", file.path,
-                                                "unpack_files", "output",
-                                                kind_of(String)).ordered
-                                          .and_return(true)
+      expect(uploader).to receive(:run_pdftk) do |*args|
+        expect(args[0...3]).to eq([file.path, "unpack_files", "output"])
+        expect(args[3]).to start_with(PdfUploader::UNPACK_ROOT.to_s)
+        File.write(File.join(args[3], "structure.mampf"), "MaMpf-Version|1.2.3\n")
+        true
+      end.ordered
 
       metadata = uploader.send(:extract_metadata, file, action: :upload)
 
       expect(metadata["pages"]).to eq(7)
+      expect(metadata["version"]).to eq("1.2.3")
     ensure
       file.close!
+    end
+  end
+
+  describe "pdftk execution" do
+    it "returns false when pdftk exceeds the timeout" do
+      uploader = described_class.new(:store)
+
+      allow(Process).to receive(:spawn).and_return(1234)
+      allow(Timeout).to receive(:timeout).with(PdfUploader::PDFTK_TIMEOUT)
+                                         .and_raise(Timeout::Error)
+      expect(uploader).to receive(:terminate_process_group).with(1234)
+
+      expect(uploader.send(:run_pdftk, "input.pdf", "dump_data_utf8")).to be(false)
+    end
+  end
+
+  describe "unpacked structure validation" do
+    it "accepts only structure.mampf" do
+      uploader = described_class.new(:store)
+
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "structure.mampf"), "MaMpf-Version|1.2.3\n")
+
+        expect(uploader.send(:valid_unpacked_structure?, dir)).to be(true)
+      end
+    end
+
+    it "rejects unexpected extracted files" do
+      uploader = described_class.new(:store)
+
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "structure.mampf"), "MaMpf-Version|1.2.3\n")
+        File.write(File.join(dir, "extra.bin"), "x")
+
+        expect(uploader.send(:valid_unpacked_structure?, dir)).to be(false)
+      end
+    end
+
+    it "rejects oversized structure.mampf files" do
+      uploader = described_class.new(:store)
+
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "structure.mampf"),
+                   "x" * (PdfUploader::MAX_STRUCTURE_BYTES + 1))
+
+        expect(uploader.send(:valid_unpacked_structure?, dir)).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
**Note:** This PR is superseded by #1151.

This PR improves the robustness of PDF uploads by hardening the pdftk-based metadata extraction path. It removes shell invocation, adds execution and size bounds, and only accepts the expected structure.mampf attachment during unpacking.

Note: This PR is superseded by #1151, in which we replace pdftk by qpdf (and also tighten security) 