### PR TITLE
Update Ruby LSP settings for Ruby LSP 10.4 compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -100,6 +100,9 @@
     "postCreateCommand": ".devcontainer/boot.sh",
     "customizations": {
         "vscode": {
+            "settings": {
+                "rubyLsp.customRubyCommand": "export PATH=/usr/local/bin:$PATH"
+            },
             // 🎹 keep this in sync with extensions.json
             "extensions": [
                 "ms-azuretools.vscode-containers",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -100,9 +100,6 @@
     "postCreateCommand": ".devcontainer/boot.sh",
     "customizations": {
         "vscode": {
-            "settings": {
-                "rubyLsp.customRubyCommand": "export PATH=/usr/local/bin:$PATH"
-            },
             // 🎹 keep this in sync with extensions.json
             "extensions": [
                 "ms-azuretools.vscode-containers",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,7 +44,6 @@
         "editor.formatOnSave": true
     },
     "rubyLsp.formatter": "rubocop",
-    // https://shopify.github.io/ruby-lsp/version-managers.html#custom-activation
     "rubyLsp.rubyVersionManager": {
         "identifier": "none"
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,7 @@
     "rubyLsp.rubyVersionManager": {
         "identifier": "none"
     },
+    "rubyLsp.customRubyCommand": "export PATH=/usr/local/bin:$PATH",
     "rubyLsp.rubyExecutablePath": "/usr/local/bin/ruby",
     "rubyLsp.enabledFeatures": {
         "codeActions": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,7 @@
     "rubyLsp.formatter": "rubocop",
     // https://shopify.github.io/ruby-lsp/version-managers.html#custom-activation
     "rubyLsp.rubyVersionManager": {
-        "identifier": "custom"
+        "identifier": "none"
     },
     "rubyLsp.rubyExecutablePath": "/usr/local/bin/ruby",
     "rubyLsp.enabledFeatures": {


### PR DESCRIPTION
Ruby LSP stopped working with the previous configuration after upgrading to Ruby LSP 10.4. This PR updates the workspace/devcontainer settings to restore a working setup. The workspace-level rubyVersionManager change is intentional, because the previous setting no longer works with Ruby LSP 10.4. The devcontainer setting provides the additional container-specific adjustment needed in this environment.

This is a workaround for https://github.com/Shopify/ruby-lsp/issues/4114