### PR TITLE
Sanitize submission response filenames for manuscripts and corrections

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -149,10 +149,10 @@ class SubmissionsController < ApplicationController
 
   def show_manuscript
     if @submission&.manuscript
-      send_file(@submission.manuscript.to_io,
-                type: @submission.manuscript_mime_type,
-                disposition: @disposition,
-                filename: @submission.manuscript_filename)
+      send_submission_file(@submission.manuscript,
+                           type: @submission.manuscript_mime_type,
+                           disposition: @disposition,
+                           fallback: "manuscript")
     elsif @submission
       redirect_to :start, alert: t("submission.no_manuscript_yet")
     else
@@ -162,10 +162,10 @@ class SubmissionsController < ApplicationController
 
   def show_correction
     if @submission&.correction
-      send_file(@submission.correction.to_io,
-                type: @submission.correction_mime_type,
-                disposition: @disposition,
-                filename: @submission.correction_filename)
+      send_submission_file(@submission.correction,
+                           type: @submission.correction_mime_type,
+                           disposition: @disposition,
+                           fallback: "correction")
     elsif @submission
       redirect_to :start, alert: t("submission.no_correction_yet")
     else
@@ -461,5 +461,24 @@ class SubmissionsController < ApplicationController
       return unless accepted.in?(Assignment.non_inline_file_types)
 
       @disposition = "attachment"
+    end
+
+    def send_submission_file(file, type:, disposition:, fallback:)
+      send_file(submission_file_path(file),
+                type: type,
+                disposition: disposition,
+                filename: sanitized_submission_filename(file, fallback))
+    end
+
+    def submission_file_path(file)
+      return file.storage.path(file.id) if file.storage.respond_to?(:path)
+
+      file.to_io.path
+    end
+
+    def sanitized_submission_filename(file, fallback)
+      filename = File.basename(file.metadata["filename"].to_s.tr("\\", "/"))
+
+      ActiveStorage::Filename.wrap(filename.presence || fallback).sanitized
     end
 end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe("Submissions", type: :request) do
+  let(:user) { create(:confirmed_user) }
+  let(:lecture) { create(:lecture, :released_for_all) }
+  let(:assignment) { create(:assignment, lecture: lecture, accepted_file_type: ".pdf") }
+  let(:tutorial) { create(:tutorial, lecture: lecture) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /submissions/:id/show_manuscript" do
+    let(:submission) do
+      create(:submission, :with_manuscript, assignment: assignment,
+                                            tutorial: tutorial).tap do |record|
+        record.users << user
+      end
+    end
+
+    it "sanitizes the manuscript filename from uploaded metadata" do
+      allow_any_instance_of(SubmissionUploader::UploadedFile).to receive(:metadata)
+        .and_wrap_original do |original, *args|
+          original.call(*args).merge("filename" => "../evil\r\nname.pdf")
+        end
+
+      get show_submission_manuscript_path(submission)
+
+      content_disposition = response.headers["Content-Disposition"]
+
+      expect(response).to have_http_status(:ok)
+      expect(content_disposition).to include("inline")
+      expect(content_disposition).to include("evil")
+      expect(content_disposition).to include("name.pdf")
+      expect(content_disposition).not_to include("../")
+      expect(content_disposition).not_to match(/[\r\n]/)
+    end
+  end
+
+  describe "GET /submissions/:id/show_correction" do
+    let(:submission) do
+      create(:submission, :with_correction, assignment: assignment,
+                                            tutorial: tutorial).tap do |record|
+        record.users << user
+      end
+    end
+
+    it "sanitizes the correction filename from uploaded metadata" do
+      allow_any_instance_of(CorrectionUploader::UploadedFile).to receive(:metadata)
+        .and_wrap_original do |original, *args|
+          original.call(*args).merge("filename" => "../evil\r\nname.pdf")
+        end
+
+      get show_correction_path(submission, download: true)
+
+      content_disposition = response.headers["Content-Disposition"]
+
+      expect(response).to have_http_status(:ok)
+      expect(content_disposition).to include("attachment")
+      expect(content_disposition).to include("evil")
+      expect(content_disposition).to include("name.pdf")
+      expect(content_disposition).not_to include("../")
+      expect(content_disposition).not_to match(/[\r\n]/)
+    end
+  end
+end


### PR DESCRIPTION
**Note:** This PR has been superseded by #1151.

In writing #1144 I realized that our submission downloads deserve a hardening, that's why I wrote this fix. Note that this is not a path traversal problem we fix here: the file path served by Rails already comes from Shrine-managed storage, not from the uploaded filename. Still, uploaded metadata was flowing into the response filename, so we now strip path segments and control characters before handing it to Rails. Adds request coverage for hostile metadata on both endpoints.