### PR TITLE
Remove mediaforward

### DIFF
--- a/app/abilities/medium_ability.rb
+++ b/app/abilities/medium_ability.rb
@@ -45,9 +45,5 @@ class MediumAbility
     can :update_tags, Medium do |medium|
       !user.generic? && user.can_edit?(medium)
     end
-
-    can [:register_download], Medium do |_medium|
-      !user.new_record?
-    end
   end
 end

--- a/app/abilities/medium_ability.rb
+++ b/app/abilities/medium_ability.rb
@@ -37,7 +37,7 @@ class MediumAbility
     end
 
     # guest users can play/display media when their release status 'all'
-    can [:play, :display, :geogebra], Medium do |medium|
+    can [:play, :display, :geogebra, :download], Medium do |medium|
       (!user.new_record? && medium.visible_for_user?(user)) ||
         medium.free?
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,6 +115,13 @@ class ApplicationController < ActionController::Base
       Current.user = current_user
     end
 
+    def enqueue_consumption(medium_id, mode, sort)
+      ConsumptionSaver.perform_async(medium_id, mode, sort)
+    rescue StandardError => e
+      Rails.logger.error("Failed to enqueue consumption " \
+                         "medium_id=#{medium_id} mode=#{mode} sort=#{sort}: #{e.message}")
+    end
+
     # Ensures that the current request is a Turbo Frame request.
     # If not, sets a flash message and redirects to the root path.
     #

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,7 +1,5 @@
 # MediaController
 class MediaController < ApplicationController
-  DOWNLOADABLE_MEDIA_SORTS = ["video", "manuscript", "geogebra"].freeze
-
   skip_before_action :authenticate_user!, only: [:play, :display, :download]
   before_action :set_medium, except: [:index, :new, :create, :search,
                                       :fill_teachable_select,
@@ -295,7 +293,7 @@ class MediaController < ApplicationController
   end
 
   def download
-    download_sort = validated_download_sort!
+    download_sort = params[:sort]
     file = case download_sort
            when "video"
              @medium.video
@@ -303,6 +301,8 @@ class MediaController < ApplicationController
              @medium.manuscript
            when "geogebra"
              @medium.geogebra
+           else
+             raise(CanCan::AccessDenied, I18n.t("unauthorized.default"))
     end
     if file.nil?
       redirect_to :root,
@@ -602,13 +602,6 @@ class MediaController < ApplicationController
       return unless params[:teachable_id].present? && allowed_types.key?(params[:teachable_type])
 
       @teachable = allowed_types[params[:teachable_type]].find_by(id: params[:teachable_id])
-    end
-
-    def validated_download_sort!
-      download_sort = params[:sort]
-      return download_sort if download_sort.in?(DOWNLOADABLE_MEDIA_SORTS)
-
-      raise(CanCan::AccessDenied, I18n.t("unauthorized.default"))
     end
 
     def detach_components

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -302,7 +302,9 @@ class MediaController < ApplicationController
            when "geogebra"
              @medium.geogebra
            else
-             raise(CanCan::AccessDenied, I18n.t("unauthorized.default"))
+             redirect_to :root,
+                         alert: I18n.t("controllers.invalid_download")
+             return
     end
     if file.nil?
       redirect_to :root,

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -321,7 +321,7 @@ class MediaController < ApplicationController
 
     send_file(file.to_io, **options)
     prevent_caching unless @medium.free?
-    ConsumptionSaver.perform_async(@medium.id, "download", download_sort)
+    enqueue_consumption(@medium.id, "download", download_sort)
   end
 
   # add a toc item for the video
@@ -661,6 +661,6 @@ class MediaController < ApplicationController
     def store_access
       mode = action_name == "play" ? "thyme" : "pdf_view"
       sort = action_name == "play" ? "video" : "manuscript"
-      ConsumptionSaver.perform_async(@medium.id, mode, sort)
+      enqueue_consumption(@medium.id, mode, sort)
     end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,8 @@
 # MediaController
 class MediaController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:play, :display]
+  DOWNLOADABLE_MEDIA_SORTS = ["video", "manuscript", "geogebra"].freeze
+
+  skip_before_action :authenticate_user!, only: [:play, :display, :download]
   before_action :set_medium, except: [:index, :new, :create, :search,
                                       :fill_teachable_select,
                                       :fill_media_select,
@@ -10,11 +12,12 @@ class MediaController < ApplicationController
                                       :render_import_vertex,
                                       :cancel_import_media,
                                       :cancel_import_vertex]
+  before_action :set_download_sort, only: [:download]
   before_action :set_lecture, only: [:index]
   before_action :set_teachable, only: [:new]
-  before_action :check_for_consent, except: [:play, :display]
+  before_action :check_for_consent, except: [:play, :display, :download]
   after_action :store_access, only: [:play, :display]
-  after_action :store_download, only: [:register_download]
+  after_action :store_download, only: [:register_download, :download]
   authorize_resource except: [:index, :new, :create, :search,
                               :fill_teachable_select, :fill_media_select,
                               :fill_medium_preview, :render_medium_actions,
@@ -291,6 +294,24 @@ class MediaController < ApplicationController
     end
     I18n.locale = @medium.locale_with_inheritance
     render layout: "geogebra"
+  end
+
+  def download
+    file = @medium.public_send(@download_sort)
+    if file.nil?
+      redirect_to :root,
+                  alert: I18n.t("controllers.no_#{@download_sort}")
+      return
+    end
+
+    options = {
+      disposition: "attachment",
+      filename: file.metadata["filename"]
+    }
+    mime_type = file.metadata["mime_type"]
+    options[:type] = mime_type if mime_type.present?
+
+    send_file(file.to_io, **options)
   end
 
   # add a toc item for the video
@@ -580,6 +601,13 @@ class MediaController < ApplicationController
       @teachable = allowed_types[params[:teachable_type]].find_by(id: params[:teachable_id])
     end
 
+    def set_download_sort
+      @download_sort = params[:sort]
+      return if @download_sort.in?(DOWNLOADABLE_MEDIA_SORTS)
+
+      raise(CanCan::AccessDenied, I18n.t("unauthorized.default"))
+    end
+
     def detach_components
       if params[:medium][:detach_video] == "true"
         @medium.update(video: nil)
@@ -638,6 +666,9 @@ class MediaController < ApplicationController
     end
 
     def store_download
+      return unless response.ok?
+      return unless params[:sort].in?(DOWNLOADABLE_MEDIA_SORTS)
+
       ConsumptionSaver.perform_async(@medium.id, "download", params[:sort])
     end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -312,14 +312,18 @@ class MediaController < ApplicationController
       return
     end
 
+    filename = File.basename(file.metadata["filename"].to_s.tr("\\", "/"))
+
     options = {
       disposition: "attachment",
-      filename: file.metadata["filename"]
+      filename: ActiveStorage::Filename.wrap(
+        filename.presence || download_sort
+      ).sanitized
     }
     mime_type = file.metadata["mime_type"]
     options[:type] = mime_type if mime_type.present?
 
-    send_file(file.to_io, **options)
+    send_file(download_path(file), **options)
     prevent_caching unless @medium.free?
     enqueue_consumption(@medium.id, "download", download_sort)
   end
@@ -638,6 +642,12 @@ class MediaController < ApplicationController
 
     def lecture_media_search_params
       params.permit(:project, :visibility, :reverse, :id, :all, :page, :per)
+    end
+
+    def download_path(file)
+      return file.storage.path(file.id) if file.storage.respond_to?(:path)
+
+      file.to_io.path
     end
 
     # destroy all notifications related to this medium

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -296,7 +296,14 @@ class MediaController < ApplicationController
 
   def download
     download_sort = validated_download_sort!
-    file = @medium.public_send(download_sort)
+    file = case download_sort
+    when "video"
+      @medium.video
+    when "manuscript"
+      @medium.manuscript
+    when "geogebra"
+      @medium.geogebra
+    end
     if file.nil?
       redirect_to :root,
                   alert: I18n.t("controllers.no_#{download_sort}")

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -17,7 +17,7 @@ class MediaController < ApplicationController
   before_action :set_teachable, only: [:new]
   before_action :check_for_consent, except: [:play, :display, :download]
   after_action :store_access, only: [:play, :display]
-  after_action :store_download, only: [:register_download, :download]
+  after_action :store_download, only: [:download]
   authorize_resource except: [:index, :new, :create, :search,
                               :fill_teachable_select, :fill_media_select,
                               :fill_medium_preview, :render_medium_actions,
@@ -407,10 +407,6 @@ class MediaController < ApplicationController
 
     @medium.tags = Tag.where(id: params[:tag_ids])
     @medium.touch
-  end
-
-  def register_download
-    head :ok
   end
 
   def statistics

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -297,12 +297,12 @@ class MediaController < ApplicationController
   def download
     download_sort = validated_download_sort!
     file = case download_sort
-    when "video"
-      @medium.video
-    when "manuscript"
-      @medium.manuscript
-    when "geogebra"
-      @medium.geogebra
+           when "video"
+             @medium.video
+           when "manuscript"
+             @medium.manuscript
+           when "geogebra"
+             @medium.geogebra
     end
     if file.nil?
       redirect_to :root,

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -12,12 +12,10 @@ class MediaController < ApplicationController
                                       :render_import_vertex,
                                       :cancel_import_media,
                                       :cancel_import_vertex]
-  before_action :set_download_sort, only: [:download]
   before_action :set_lecture, only: [:index]
   before_action :set_teachable, only: [:new]
   before_action :check_for_consent, except: [:play, :display, :download]
   after_action :store_access, only: [:play, :display]
-  after_action :store_download, only: [:download]
   authorize_resource except: [:index, :new, :create, :search,
                               :fill_teachable_select, :fill_media_select,
                               :fill_medium_preview, :render_medium_actions,
@@ -297,10 +295,11 @@ class MediaController < ApplicationController
   end
 
   def download
-    file = @medium.public_send(@download_sort)
+    download_sort = validated_download_sort!
+    file = @medium.public_send(download_sort)
     if file.nil?
       redirect_to :root,
-                  alert: I18n.t("controllers.no_#{@download_sort}")
+                  alert: I18n.t("controllers.no_#{download_sort}")
       return
     end
 
@@ -312,6 +311,7 @@ class MediaController < ApplicationController
     options[:type] = mime_type if mime_type.present?
 
     send_file(file.to_io, **options)
+    ConsumptionSaver.perform_async(@medium.id, "download", download_sort)
   end
 
   # add a toc item for the video
@@ -597,9 +597,9 @@ class MediaController < ApplicationController
       @teachable = allowed_types[params[:teachable_type]].find_by(id: params[:teachable_id])
     end
 
-    def set_download_sort
-      @download_sort = params[:sort]
-      return if @download_sort.in?(DOWNLOADABLE_MEDIA_SORTS)
+    def validated_download_sort!
+      download_sort = params[:sort]
+      return download_sort if download_sort.in?(DOWNLOADABLE_MEDIA_SORTS)
 
       raise(CanCan::AccessDenied, I18n.t("unauthorized.default"))
     end
@@ -659,12 +659,5 @@ class MediaController < ApplicationController
       mode = action_name == "play" ? "thyme" : "pdf_view"
       sort = action_name == "play" ? "video" : "manuscript"
       ConsumptionSaver.perform_async(@medium.id, mode, sort)
-    end
-
-    def store_download
-      return unless response.ok?
-      return unless params[:sort].in?(DOWNLOADABLE_MEDIA_SORTS)
-
-      ConsumptionSaver.perform_async(@medium.id, "download", params[:sort])
     end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -318,6 +318,7 @@ class MediaController < ApplicationController
     options[:type] = mime_type if mime_type.present?
 
     send_file(file.to_io, **options)
+    prevent_caching unless @medium.free?
     ConsumptionSaver.perform_async(@medium.id, "download", download_sort)
   end
 

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -156,6 +156,6 @@ class QuizzesController < ApplicationController
     end
 
     def store_access
-      ConsumptionSaver.perform_async(@quiz.id, "browser", "quiz")
+      enqueue_consumption(@quiz.id, "browser", "quiz")
     end
 end

--- a/app/frontend/js/media.coffee
+++ b/app/frontend/js/media.coffee
@@ -315,17 +315,6 @@ $(document).on 'turbo:load', ->
         throwOnError: false
       return
 
-  $(document).on 'click', '.triggerDownload', ->
-    mediumId = $(this).data('medium')
-    sort = $(this).data('sort')
-    $.ajax Routes.register_download_path(mediumId, { sort: sort }),
-      type: 'POST'
-      dataType: 'script'
-      data: {
-        sort:  sort
-      }
-    return
-
   $(document).on 'click', '#showMediaStatistics', ->
     mediumId = $(this).data('medium')
     $.ajax Routes.statistics_path(mediumId),
@@ -365,6 +354,5 @@ $(document).on 'turbo:before-cache', ->
   $(document).off 'click', '#cancel-medium-actions'
   $(document).off 'click', '#editMediumTags'
   $(document).off 'click', '#cancelMediumTags'
-  $(document).off 'click', '.triggerDownload'
   $(document).off 'click', '#showMediaStatistics'
   return

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,15 +22,6 @@ module ApplicationHelper
     end
   end
 
-  # The HTML download attribute only works for files within the domain of
-  # the webpage. Therefore, we use an apache redirect from an internal folder
-  # which is stored in the DOWNLOAD_LOCATION environment variable, to
-  # the actual media server.
-  # This is used for the download buttons for videos and manuscripts.
-  def download_host
-    Rails.env.production? ? ENV.fetch("DOWNLOAD_LOCATION") : ""
-  end
-
   # Returns the full title on a per-page basis.
   def full_title(page_title = "")
     return page_title if action_name == "play" && controller_name == "media"

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -13,18 +13,6 @@ module MediaHelper
     current_user.admin || medium.edited_with_inheritance_by?(current_user)
   end
 
-  def video_download_file(medium)
-    "#{medium.title}.mp4"
-  end
-
-  def manuscript_download_file(medium)
-    "#{medium.title}.pdf"
-  end
-
-  def geogebra_download_file(medium)
-    "#{medium.title}.ggb"
-  end
-
   def inspect_or_edit_medium_path(medium, inspection)
     inspection ? inspect_medium_path(medium) : edit_medium_path(medium)
   end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -385,10 +385,6 @@ class Medium < ApplicationRecord
     video.url(host: host)
   end
 
-  def video_download_url
-    video.url(host: download_host)
-  end
-
   def video_filename
     return if video.blank?
 
@@ -435,10 +431,6 @@ class Medium < ApplicationRecord
     geogebra_url(host: host)
   end
 
-  def geogebra_download_url
-    geogebra_url(host: download_host)
-  end
-
   def geogebra_screenshot_url
     return "" if geogebra.blank?
 
@@ -449,10 +441,6 @@ class Medium < ApplicationRecord
     return "#{manuscript_url(host: host)}/#{manuscript_filename}" if ENV["REWRITE_ENABLED"] == "1"
 
     manuscript_url(host: host)
-  end
-
-  def manuscript_download_url
-    manuscript_url(host: download_host)
   end
 
   def manuscript_filename

--- a/app/views/media/_geogebra_card.html.erb
+++ b/app/views/media/_geogebra_card.html.erb
@@ -19,7 +19,8 @@
               </i>
             </a>
             <div class="download-button">
-              <a href="<%= download_medium_path(medium, sort: "geogebra") %>">
+              <a href="<%= download_medium_path(medium, sort: "geogebra") %>"
+                 data-turbo="false">
                 <span>
                   <span class="badge bg-secondary"
                         data-bs-toggle="tooltip"

--- a/app/views/media/_geogebra_card.html.erb
+++ b/app/views/media/_geogebra_card.html.erb
@@ -19,11 +19,7 @@
               </i>
             </a>
             <div class="download-button">
-              <a href="<%= medium.geogebra_download_url %>"
-                 download="<%= geogebra_download_file(medium) %>"
-                 class="triggerDownload"
-                 data-medium="<%= medium.id %>"
-                 data-sort="geogebra">
+              <a href="<%= download_medium_path(medium, sort: "geogebra") %>">
                 <span>
                   <span class="badge bg-secondary"
                         data-bs-toggle="tooltip"

--- a/app/views/media/_manuscript_card.html.erb
+++ b/app/views/media/_manuscript_card.html.erb
@@ -19,11 +19,7 @@
             </i>
           </a>
           <div class="download-button">
-            <a href="<%= medium.manuscript_download_url %>"
-               download="<%= manuscript_download_file(medium) %>"
-               class="triggerDownload"
-               data-medium="<%= medium.id %>"
-               data-sort="manuscript">
+            <a href="<%= download_medium_path(medium, sort: "manuscript") %>">
               <span>
                 <span class="badge bg-secondary"
                       data-bs-toggle="tooltip"

--- a/app/views/media/_manuscript_card.html.erb
+++ b/app/views/media/_manuscript_card.html.erb
@@ -19,7 +19,8 @@
             </i>
           </a>
           <div class="download-button">
-            <a href="<%= download_medium_path(medium, sort: "manuscript") %>">
+            <a href="<%= download_medium_path(medium, sort: "manuscript") %>"
+               data-turbo="false">
               <span>
                 <span class="badge bg-secondary"
                       data-bs-toggle="tooltip"

--- a/app/views/media/_video_card.html.erb
+++ b/app/views/media/_video_card.html.erb
@@ -19,7 +19,8 @@
               </i>
             </a>
             <div class="download-button">
-              <a href="<%= download_medium_path(medium, sort: "video") %>">
+              <a href="<%= download_medium_path(medium, sort: "video") %>"
+                 data-turbo="false">
                 <span>
                   <span class="badge bg-secondary"
                         data-bs-toggle="tooltip"

--- a/app/views/media/_video_card.html.erb
+++ b/app/views/media/_video_card.html.erb
@@ -19,11 +19,7 @@
               </i>
             </a>
             <div class="download-button">
-              <a href="<%= medium.video_download_url %>"
-                 download="<%= video_download_file(medium) %>"
-                 class="triggerDownload"
-                 data-medium="<%= medium.id %>"
-                 data-sort="video">
+              <a href="<%= download_medium_path(medium, sort: "video") %>">
                 <span>
                   <span class="badge bg-secondary"
                         data-bs-toggle="tooltip"

--- a/app/views/media/medium/_buttons.html.erb
+++ b/app/views/media/medium/_buttons.html.erb
@@ -58,22 +58,16 @@
 
 <div class="media-download-buttons">
   <% if medium.video.present? %>
-    <a href="<%= medium.video_download_url %>"
-      download="<%= video_download_file(medium) %>"
-      class="triggerDownload download-button btn btn-outline-secondary" role="button"
-      data-medium="<%= medium.id %>"
-      data-sort="video"
+    <a href="<%= download_medium_path(medium, sort: "video") %>"
+      class="download-button btn btn-outline-secondary" role="button"
       title="<%= t('video.download') %>">
       &darr;mp4
     </a>
   <% end %>
 
   <% if medium.manuscript.present? %>
-    <a href="<%= medium.manuscript_download_url %>"
-      download="<%= manuscript_download_file(medium) %>"
-      class="triggerDownload download-button btn btn-outline-secondary" role="button"
-      data-medium="<%= medium.id %>"
-      data-sort="manuscript"
+    <a href="<%= download_medium_path(medium, sort: "manuscript") %>"
+      class="download-button btn btn-outline-secondary" role="button"
       title="<%= t('manuscript.download') %>">
       &darr;pdf
     </a>

--- a/app/views/media/medium/_buttons.html.erb
+++ b/app/views/media/medium/_buttons.html.erb
@@ -59,16 +59,18 @@
 <div class="media-download-buttons">
   <% if medium.video.present? %>
     <a href="<%= download_medium_path(medium, sort: "video") %>"
-      class="download-button btn btn-outline-secondary" role="button"
-      title="<%= t('video.download') %>">
+       class="download-button btn btn-outline-secondary" role="button"
+       data-turbo="false"
+       title="<%= t('video.download') %>">
       &darr;mp4
     </a>
   <% end %>
 
   <% if medium.manuscript.present? %>
     <a href="<%= download_medium_path(medium, sort: "manuscript") %>"
-      class="download-button btn btn-outline-secondary" role="button"
-      title="<%= t('manuscript.download') %>">
+       class="download-button btn btn-outline-secondary" role="button"
+       data-turbo="false"
+       title="<%= t('manuscript.download') %>">
       &darr;pdf
     </a>
   <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3845,6 +3845,7 @@ de:
     no_video: 'Zu diesem Medium existiert kein Video.'
     no_manuscript: 'Zu diesem Medium existiert kein Manuskript.'
     no_geogebra: 'Zu diesem Medium existiert kein Geogebra-Applet.'
+    invalid_download: 'Der angeforderte Download ist ungültig.'
     no_medium: 'Ein Medium mit der angeforderten id existiert nicht.'
     contradiction: 'Widersprüchliche Suchanfrage.'
     no_notification: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3633,6 +3633,7 @@ en:
     no_video: 'There is no video for this medium.'
     no_manuscript: 'There is no manuscript for this medium.'
     no_geogebra: 'There is no Geogebra applet for this medium.'
+    invalid_download: 'The requested download is invalid.'
     no_medium: 'There is no medium with this id.'
     contradiction: 'Contradictory request.'
     no_notification: 'There is no notification with this id.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -435,10 +435,6 @@ Rails.application.routes.draw do
        to: "media#update_tags",
        as: "update_tags"
 
-  post "media/:id/register_download",
-       to: "media#register_download",
-       as: "register_download"
-
   get "media/:id/statistics",
       to: "media#statistics",
       as: "statistics"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,6 +391,10 @@ Rails.application.routes.draw do
       to: "media#geogebra",
       as: "geogebra_medium"
 
+  get "media/:id/download/:sort",
+      to: "media#download",
+      as: "download_medium"
+
   get "media/:id/add_item",
       to: "media#add_item",
       as: "add_item"

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -98,10 +98,11 @@ RSpec.describe("Media", type: :request) do
       expect(response).to redirect_to(root_url)
     end
 
-    it "rejects invalid download sorts" do
+    it "redirects invalid download sorts with a specific alert" do
       get download_medium_path(restricted_medium, sort: "invalid")
 
       expect(response).to redirect_to(root_url)
+      expect(flash[:alert]).to eq(I18n.t("controllers.invalid_download"))
     end
   end
 end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -85,6 +85,23 @@ RSpec.describe("Media", type: :request) do
         .to include(restricted_medium.manuscript_filename)
     end
 
+    it "sanitizes the attachment filename from uploaded metadata" do
+      allow_any_instance_of(PdfUploader::UploadedFile).to receive(:metadata)
+        .and_wrap_original do |original, *args|
+          original.call(*args).merge("filename" => "../evil\r\nname.pdf")
+        end
+
+      get download_medium_path(restricted_medium, sort: "manuscript")
+      content_disposition = response.headers["Content-Disposition"]
+
+      expect(response).to have_http_status(:ok)
+      expect(content_disposition).to include("attachment")
+      expect(content_disposition).to include("evil")
+      expect(content_disposition).to include("name.pdf")
+      expect(content_disposition).not_to include("../")
+      expect(content_disposition).not_to match(/[\r\n]/)
+    end
+
     it "allows guest downloads for free media" do
       sign_out user
 

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe("Media", type: :request) do
         .to include("attachment")
       expect(response.headers["Content-Disposition"])
         .to include(restricted_medium.manuscript_filename)
+      expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"])
+        .to eq("Mon, 01 Jan 1990 00:00:00 GMT")
     end
 
     it "allows guest downloads for free media" do
@@ -72,6 +76,7 @@ RSpec.describe("Media", type: :request) do
       expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Disposition"])
         .to include(free_medium.manuscript_filename)
+      expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
     end
 
     it "serves a video attachment through Rails" do

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe("Media", type: :request) do
   describe "GET /media/:id/download/:sort" do
     let(:restricted_medium) { create(:lecture_medium, :with_manuscript) }
     let(:free_medium) { create(:lecture_medium, :with_manuscript, :released) }
+    let(:video_medium) { create(:lecture_medium, :with_video) }
 
     it "serves a manuscript attachment through Rails" do
       get download_medium_path(restricted_medium, sort: "manuscript")
@@ -71,6 +72,31 @@ RSpec.describe("Media", type: :request) do
       expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Disposition"])
         .to include(free_medium.manuscript_filename)
+    end
+
+    it "serves a video attachment through Rails" do
+      get download_medium_path(video_medium, sort: "video")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("video/mp4")
+      expect(response.headers["Content-Disposition"])
+        .to include("attachment")
+      expect(response.headers["Content-Disposition"])
+        .to include(video_medium.video_filename)
+    end
+
+    it "rejects guest downloads for restricted media" do
+      sign_out user
+
+      get download_medium_path(restricted_medium, sort: "manuscript")
+
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "rejects invalid download sorts" do
+      get download_medium_path(restricted_medium, sort: "invalid")
+
+      expect(response).to redirect_to(root_url)
     end
   end
 end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -47,4 +47,30 @@ RSpec.describe("Media", type: :request) do
       expect(response.body).not_to include(medium_python.description)
     end
   end
+
+  describe "GET /media/:id/download/:sort" do
+    let(:restricted_medium) { create(:lecture_medium, :with_manuscript) }
+    let(:free_medium) { create(:lecture_medium, :with_manuscript, :released) }
+
+    it "serves a manuscript attachment through Rails" do
+      get download_medium_path(restricted_medium, sort: "manuscript")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/pdf")
+      expect(response.headers["Content-Disposition"])
+        .to include("attachment")
+      expect(response.headers["Content-Disposition"])
+        .to include(restricted_medium.manuscript_filename)
+    end
+
+    it "allows guest downloads for free media" do
+      sign_out user
+
+      get download_medium_path(free_medium, sort: "manuscript")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Disposition"])
+        .to include(free_medium.manuscript_filename)
+    end
+  end
 end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe("Media", type: :request) do
         .to eq("Mon, 01 Jan 1990 00:00:00 GMT")
     end
 
+    it "still serves the download when consumption enqueue fails" do
+      expect(Rails.logger).to receive(:error).with(include(
+                                                     "medium_id=#{restricted_medium.id}",
+                                                     "mode=download",
+                                                     "sort=manuscript",
+                                                     "redis down"
+                                                   ))
+      allow(ConsumptionSaver).to receive(:perform_async)
+        .and_raise(StandardError, "redis down")
+
+      get download_medium_path(restricted_medium, sort: "manuscript")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Disposition"])
+        .to include(restricted_medium.manuscript_filename)
+    end
+
     it "allows guest downloads for free media" do
       sign_out user
 


### PR DESCRIPTION
**Note:** This PR has been superseded by #1151 .

In this PR, we remove the mediaforward by introducing dedicated download endpoints. This means we can throw out the "outer apache".