### PR TITLE
Route manuscript and GeoGebra files through Rails while keeping display compatibility (inlining pt. 1)

### DIFF
--- a/app/abilities/medium_ability.rb
+++ b/app/abilities/medium_ability.rb
@@ -37,7 +37,7 @@ class MediumAbility
     end
 
     # guest users can play/display media when their release status 'all'
-    can [:play, :display, :geogebra, :download], Medium do |medium|
+    can [:play, :display, :inline, :geogebra, :download], Medium do |medium|
       (!user.new_record? && medium.visible_for_user?(user)) ||
         medium.free?
     end

--- a/app/abilities/medium_ability.rb
+++ b/app/abilities/medium_ability.rb
@@ -37,7 +37,7 @@ class MediumAbility
     end
 
     # guest users can play/display media when their release status 'all'
-    can [:play, :display, :inline, :geogebra, :download], Medium do |medium|
+    can [:play, :display, :inline, :geogebra, :inline_geogebra, :download], Medium do |medium|
       (!user.new_record? && medium.visible_for_user?(user)) ||
         medium.free?
     end

--- a/app/abilities/medium_ability.rb
+++ b/app/abilities/medium_ability.rb
@@ -37,7 +37,8 @@ class MediumAbility
     end
 
     # guest users can play/display media when their release status 'all'
-    can [:play, :display, :inline, :geogebra, :inline_geogebra, :download], Medium do |medium|
+    can [:play, :display, :inline_manuscript, :geogebra,
+         :inline_geogebra, :download], Medium do |medium|
       (!user.new_record? && medium.visible_for_user?(user)) ||
         medium.free?
     end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,6 @@
 # MediaController
 class MediaController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:play, :display, :download]
+  skip_before_action :authenticate_user!, only: [:play, :display, :inline, :download]
   before_action :set_medium, except: [:index, :new, :create, :search,
                                       :fill_teachable_select,
                                       :fill_media_select,
@@ -12,7 +12,7 @@ class MediaController < ApplicationController
                                       :cancel_import_vertex]
   before_action :set_lecture, only: [:index]
   before_action :set_teachable, only: [:new]
-  before_action :check_for_consent, except: [:play, :display, :download]
+  before_action :check_for_consent, except: [:play, :display, :inline, :download]
   after_action :store_access, only: [:play, :display]
   authorize_resource except: [:index, :new, :create, :search,
                               :fill_teachable_select, :fill_media_select,
@@ -269,17 +269,27 @@ class MediaController < ApplicationController
       redirect_to :root, alert: I18n.t("controllers.no_manuscript")
       return
     end
-    if params[:destination].present?
-      redirect_to "#{@medium.manuscript_url_with_host}##{params[:destination]}",
-                  allow_other_host: true
-      return
-    elsif params[:page].present?
-      redirect_to "#{@medium.manuscript_url_with_host}#page=#{params[:page]}",
-                  allow_other_host: true
+
+    @manuscript_inline_url = inline_medium_path(@medium) + manuscript_fragment
+    render layout: false
+    prevent_caching unless @medium.free?
+  end
+
+  def inline
+    if @medium.manuscript.nil?
+      redirect_to :root, alert: I18n.t("controllers.no_manuscript")
       return
     end
-    redirect_to @medium.manuscript_url_with_host,
-                allow_other_host: true
+
+    options = {
+      disposition: "inline",
+      filename: @medium.manuscript.metadata["filename"]
+    }
+    mime_type = @medium.manuscript.metadata["mime_type"]
+    options[:type] = mime_type if mime_type.present?
+
+    send_file(@medium.manuscript.to_io, **options)
+    prevent_caching unless @medium.free?
   end
 
   # run the geogebra applet using Geogebra's Javascript API
@@ -638,6 +648,16 @@ class MediaController < ApplicationController
 
     def lecture_media_search_params
       params.permit(:project, :visibility, :reverse, :id, :all, :page, :per)
+    end
+
+    def manuscript_fragment
+      if params[:destination].present?
+        "##{ERB::Util.url_encode(params[:destination])}"
+      elsif params[:page].present?
+        "#page=#{ERB::Util.url_encode(params[:page])}"
+      else
+        ""
+      end
     end
 
     # destroy all notifications related to this medium

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -288,14 +288,8 @@ class MediaController < ApplicationController
       return
     end
 
-    options = {
-      disposition: "inline",
-      filename: @medium.manuscript.metadata["filename"]
-    }
-    mime_type = @medium.manuscript.metadata["mime_type"]
-    options[:type] = mime_type if mime_type.present?
-
-    send_file(@medium.manuscript.to_io, **options)
+    send_stored_file(@medium.manuscript, disposition: "inline",
+                                         fallback: "manuscript")
     prevent_caching unless @medium.free?
   end
 
@@ -316,14 +310,8 @@ class MediaController < ApplicationController
       return
     end
 
-    options = {
-      disposition: "inline",
-      filename: @medium.geogebra.metadata["filename"]
-    }
-    mime_type = @medium.geogebra.metadata["mime_type"]
-    options[:type] = mime_type if mime_type.present?
-
-    send_file(@medium.geogebra.to_io, **options)
+    send_stored_file(@medium.geogebra, disposition: "inline",
+                                       fallback: "geogebra")
     prevent_caching unless @medium.free?
   end
 
@@ -347,18 +335,7 @@ class MediaController < ApplicationController
       return
     end
 
-    filename = File.basename(file.metadata["filename"].to_s.tr("\\", "/"))
-
-    options = {
-      disposition: "attachment",
-      filename: ActiveStorage::Filename.wrap(
-        filename.presence || download_sort
-      ).sanitized
-    }
-    mime_type = file.metadata["mime_type"]
-    options[:type] = mime_type if mime_type.present?
-
-    send_file(download_path(file), **options)
+    send_stored_file(file, disposition: "attachment", fallback: download_sort)
     prevent_caching unless @medium.free?
     enqueue_consumption(@medium.id, "download", download_sort)
   end
@@ -683,6 +660,23 @@ class MediaController < ApplicationController
       return file.storage.path(file.id) if file.storage.respond_to?(:path)
 
       file.to_io.path
+    end
+
+    def send_stored_file(file, disposition:, fallback:)
+      options = {
+        disposition: disposition,
+        filename: stored_filename(file, fallback)
+      }
+      mime_type = file.metadata["mime_type"]
+      options[:type] = mime_type if mime_type.present?
+
+      send_file(download_path(file), **options)
+    end
+
+    def stored_filename(file, fallback)
+      filename = File.basename(file.metadata["filename"].to_s.tr("\\", "/"))
+
+      ActiveStorage::Filename.wrap(filename.presence || fallback).sanitized
     end
 
     def manuscript_fragment

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,7 @@
 # MediaController
 class MediaController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:play, :display, :inline,
+  skip_before_action :authenticate_user!, only: [:play, :display,
+                                                 :inline_manuscript,
                                                  :geogebra, :inline_geogebra,
                                                  :download]
   before_action :set_medium, except: [:index, :new, :create, :search,
@@ -14,7 +15,8 @@ class MediaController < ApplicationController
                                       :cancel_import_vertex]
   before_action :set_lecture, only: [:index]
   before_action :set_teachable, only: [:new]
-  before_action :check_for_consent, except: [:play, :display, :inline,
+  before_action :check_for_consent, except: [:play, :display,
+                                             :inline_manuscript,
                                              :geogebra, :inline_geogebra,
                                              :download]
   after_action :store_access, only: [:play, :display]
@@ -274,12 +276,13 @@ class MediaController < ApplicationController
       return
     end
 
-    @manuscript_inline_url = inline_medium_path(@medium) + manuscript_fragment
+    @manuscript_inline_url = inline_manuscript_medium_path(@medium) +
+                             manuscript_fragment
     render layout: false
     prevent_caching unless @medium.free?
   end
 
-  def inline
+  def inline_manuscript
     if @medium.manuscript.nil?
       redirect_to :root, alert: I18n.t("controllers.no_manuscript")
       return

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,8 @@
 # MediaController
 class MediaController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:play, :display, :inline, :download]
+  skip_before_action :authenticate_user!, only: [:play, :display, :inline,
+                                                 :geogebra, :inline_geogebra,
+                                                 :download]
   before_action :set_medium, except: [:index, :new, :create, :search,
                                       :fill_teachable_select,
                                       :fill_media_select,
@@ -12,7 +14,9 @@ class MediaController < ApplicationController
                                       :cancel_import_vertex]
   before_action :set_lecture, only: [:index]
   before_action :set_teachable, only: [:new]
-  before_action :check_for_consent, except: [:play, :display, :inline, :download]
+  before_action :check_for_consent, except: [:play, :display, :inline,
+                                             :geogebra, :inline_geogebra,
+                                             :download]
   after_action :store_access, only: [:play, :display]
   authorize_resource except: [:index, :new, :create, :search,
                               :fill_teachable_select, :fill_media_select,
@@ -300,6 +304,24 @@ class MediaController < ApplicationController
     end
     I18n.locale = @medium.locale_with_inheritance
     render layout: "geogebra"
+    prevent_caching unless @medium.free?
+  end
+
+  def inline_geogebra
+    if @medium.geogebra.nil?
+      redirect_to :root, alert: I18n.t("controllers.no_geogebra")
+      return
+    end
+
+    options = {
+      disposition: "inline",
+      filename: @medium.geogebra.metadata["filename"]
+    }
+    mime_type = @medium.geogebra.metadata["mime_type"]
+    options[:type] = mime_type if mime_type.present?
+
+    send_file(@medium.geogebra.to_io, **options)
+    prevent_caching unless @medium.free?
   end
 
   def download

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -437,12 +437,6 @@ class Medium < ApplicationRecord
     geogebra_url(:screenshot, host: host)
   end
 
-  def manuscript_url_with_host
-    return "#{manuscript_url(host: host)}/#{manuscript_filename}" if ENV["REWRITE_ENABLED"] == "1"
-
-    manuscript_url(host: host)
-  end
-
   def manuscript_filename
     return if manuscript.blank?
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -427,10 +427,6 @@ class Medium < ApplicationRecord
     geogebra.metadata["size"]
   end
 
-  def geogebra_url_with_host
-    geogebra_url(host: host)
-  end
-
   def geogebra_screenshot_url
     return "" if geogebra.blank?
 

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -101,7 +101,7 @@
         </div>
         <div class="col-2">
           <%= link_to t('buttons.view_pdf'),
-                      item.medium.manuscript_url_with_host,
+                      display_medium_path(item.medium),
                       class: 'btn btn-sm btn-outline-info',
                       target: "_blank" %>
         </div>

--- a/app/views/media/_manuscript.html.erb
+++ b/app/views/media/_manuscript.html.erb
@@ -43,7 +43,7 @@
         <%= t('basics.screenshot') %>
       </button>
       <%= link_to t('buttons.view'),
-                  medium.manuscript_url_with_host,
+                  display_medium_path(medium),
                   class: 'btn btn-sm btn-outline-secondary',
                   target: "_blank" %>
     <% end %>

--- a/app/views/media/display.html.erb
+++ b/app/views/media/display.html.erb
@@ -20,6 +20,7 @@
     </style>
   </head>
   <body>
-    <iframe src="<%= @manuscript_inline_url %>"></iframe>
+    <iframe src="<%= @manuscript_inline_url %>"
+            title="<%= @medium.manuscript_filename || "PDF" %>"></iframe>
   </body>
 </html>

--- a/app/views/media/display.html.erb
+++ b/app/views/media/display.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><%= @medium.manuscript_filename || "PDF" %></title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+
+      iframe {
+        border: 0;
+        display: block;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe src="<%= @manuscript_inline_url %>"></iframe>
+  </body>
+</html>

--- a/app/views/media/geogebra.html.erb
+++ b/app/views/media/geogebra.html.erb
@@ -6,7 +6,7 @@
 </div>
 <div class="row ps-2 ms-2">
   <div id="ggb-element"
-       data-filename="<%= @medium.geogebra_url_with_host %>"
+       data-filename="<%= inline_geogebra_medium_path(@medium) %>"
        data-type="<%= @medium.geogebra_app_name %>">
   </div>
 </div>

--- a/app/views/media/inspect.html.erb
+++ b/app/views/media/inspect.html.erb
@@ -240,7 +240,7 @@
       <%= link_to image_tag(@medium.manuscript_screenshot_url,
                             class: 'img-fluid',
                             id: 'manuscript-preview'),
-                  @medium.manuscript_url_with_host,
+                  display_medium_path(@medium),
                   target: "_blank" %>
       <% else %>
         <%= t('manuscript.no_manuscript') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,9 +387,9 @@ Rails.application.routes.draw do
       to: "media#display",
       as: "display_medium"
 
-  get "media/:id/inline",
-      to: "media#inline",
-      as: "inline_medium"
+  get "media/:id/manuscript/inline",
+      to: "media#inline_manuscript",
+      as: "inline_manuscript_medium"
 
   get "media/:id/geogebra",
       to: "media#geogebra",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -395,6 +395,10 @@ Rails.application.routes.draw do
       to: "media#geogebra",
       as: "geogebra_medium"
 
+  get "media/:id/geogebra/inline",
+      to: "media#inline_geogebra",
+      as: "inline_geogebra_medium"
+
   get "media/:id/download/:sort",
       to: "media#download",
       as: "download_medium"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,6 +387,10 @@ Rails.application.routes.draw do
       to: "media#display",
       as: "display_medium"
 
+  get "media/:id/inline",
+      to: "media#inline",
+      as: "inline_medium"
+
   get "media/:id/geogebra",
       to: "media#geogebra",
       as: "geogebra_medium"

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -199,6 +199,24 @@ RSpec.describe("Media", type: :request) do
       expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
     end
 
+    it "sanitizes the inline filename from uploaded metadata" do
+      allow_any_instance_of(PdfUploader::UploadedFile).to receive(:metadata)
+        .and_wrap_original do |original, *args|
+          original.call(*args).merge("filename" => "../evil\r\nname.pdf")
+        end
+
+      get inline_manuscript_medium_path(restricted_medium)
+
+      content_disposition = response.headers["Content-Disposition"]
+
+      expect(response).to have_http_status(:ok)
+      expect(content_disposition).to include("inline")
+      expect(content_disposition).to include("evil")
+      expect(content_disposition).to include("name.pdf")
+      expect(content_disposition).not_to include("../")
+      expect(content_disposition).not_to match(/[\r\n]/)
+    end
+
     it "allows guest inline access for free media" do
       sign_out user
 
@@ -220,7 +238,8 @@ RSpec.describe("Media", type: :request) do
     let(:fake_geogebra) do
       instance_double(
         "Shrine::UploadedFile",
-        to_io: File.join(SPEC_FILES, "manuscript.pdf"),
+        to_io: File.open(File.join(SPEC_FILES, "manuscript.pdf")),
+        storage: double("storage"),
         metadata: {
           "filename" => "demo.ggb",
           "mime_type" => "application/zip"
@@ -263,7 +282,8 @@ RSpec.describe("Media", type: :request) do
     let(:fake_geogebra) do
       instance_double(
         "Shrine::UploadedFile",
-        to_io: File.join(SPEC_FILES, "manuscript.pdf"),
+        to_io: File.open(File.join(SPEC_FILES, "manuscript.pdf")),
+        storage: double("storage"),
         metadata: {
           "filename" => "demo.ggb",
           "mime_type" => "application/zip"
@@ -283,6 +303,31 @@ RSpec.describe("Media", type: :request) do
       expect(response.headers["Content-Disposition"]).to include("inline")
       expect(response.headers["Content-Disposition"]).to include("demo.ggb")
       expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+    end
+
+    it "sanitizes the inline geogebra filename from uploaded metadata" do
+      hostile_geogebra = instance_double(
+        "Shrine::UploadedFile",
+        to_io: File.open(File.join(SPEC_FILES, "manuscript.pdf")),
+        storage: double("storage"),
+        metadata: {
+          "filename" => "../demo\r\nfile.ggb",
+          "mime_type" => "application/zip"
+        }
+      )
+      allow_any_instance_of(Medium).to receive(:geogebra)
+        .and_return(hostile_geogebra)
+
+      get inline_geogebra_medium_path(restricted_medium)
+
+      content_disposition = response.headers["Content-Disposition"]
+
+      expect(response).to have_http_status(:ok)
+      expect(content_disposition).to include("inline")
+      expect(content_disposition).to include("demo")
+      expect(content_disposition).to include("file.ggb")
+      expect(content_disposition).not_to include("../")
+      expect(content_disposition).not_to match(/[\r\n]/)
     end
 
     it "allows guest inline geogebra access for free media" do

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -122,4 +122,66 @@ RSpec.describe("Media", type: :request) do
       expect(flash[:alert]).to eq(I18n.t("controllers.invalid_download"))
     end
   end
+
+  describe "GET /media/:id/display" do
+    let(:restricted_medium) { create(:lecture_medium, :with_manuscript) }
+    let(:free_medium) { create(:lecture_medium, :with_manuscript, :released) }
+
+    it "renders a compatibility page that points to the inline manuscript" do
+      get display_medium_path(restricted_medium), params: { page: "17" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/html")
+      expect(response.body)
+        .to include("src=\"#{inline_medium_path(restricted_medium)}#page=17\"")
+      expect(response.headers["Cache-Control"]).to include("no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"])
+        .to eq("Mon, 01 Jan 1990 00:00:00 GMT")
+    end
+
+    it "preserves named destinations in the inline manuscript fragment" do
+      get display_medium_path(restricted_medium), params: { destination: "Theorem 1" }
+
+      expect(response.body)
+        .to include("src=\"#{inline_medium_path(restricted_medium)}#Theorem%201\"")
+    end
+
+    it "allows guest access to the compatibility page for free media" do
+      sign_out user
+
+      get display_medium_path(free_medium), params: { page: "3" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body)
+        .to include("src=\"#{inline_medium_path(free_medium)}#page=3\"")
+      expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
+    end
+  end
+
+  describe "GET /media/:id/inline" do
+    let(:restricted_medium) { create(:lecture_medium, :with_manuscript) }
+    let(:free_medium) { create(:lecture_medium, :with_manuscript, :released) }
+
+    it "serves the manuscript inline through Rails" do
+      get inline_medium_path(restricted_medium)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/pdf")
+      expect(response.headers["Content-Disposition"]).to include("inline")
+      expect(response.headers["Content-Disposition"])
+        .to include(restricted_medium.manuscript_filename)
+      expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+    end
+
+    it "allows guest inline access for free media" do
+      sign_out user
+
+      get inline_medium_path(free_medium)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Disposition"]).to include("inline")
+      expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
+    end
+  end
 end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -133,7 +133,9 @@ RSpec.describe("Media", type: :request) do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("text/html")
       expect(response.body)
-        .to include("src=\"#{inline_medium_path(restricted_medium)}#page=17\"")
+        .to include(
+          "src=\"#{inline_manuscript_medium_path(restricted_medium)}#page=17\""
+        )
       expect(response.headers["Cache-Control"]).to include("no-store")
       expect(response.headers["Pragma"]).to eq("no-cache")
       expect(response.headers["Expires"])
@@ -144,7 +146,9 @@ RSpec.describe("Media", type: :request) do
       get display_medium_path(restricted_medium), params: { destination: "Theorem 1" }
 
       expect(response.body)
-        .to include("src=\"#{inline_medium_path(restricted_medium)}#Theorem%201\"")
+        .to include(
+          "src=\"#{inline_manuscript_medium_path(restricted_medium)}#Theorem%201\""
+        )
     end
 
     it "allows guest access to the compatibility page for free media" do
@@ -154,17 +158,19 @@ RSpec.describe("Media", type: :request) do
 
       expect(response).to have_http_status(:ok)
       expect(response.body)
-        .to include("src=\"#{inline_medium_path(free_medium)}#page=3\"")
+        .to include(
+          "src=\"#{inline_manuscript_medium_path(free_medium)}#page=3\""
+        )
       expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
     end
   end
 
-  describe "GET /media/:id/inline" do
+  describe "GET /media/:id/manuscript/inline" do
     let(:restricted_medium) { create(:lecture_medium, :with_manuscript) }
     let(:free_medium) { create(:lecture_medium, :with_manuscript, :released) }
 
     it "serves the manuscript inline through Rails" do
-      get inline_medium_path(restricted_medium)
+      get inline_manuscript_medium_path(restricted_medium)
 
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("application/pdf")
@@ -177,7 +183,7 @@ RSpec.describe("Media", type: :request) do
     it "allows guest inline access for free media" do
       sign_out user
 
-      get inline_medium_path(free_medium)
+      get inline_manuscript_medium_path(free_medium)
 
       expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Disposition"]).to include("inline")

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe("Media", type: :request) do
         .to include(
           "src=\"#{inline_manuscript_medium_path(restricted_medium)}#page=17\""
         )
+      expect(response.body)
+        .to include("title=\"#{restricted_medium.manuscript_filename}\"")
       expect(response.headers["Cache-Control"]).to include("no-store")
       expect(response.headers["Pragma"]).to eq("no-cache")
       expect(response.headers["Expires"])

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -184,4 +184,90 @@ RSpec.describe("Media", type: :request) do
       expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
     end
   end
+
+  describe "GET /media/:id/geogebra" do
+    let(:restricted_medium) do
+      create(:lecture_medium, geogebra_app_name: "classic")
+    end
+    let(:free_medium) do
+      create(:lecture_medium, :released, geogebra_app_name: "classic")
+    end
+    let(:fake_geogebra) do
+      instance_double(
+        "Shrine::UploadedFile",
+        to_io: File.join(SPEC_FILES, "manuscript.pdf"),
+        metadata: {
+          "filename" => "demo.ggb",
+          "mime_type" => "application/zip"
+        }
+      )
+    end
+
+    before do
+      allow_any_instance_of(Medium).to receive(:geogebra).and_return(fake_geogebra)
+    end
+
+    it "renders the geogebra page with a Rails-served inline asset" do
+      get geogebra_medium_path(restricted_medium)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/html")
+      expect(response.body)
+        .to include("data-filename=\"#{inline_geogebra_medium_path(restricted_medium)}\"")
+      expect(response.headers["Cache-Control"]).to include("no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"])
+        .to eq("Mon, 01 Jan 1990 00:00:00 GMT")
+    end
+
+    it "allows guest access to the geogebra page for free media" do
+      sign_out user
+
+      get geogebra_medium_path(free_medium)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body)
+        .to include("data-filename=\"#{inline_geogebra_medium_path(free_medium)}\"")
+      expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
+    end
+  end
+
+  describe "GET /media/:id/geogebra/inline" do
+    let(:restricted_medium) { create(:lecture_medium) }
+    let(:free_medium) { create(:lecture_medium, :released) }
+    let(:fake_geogebra) do
+      instance_double(
+        "Shrine::UploadedFile",
+        to_io: File.join(SPEC_FILES, "manuscript.pdf"),
+        metadata: {
+          "filename" => "demo.ggb",
+          "mime_type" => "application/zip"
+        }
+      )
+    end
+
+    before do
+      allow_any_instance_of(Medium).to receive(:geogebra).and_return(fake_geogebra)
+    end
+
+    it "serves the geogebra file inline through Rails" do
+      get inline_geogebra_medium_path(restricted_medium)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/zip")
+      expect(response.headers["Content-Disposition"]).to include("inline")
+      expect(response.headers["Content-Disposition"]).to include("demo.ggb")
+      expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+    end
+
+    it "allows guest inline geogebra access for free media" do
+      sign_out user
+
+      get inline_geogebra_medium_path(free_medium)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Disposition"]).to include("inline")
+      expect(response.headers["Cache-Control"]).not_to eq("no-cache, no-store")
+    end
+  end
 end


### PR DESCRIPTION
This PR is a follow-up to #1144 . It moves manuscript and GeoGebra access behind authorized Rails endpoints instead of exposing direct file URLs. It keeps the existing `display?page=` / `display?destination=` manuscript contract via a compatibility shim, cleans up the old helper usage, and leaves video handling unchanged (for now).

This PR will be part one of a series of PRs that will do the same for videos, vtts,...