### PR TITLE
Fix broken playwright test

### DIFF
--- a/e2e/lecture_groups_registration_sections.spec.ts
+++ b/e2e/lecture_groups_registration_sections.spec.ts
@@ -40,12 +40,8 @@ test.describe("lecture group registration sections", () => {
       await expect(campaignSection.getByTestId("registration-campaign-section-body"))
         .toBeVisible();
 
-      const noCampaignSection = page.getByTestId("registration-no-campaign-section");
-      await expect(
-        noCampaignSection.getByRole("button", { name: "Without Registration Process" }),
-      ).toHaveAttribute("aria-expanded", "false");
-      await expect(noCampaignSection.getByTestId("registration-no-campaign-section-body"))
-        .not.toBeVisible();
+      await expect(page.getByTestId("registration-no-campaign-section-body"))
+        .toBeVisible();
     });
 
   test("opens the ambient section after choosing it",


### PR DESCRIPTION
#1163 fixed a bug in the groups tab, but it didn't update the corresponding playwright test. So the playwright test fails currently, because it expects the faulty outcome. This PR fixes it.