### PR TITLE
Add banners for participants and groups in roster views

### DIFF
--- a/app/frontend/lectures/edit/_participants.html.erb
+++ b/app/frontend/lectures/edit/_participants.html.erb
@@ -1,5 +1,5 @@
 <div class="col-12">
-    <div class="alert alert-info d-flex align-items-start mb-3"
+    <div class="alert alert-warning d-flex align-items-start mb-3"
        role="alert">
     <i class="bi bi-info-circle-fill flex-shrink-0 me-2 mt-1"
        aria-hidden="true"></i>

--- a/app/frontend/lectures/edit/_participants.html.erb
+++ b/app/frontend/lectures/edit/_participants.html.erb
@@ -1,4 +1,8 @@
 <div class="col-12">
+  <div class="alert alert-info mb-3" role="alert">
+    <%= t("roster.banners.participants") %>
+  </div>
+
   <%= turbo_frame_tag "roster_participants_panel",
                       src: lecture_roster_participants_path(lecture),
                       loading: "lazy" do %>

--- a/app/frontend/lectures/edit/_participants.html.erb
+++ b/app/frontend/lectures/edit/_participants.html.erb
@@ -1,6 +1,9 @@
 <div class="col-12">
-  <div class="alert alert-info mb-3" role="alert">
-    <%= t("roster.banners.participants") %>
+    <div class="alert alert-info d-flex align-items-start mb-3"
+       role="alert">
+    <i class="bi bi-info-circle-fill flex-shrink-0 me-2 mt-1"
+       aria-hidden="true"></i>
+    <div><%= t("roster.banners.participants") %></div>
   </div>
 
   <%= turbo_frame_tag "roster_participants_panel",

--- a/app/frontend/lectures/edit/_roster.html.erb
+++ b/app/frontend/lectures/edit/_roster.html.erb
@@ -1,6 +1,6 @@
 <% group_type ||= :all %>
 <div class="col-12">
-    <div class="alert alert-info d-flex align-items-start mb-3"
+    <div class="alert alert-warning d-flex align-items-start mb-3"
        role="alert">
     <i class="bi bi-info-circle-fill flex-shrink-0 me-2 mt-1"
        aria-hidden="true"></i>

--- a/app/frontend/lectures/edit/_roster.html.erb
+++ b/app/frontend/lectures/edit/_roster.html.erb
@@ -1,5 +1,9 @@
 <% group_type ||= :all %>
 <div class="col-12">
+  <div class="alert alert-info mb-3" role="alert">
+    <%= t("roster.banners.groups") %>
+  </div>
+
   <%= turbo_frame_tag roster_maintenance_frame_id(group_type),
                       src: lecture_roster_path(lecture, group_type: group_type),
                       loading: "lazy" do %>

--- a/app/frontend/lectures/edit/_roster.html.erb
+++ b/app/frontend/lectures/edit/_roster.html.erb
@@ -1,7 +1,10 @@
 <% group_type ||= :all %>
 <div class="col-12">
-  <div class="alert alert-info mb-3" role="alert">
-    <%= t("roster.banners.groups") %>
+    <div class="alert alert-info d-flex align-items-start mb-3"
+       role="alert">
+    <i class="bi bi-info-circle-fill flex-shrink-0 me-2 mt-1"
+       aria-hidden="true"></i>
+    <div><%= t("roster.banners.groups") %></div>
   </div>
 
   <%= turbo_frame_tag roster_maintenance_frame_id(group_type),

--- a/config/locales/roster/de.yml
+++ b/config/locales/roster/de.yml
@@ -50,7 +50,7 @@ de:
       all: 'Alle'
       unassigned: 'Ohne Gruppe'
     banners:
-      groups: "MaMpf integriert Müsli. In diesem Tab werden ab jetzt die Tutorien und Gruppen verwaltet. Da die Anmeldungen im Sommersemster 2026 noch nicht über MaMpf durchgeführt wurden, stehen die Teilnehmerzahlen derzeit auf 0, auch wenn bereits Tutorien existieren. Wir empfehlen, dies in diesem Semester so zu belassen und insbesondere keine neuen Anmeldungen mehr zu starten. Ab dem WS 2026/27 kann die Registrierung für Vorlesungen und Seminare über MaMpf erfolgen"
+      groups: "MaMpf integriert Müsli. In diesem Tab werden ab jetzt die Tutorien und Gruppen verwaltet. Da die Anmeldungen im Sommersemster 2026 noch nicht über MaMpf durchgeführt wurden, stehen die Teilnehmerzahlen derzeit auf 0, auch wenn bereits Tutorien existieren. Wir empfehlen, dies in diesem Semester so zu belassen und insbesondere keine neuen Anmeldungen mehr zu starten. Ab dem WS 2026/27 kann die Registrierung für Vorlesungen und Seminare über MaMpf erfolgen."
       participants: "MaMpf integriert Müsli. Da die Anmeldungen im Sommersemester 2026 noch nicht über MaMpf durchgeführt wurden, ist die Teilnehmerliste leer. Ab dem WS 2026/27 können sich Studierende über MaMpf für Vorlesungen und Seminare registrieren, und die Teilnehmerliste wird sich nach der Anmeldung automatisch füllen."
     dashboard:
       title: 'Dashboard'

--- a/config/locales/roster/de.yml
+++ b/config/locales/roster/de.yml
@@ -49,6 +49,9 @@ de:
     filters:
       all: 'Alle'
       unassigned: 'Ohne Gruppe'
+    banners:
+      groups: "MaMpf integriert Müsli. In diesem Tab werden ab jetzt die Tutorien und Gruppen verwaltet. Da die Anmeldungen im Sommersemster 2026 noch nicht über MaMpf durchgeführt wurden, stehen die Teilnehmerzahlen derzeit auf 0, auch wenn bereits Tutorien existieren. Wir empfehlen, dies in diesem Semester so zu belassen und insbesondere keine neuen Anmeldungen mehr zu starten. Ab dem WS 2026/27 kann die Registrierung für Vorlesungen und Seminare über MaMpf erfolgen"
+      participants: "MaMpf integriert Müsli. Da die Anmeldungen im Sommersemester 2026 noch nicht über MaMpf durchgeführt wurden, ist die Teilnehmerliste leer. Ab dem WS 2026/27 können sich Studierende über MaMpf für Vorlesungen und Seminare registrieren, und die Teilnehmerliste wird sich nach der Anmeldung automatisch füllen."
     dashboard:
       title: 'Dashboard'
       description: 'Verwaltung der Zuteilungen und globale Übersicht.'

--- a/config/locales/roster/en.yml
+++ b/config/locales/roster/en.yml
@@ -50,7 +50,7 @@ en:
       all: 'All'
       unassigned: 'Without group'
     banners:
-      groups: 'MaMpf is integrating Muesli. Tutorials and groups will now be managed in this tab. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant counts are currently 0, even if tutorials already exist. We recommend leaving this as it is for this semester and, in particular, not starting any new registrations. Starting with winter semester 2026/27, registration for lectures and seminars can take place via MaMpf.'
+      groups: 'MaMpf is integrating Müsli. Tutorials and groups will now be managed in this tab. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant counts are currently 0, even if tutorials already exist. We recommend leaving this as is for this semester and, in particular, not starting any new registrations. Starting with winter semester 2026/27, registration for lectures and seminars can take place via MaMpf.'
       participants: 'MaMpf is integrating Muesli. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant list is empty. Starting with winter semester 2026/27, students will be able to register for lectures and seminars via MaMpf, and the participant list will fill automatically after registration.'
     dashboard:
       title: 'Dashboard'

--- a/config/locales/roster/en.yml
+++ b/config/locales/roster/en.yml
@@ -51,7 +51,7 @@ en:
       unassigned: 'Without group'
     banners:
       groups: 'MaMpf is integrating Müsli. Tutorials and groups will now be managed in this tab. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant counts are currently 0, even if tutorials already exist. We recommend leaving this as is for this semester and, in particular, not starting any new registrations. Starting with winter semester 2026/27, registration for lectures and seminars can take place via MaMpf.'
-      participants: 'MaMpf is integrating Muesli. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant list is empty. Starting with winter semester 2026/27, students will be able to register for lectures and seminars via MaMpf, and the participant list will fill automatically after registration.'
+      participants: 'MaMpf is integrating Müsli. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant list is empty. Starting with winter semester 2026/27, students will be able to register for lectures and seminars via MaMpf, and the participant list will fill automatically after registration.'
     dashboard:
       title: 'Dashboard'
       description: 'Manage allocations and view global performance.'

--- a/config/locales/roster/en.yml
+++ b/config/locales/roster/en.yml
@@ -49,6 +49,9 @@ en:
     filters:
       all: 'All'
       unassigned: 'Without group'
+    banners:
+      groups: 'MaMpf is integrating Muesli. Tutorials and groups will now be managed in this tab. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant counts are currently 0, even if tutorials already exist. We recommend leaving this as it is for this semester and, in particular, not starting any new registrations. Starting with winter semester 2026/27, registration for lectures and seminars can take place via MaMpf.'
+      participants: 'MaMpf is integrating Muesli. Since registrations for the summer semester 2026 have not yet been carried out via MaMpf, the participant list is empty. Starting with winter semester 2026/27, students will be able to register for lectures and seminars via MaMpf, and the participant list will fill automatically after registration.'
     dashboard:
       title: 'Dashboard'
       description: 'Manage allocations and view global performance.'


### PR DESCRIPTION
In this PR we add two banners, one in the groups tab and one in the participants tab of the lecture edit view, whose purpose it is to inform the users of the ongoing integration of Müsli in MaMpf and the structural changes in the lecture edit view page. In particular they explain why for the current semester the studnet counts are all 0.

<img width="779" height="611" alt="Screenshot 2026-06-21 185651" src="https://github.com/user-attachments/assets/9bdffb64-5a92-4180-a851-b81655f730d6" />
<img width="776" height="383" alt="Screenshot 2026-06-21 185701" src="https://github.com/user-attachments/assets/ecf7699d-3a56-49b6-b16e-4cefcc2127fc" />

