### PR TITLE
Fix bugs in groups tab

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,7 +81,10 @@ class ApplicationController < ActionController::Base
 
     turbo_stream.update("campaigns_container",
                         partial: "registration/campaigns/card_body_index",
-                        locals: { lecture: lecture })
+                        locals: {
+                          lecture: lecture,
+                          registration_section: params[:registration_section]
+                        })
   end
 
   protected

--- a/app/controllers/registration_campaign_context.rb
+++ b/app/controllers/registration_campaign_context.rb
@@ -42,7 +42,9 @@ module RegistrationCampaignContext
 
     def existing_registration_campaign(lecture:, error_target:)
       campaign_id = params[:registration_campaign_id]
-      scope = lecture.registration_campaigns.order(created_at: :desc)
+      scope = Registration::Campaign.where(campaignable: lecture)
+                                    .where.not(status: :completed)
+                                    .order(created_at: :desc)
       campaign = campaign_id.present? ? scope.find_by(id: campaign_id) : scope.first
       return campaign if campaign
 

--- a/app/frontend/registration/campaigns/_card_body_index.html.erb
+++ b/app/frontend/registration/campaigns/_card_body_index.html.erb
@@ -1,5 +1,6 @@
 <%= render RegistrationCampaignsCardBodyIndexComponent.new(
              lecture: lecture,
              new_campaign: local_assigns[:new_campaign],
-             registration_section: params[:registration_section]
+             registration_section: local_assigns[:registration_section] ||
+                                   params[:registration_section]
            ) %>

--- a/app/frontend/registration/campaigns/registration_campaigns_card_body_index_component.rb
+++ b/app/frontend/registration/campaigns/registration_campaigns_card_body_index_component.rb
@@ -44,7 +44,7 @@ class RegistrationCampaignsCardBodyIndexComponent < ViewComponent::Base
   end
 
   def collapse_no_campaign_section?
-    selected_section == "campaign" ||
+    selected_campaign_section? ||
       (campaigns.any? && no_campaign_groups.empty?)
   end
 
@@ -80,5 +80,9 @@ class RegistrationCampaignsCardBodyIndexComponent < ViewComponent::Base
 
     def campaigns
       @campaigns ||= lecture.registration_campaigns.order(created_at: :desc).to_a
+    end
+
+    def selected_campaign_section?
+      selected_section == "campaign" && active_campaigns.any?
     end
 end

--- a/spec/components/registration/campaigns/registration_campaigns_card_body_index_component_spec.rb
+++ b/spec/components/registration/campaigns/registration_campaigns_card_body_index_component_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe(RegistrationCampaignsCardBodyIndexComponent, type: :component) do
       expect(component.no_campaign_groups).to eq([])
     end
   end
+
+  describe "collapse state" do
+    it "keeps the no-campaign section open when only completed campaigns remain" do
+      lecture = create(:lecture)
+      create(:registration_campaign, :completed, campaignable: lecture)
+      tutorial = create(:tutorial, lecture: lecture)
+
+      component = described_class.new(lecture: lecture,
+                                      registration_section: "campaign")
+
+      allow(component).to receive(:no_campaign_groups).and_return([tutorial])
+
+      expect(component.collapse_campaign_section?).to be(true)
+      expect(component.collapse_no_campaign_section?).to be(false)
+    end
+  end
 end

--- a/spec/controllers/registration_campaign_context_spec.rb
+++ b/spec/controllers/registration_campaign_context_spec.rb
@@ -152,6 +152,46 @@ RSpec.describe(RegistrationCampaignContext) do
           item = Registration::Item.last
           expect(item.registration_campaign).to eq(newer_campaign)
         end
+
+        it "ignores completed campaigns when selecting an existing campaign" do
+          completed_campaign = create(:registration_campaign,
+                                      :completed,
+                                      campaignable: lecture,
+                                      created_at: 1.day.from_now)
+
+          expect do
+            result = context_instance.send(:apply_registration_context,
+                                           registerable: registerable,
+                                           lecture: lecture,
+                                           error_target: error_target)
+            expect(result).to be(true)
+          end.to change(Registration::Item, :count).by(1)
+             .and(change(Registration::Campaign, :count).by(0))
+
+          item = Registration::Item.find_by!(registerable: registerable)
+          expect(item.registration_campaign).to eq(existing_campaign)
+          expect(item.registration_campaign).not_to eq(completed_campaign)
+        end
+      end
+
+      context "when only completed campaigns exist and no ID is provided" do
+        before do
+          create(:registration_campaign, :completed, campaignable: lecture)
+        end
+
+        it "creates a new active campaign instead of reusing a completed one" do
+          expect do
+            result = context_instance.send(:apply_registration_context,
+                                           registerable: registerable,
+                                           lecture: lecture,
+                                           error_target: error_target)
+            expect(result).to be(true)
+          end.to change(Registration::Campaign, :count).by(1)
+             .and(change(Registration::Item, :count).by(1))
+
+          item = Registration::Item.find_by!(registerable: registerable)
+          expect(item.registration_campaign).not_to be_completed
+        end
       end
 
       context "when failing to create a registration item" do


### PR DESCRIPTION
In this PR we fix two bugs in the groups tab. To reproduce these in `next`, successfully finish a campaign and the create a tutorial in a new campaign. Then the two things occur:

- the tutorial is actually created in the "no campaign" area
- both areas - campaign and no campaign - are collapsed

