### PR TITLE
lecture-home: decouple registration access from subscription and passphrase

### DIFF
--- a/app/abilities/registration_user_registration_ability.rb
+++ b/app/abilities/registration_user_registration_ability.rb
@@ -9,7 +9,14 @@ class RegistrationUserRegistrationAbility
       user.can_edit?(registration.registration_campaign.campaignable)
     end
 
-    can [:index, :create, :destroy, :add], Lecture do |lecture|
+    # Viewing a lecture's home page (its organizational front door) is open
+    # to anyone who can find the lecture: students for published lectures,
+    # and the lecture's staff at any time.
+    can :index, Lecture do |lecture|
+      lecture.published? || user.can_edit?(lecture) || user.admin
+    end
+
+    can [:create, :destroy, :add], Lecture do |lecture|
       student_registration_participant?(user, lecture)
     end
   end

--- a/app/abilities/student_registration_participant.rb
+++ b/app/abilities/student_registration_participant.rb
@@ -1,9 +1,16 @@
 module StudentRegistrationParticipant
   private
 
+    # A student may take part in registration for a lecture if the lecture is
+    # published and they are not part of the lecture's staff.
+    #
+    # Note that deliberately neither a subscription nor a passphrase is
+    # required: registration is decoupled from content access (subscription),
+    # so that students can register for lectures whose content is gated by a
+    # passphrase. Content access for confirmed roster members is granted
+    # separately (see Lecture#ensure_roster_membership!).
     def student_registration_participant?(user, lecture)
-      lecture.visible_for_user?(user) &&
-        lecture.in?(user.lectures) &&
+      lecture.published? &&
         !user.in?(lecture.tutors) &&
         user != lecture.teacher &&
         !user.can_edit?(lecture)

--- a/app/controllers/lectures/home_controller.rb
+++ b/app/controllers/lectures/home_controller.rb
@@ -23,6 +23,12 @@ module Lectures
       @self_rosterables = Rosters::SelfRosterOptionsQuery.new(@lecture, current_user).call
       @notifications = current_user.active_notifications(@lecture)
       @new_topics_count = @lecture.unread_forum_topics_count(current_user) || 0
+      @subscribed = @lecture.in?(current_user.lectures)
+      # Roster members may subscribe without the passphrase, see
+      # ProfileController#subscribe_lecture.
+      @passphrase_required = @lecture.restricted? &&
+                             !LectureMembership.exists?(user: current_user,
+                                                        lecture: @lecture)
 
       render template: "lectures/home/lecture_home",
              layout: turbo_frame_request? ? "turbo_frame" : "application"

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -361,7 +361,10 @@ class LecturesController < ApplicationController
     def check_for_subscribe
       return if @lecture.in?(current_user.lectures)
 
-      redirect_to subscribe_lecture_page_path(@lecture.id)
+      # Non-subscribers are sent to the lecture's home page (its
+      # organizational front door), which offers registration (if the
+      # lecture uses it) as well as a link to the subscription page.
+      redirect_to lecture_user_registrations_path(@lecture)
     end
 
     def lecture_params

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -360,6 +360,8 @@ class LecturesController < ApplicationController
 
     def check_for_subscribe
       return if @lecture.in?(current_user.lectures)
+      # Staff bypass the subscription gate for content.
+      return if current_user.can_edit?(@lecture)
 
       # Non-subscribers are sent to the lecture's home page (its
       # organizational front door), which offers registration (if the

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -80,15 +80,24 @@ class ProfileController < ApplicationController
     if !@lecture.published? && !current_user.admin &&
        !@lecture.edited_by?(current_user)
       @unpublished = true
+      if html_redirect_flow?
+        return redirect_to lecture_user_registrations_path(@lecture),
+                           alert: t("admin.lecture.no_rights")
+      end
       return
     end
     # Roster members may subscribe without the passphrase: a roster seat is
     # a stronger credential than a shared passphrase.
-    return if @lecture.passphrase.present? &&
-              !@lecture.in?(current_user.lectures) &&
-              !LectureMembership.exists?(user: current_user,
-                                         lecture: @lecture) &&
-              @lecture.passphrase != @passphrase
+    if @lecture.passphrase.present? &&
+       !@lecture.in?(current_user.lectures) &&
+       !LectureMembership.exists?(user: current_user, lecture: @lecture) &&
+       @lecture.passphrase != @passphrase
+      if html_redirect_flow?
+        return redirect_to lecture_user_registrations_path(@lecture),
+                           alert: t("errors.profile.passphrase")
+      end
+      return
+    end
 
     @success = current_user.subscribe_lecture!(@lecture)
 
@@ -142,6 +151,13 @@ class ProfileController < ApplicationController
   end
 
   private
+
+    # The subscribe form on the lecture home page submits as a plain HTML
+    # request, in contrast to the legacy JS-driven subscribe flows (dashboard
+    # cards, subscribe page), which expect a JS response.
+    def html_redirect_flow?
+      @parent == "redirect" && request.format.html?
+    end
 
     def set_user
       @user = current_user

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -82,8 +82,12 @@ class ProfileController < ApplicationController
       @unpublished = true
       return
     end
+    # Roster members may subscribe without the passphrase: a roster seat is
+    # a stronger credential than a shared passphrase.
     return if @lecture.passphrase.present? &&
               !@lecture.in?(current_user.lectures) &&
+              !LectureMembership.exists?(user: current_user,
+                                         lecture: @lecture) &&
               @lecture.passphrase != @passphrase
 
     @success = current_user.subscribe_lecture!(@lecture)

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -153,10 +153,16 @@ class ProfileController < ApplicationController
   private
 
     # The subscribe form on the lecture home page submits as a plain HTML
-    # request, in contrast to the legacy JS-driven subscribe flows (dashboard
-    # cards, subscribe page), which expect a JS response.
+    # or Turbo request, in contrast to the legacy JS-driven subscribe flows
+    # (dashboard cards, subscribe page), which expect a JS response.
+    #
+    # NOTE: request.format.html? alone would actually suffice even for Turbo
+    # submissions (Mime::Type#html? matches any MIME string containing
+    # "html", which includes text/vnd.turbo-stream.html) — but we spell out
+    # the Turbo case so correctness does not hinge on that subtlety.
     def html_redirect_flow?
-      @parent == "redirect" && request.format.html?
+      @parent == "redirect" &&
+        (request.format.html? || request.format.turbo_stream?)
     end
 
     def set_user

--- a/app/frontend/lectures/home/lecture_home.html.erb
+++ b/app/frontend/lectures/home/lecture_home.html.erb
@@ -66,11 +66,11 @@
         <%= f.hidden_field :id, value: @lecture.id %>
         <%= f.hidden_field :parent, value: "redirect" %>
         <% if @passphrase_required %>
-          <%= f.text_field :passphrase,
-                           class: "form-control w-auto",
-                           placeholder: t("profile.passphrase"),
-                           "aria-label": t("profile.passphrase"),
-                           data: { testid: "lecture-home-passphrase" } %>
+          <%= f.password_field :passphrase,
+                               class: "form-control w-auto",
+                               placeholder: t("profile.passphrase"),
+                               "aria-label": t("profile.passphrase"),
+                               data: { testid: "lecture-home-passphrase" } %>
         <% end %>
         <%= f.submit t("profile.subscribe_lecture"),
                      class: "btn btn-outline-primary text-nowrap",

--- a/app/frontend/lectures/home/lecture_home.html.erb
+++ b/app/frontend/lectures/home/lecture_home.html.erb
@@ -53,4 +53,17 @@
                rosterized_entries: @rosterized_entries,
                lecture: @lecture
              } %>
+
+  <% unless @lecture.in?(current_user.lectures) ||
+            current_user.can_edit?(@lecture) %>
+    <div class="alert alert-light border mt-3 d-flex align-items-center
+                justify-content-between flex-wrap gap-2"
+         data-testid="lecture-home-subscribe-hint">
+      <span><%= t("registration.lecture.home.subscribe_prompt") %></span>
+      <%= link_to t("profile.subscribe_lecture"),
+                  subscribe_lecture_page_path(@lecture.id),
+                  class: "btn btn-outline-primary btn-sm text-nowrap",
+                  data: { testid: "lecture-home-subscribe-link" } %>
+    </div>
+  <% end %>
 </div>

--- a/app/frontend/lectures/home/lecture_home.html.erb
+++ b/app/frontend/lectures/home/lecture_home.html.erb
@@ -54,16 +54,28 @@
                lecture: @lecture
              } %>
 
-  <% unless @lecture.in?(current_user.lectures) ||
-            current_user.can_edit?(@lecture) %>
-    <div class="alert alert-light border mt-3 d-flex align-items-center
-                justify-content-between flex-wrap gap-2"
+  <% unless @subscribed || current_user.can_edit?(@lecture) %>
+    <div class="alert alert-light border mt-3"
          data-testid="lecture-home-subscribe-hint">
-      <span><%= t("registration.lecture.home.subscribe_prompt") %></span>
-      <%= link_to t("profile.subscribe_lecture"),
-                  subscribe_lecture_page_path(@lecture.id),
-                  class: "btn btn-outline-primary btn-sm text-nowrap",
-                  data: { testid: "lecture-home-subscribe-link" } %>
+      <p class="mb-2"><%= t("registration.lecture.home.subscribe_prompt") %></p>
+      <%= form_with url: subscribe_lecture_path,
+                    method: :patch,
+                    local: true,
+                    scope: "lecture",
+                    class: "d-flex align-items-center flex-wrap gap-2" do |f| %>
+        <%= f.hidden_field :id, value: @lecture.id %>
+        <%= f.hidden_field :parent, value: "redirect" %>
+        <% if @passphrase_required %>
+          <%= f.text_field :passphrase,
+                           class: "form-control w-auto",
+                           placeholder: t("profile.passphrase"),
+                           "aria-label": t("profile.passphrase"),
+                           data: { testid: "lecture-home-passphrase" } %>
+        <% end %>
+        <%= f.submit t("profile.subscribe_lecture"),
+                     class: "btn btn-outline-primary text-nowrap",
+                     data: { testid: "lecture-home-subscribe-button" } %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/frontend/lectures/show/_sidebar.html.erb
+++ b/app/frontend/lectures/show/_sidebar.html.erb
@@ -20,10 +20,12 @@
   <% if lecture %>
     <% fullpath = lecture_path(lecture)%>
     <% active_class = get_class_for_path(lecture_path(lecture)) %>
-    <%# Content is only accessible to subscribers (mirrors the redirect in
-        LecturesController#check_for_subscribe). %>
+    <%# Content is only accessible to subscribers and staff (mirrors the
+        redirect in LecturesController#check_for_subscribe). %>
+    <% content_accessible = lecture.in?(current_user.lectures) ||
+                            current_user.can_edit?(lecture) %>
     <li class="sidebar-item nav-link <%= active_class %>
-            <%= lecture.in?(current_user.lectures) ? "" : "disabled" %>">
+            <%= content_accessible ? "" : "disabled" %>">
       <%= link_to url_for(fullpath),
           data: { turbo_frame: "main", action: "click->lecture-sidebar#setActive" } do %>
         <i class="bi bi-book<%= active_class.present? ? "-fill" : "" %>"></i>

--- a/app/frontend/lectures/show/_sidebar.html.erb
+++ b/app/frontend/lectures/show/_sidebar.html.erb
@@ -20,8 +20,10 @@
   <% if lecture %>
     <% fullpath = lecture_path(lecture)%>
     <% active_class = get_class_for_path(lecture_path(lecture)) %>
+    <%# Content is only accessible to subscribers (mirrors the redirect in
+        LecturesController#check_for_subscribe). %>
     <li class="sidebar-item nav-link <%= active_class %>
-            <%= !lecture ? "disabled" : ""%>">
+            <%= lecture.in?(current_user.lectures) ? "" : "disabled" %>">
       <%= link_to url_for(fullpath),
           data: { turbo_frame: "main", action: "click->lecture-sidebar#setActive" } do %>
         <i class="bi bi-book<%= active_class.present? ? "-fill" : "" %>"></i>

--- a/app/frontend/lectures/subscribe/subscribe_page.html.erb
+++ b/app/frontend/lectures/subscribe/subscribe_page.html.erb
@@ -36,9 +36,9 @@
                         method: 'patch',
                         scope: 'lecture' do |f|%>
             <p>
-              <%= f.text_field :passphrase,
-                               class: 'form-control',
-                               value: "" %>
+              <%= f.password_field :passphrase,
+                                   class: 'form-control',
+                                   value: "" %>
               <div class="invalid-feedback"
                    id="passphrase-error" >
               </div>

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -811,6 +811,14 @@ class Lecture < ApplicationRecord
       attributes,
       unique_by: [:user_id, :lecture_id]
     )
+
+    # Roster membership implies a subscription: members need access to the
+    # lecture's content, even when subscribing is gated by a passphrase
+    # (a roster seat is a stronger credential than a shared passphrase).
+    LectureUserJoin.insert_all(
+      attributes,
+      unique_by: [:lecture_id, :user_id]
+    )
     # rubocop:enable Rails/SkipsModelValidations
   end
 

--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -529,6 +529,10 @@ de:
         view_details: "Details"
     lecture:
       not_found: "Veranstaltung nicht gefunden."
+      home:
+        subscribe_prompt: >-
+          Du hast diese Veranstaltung noch nicht abonniert. Ein Abo gibt dir
+          Zugriff auf die Materialien — es ist keine verbindliche Anmeldung.
   activerecord:
     errors:
       models:

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -528,6 +528,10 @@ en:
         view_details: "Details"
     lecture:
       not_found: "Lecture not found."
+      home:
+        subscribe_prompt: >-
+          You have not subscribed to this lecture yet. Subscribing gives you
+          access to its materials — it is not a binding course registration.
   activerecord:
     errors:
       models:

--- a/spec/abilities/lecture_ability_spec.rb
+++ b/spec/abilities/lecture_ability_spec.rb
@@ -6,19 +6,21 @@ RSpec.describe(LectureAbility) do
   let(:user) { create(:confirmed_user) }
   let(:lecture) { create(:lecture, :released_for_all) }
 
-  it "allows subscribed students to self-materialize" do
-    create(:lecture_user_join, user: user, lecture: lecture)
-
+  it "allows students to self-materialize for published lectures" do
     expect(ability.can?(:self_materialize, lecture)).to be(true)
     expect(ability.can?(:enroll, lecture)).to be(true)
   end
 
-  it "does not allow users who are not subscribed to the lecture" do
-    expect(ability.can?(:self_materialize, lecture)).to be(false)
-    expect(ability.can?(:enroll, lecture)).to be(false)
+  it "does not require a subscription (registration is decoupled from " \
+     "content access)" do
+    passphrase_lecture = create(:lecture, :released_for_all,
+                                passphrase: "secret")
+
+    expect(ability.can?(:self_materialize, passphrase_lecture)).to be(true)
+    expect(ability.can?(:enroll, passphrase_lecture)).to be(true)
   end
 
-  it "does not allow students subscribed to an unpublished lecture" do
+  it "does not allow students to self-materialize for unpublished lectures" do
     unpublished_lecture = create(:lecture)
     create(:lecture_user_join, user: user, lecture: unpublished_lecture)
 

--- a/spec/abilities/registration_user_registration_ability_spec.rb
+++ b/spec/abilities/registration_user_registration_ability_spec.rb
@@ -6,21 +6,24 @@ RSpec.describe(RegistrationUserRegistrationAbility) do
   let(:user) { create(:confirmed_user) }
   let(:lecture) { create(:lecture, :released_for_all) }
 
-  it "allows subscribed students to use student registration" do
-    create(:lecture_user_join, user: user, lecture: lecture)
-
+  it "allows students to view the home page of and register for " \
+     "published lectures" do
     expect(ability.can?(:index, lecture)).to be(true)
     expect(ability.can?(:create, lecture)).to be(true)
     expect(ability.can?(:add, lecture)).to be(true)
   end
 
-  it "does not allow users who are not subscribed to the lecture" do
-    expect(ability.can?(:index, lecture)).to be(false)
-    expect(ability.can?(:create, lecture)).to be(false)
-    expect(ability.can?(:add, lecture)).to be(false)
+  it "does not require a subscription or passphrase (registration is " \
+     "decoupled from content access)" do
+    passphrase_lecture = create(:lecture, :released_for_all,
+                                passphrase: "secret")
+
+    expect(ability.can?(:index, passphrase_lecture)).to be(true)
+    expect(ability.can?(:create, passphrase_lecture)).to be(true)
+    expect(ability.can?(:add, passphrase_lecture)).to be(true)
   end
 
-  it "does not allow students subscribed to an unpublished lecture" do
+  it "does not allow students to access unpublished lectures" do
     unpublished_lecture = create(:lecture)
     create(:lecture_user_join, user: user, lecture: unpublished_lecture)
 
@@ -29,11 +32,10 @@ RSpec.describe(RegistrationUserRegistrationAbility) do
     expect(ability.can?(:add, unpublished_lecture)).to be(false)
   end
 
-  it "does not allow lecture staff" do
-    staff_lecture = create(:lecture, :released_for_all, teacher: user)
-    create(:lecture_user_join, user: user, lecture: staff_lecture)
+  it "allows lecture staff to view the home page but not to register" do
+    staff_lecture = create(:lecture, teacher: user)
 
-    expect(ability.can?(:index, staff_lecture)).to be(false)
+    expect(ability.can?(:index, staff_lecture)).to be(true)
     expect(ability.can?(:create, staff_lecture)).to be(false)
     expect(ability.can?(:add, staff_lecture)).to be(false)
   end

--- a/spec/models/lecture_spec.rb
+++ b/spec/models/lecture_spec.rb
@@ -270,5 +270,24 @@ RSpec.describe(Lecture, type: :model) do
       expect(lecture.members).to include(*users)
       expect(LectureMembership.where(lecture: lecture, user: users.first).count).to eq(1)
     end
+
+    it "subscribes roster members to the lecture" do
+      expect do
+        lecture.ensure_roster_membership!(users.map(&:id))
+      end.to change(LectureUserJoin, :count).by(3)
+
+      expect(lecture.users).to include(*users)
+    end
+
+    it "keeps existing subscriptions intact" do
+      create(:lecture_user_join, user: users.first, lecture: lecture)
+
+      expect do
+        lecture.ensure_roster_membership!(users.map(&:id))
+      end.to change(LectureUserJoin, :count).by(2) # Only 2 new ones
+
+      expect(LectureUserJoin.where(lecture: lecture, user: users.first).count)
+        .to eq(1)
+    end
   end
 end

--- a/spec/requests/lectures_spec.rb
+++ b/spec/requests/lectures_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe("Lectures", type: :request) do
 
       expect(response).to redirect_to(lecture_user_registrations_path(lecture))
     end
+
+    it "does not redirect staff (they bypass the subscription gate)" do
+      teacher_lecture = create(:lecture, :released_for_all, teacher: user)
+
+      get lecture_path(teacher_lecture)
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "XSS protections" do

--- a/spec/requests/lectures_spec.rb
+++ b/spec/requests/lectures_spec.rb
@@ -121,6 +121,17 @@ RSpec.describe("Lectures", type: :request) do
     end
   end
 
+  describe "GET /lectures/:id/outline as a non-subscriber" do
+    let(:user) { create(:confirmed_user) }
+    let(:lecture) { create(:lecture, :released_for_all) }
+
+    it "redirects to the lecture's home page" do
+      get lecture_path(lecture)
+
+      expect(response).to redirect_to(lecture_user_registrations_path(lecture))
+    end
+  end
+
   describe "XSS protections" do
     let(:xss_payload) { "<div id='test-xss-xyz123'><script>alert('lecture-xss')</script></div>" }
     let!(:xss_course) { create(:course, title: "XSS Course") }

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -41,5 +41,45 @@ RSpec.describe("Profile", type: :request) do
         expect(user.reload.lectures).to include(lecture)
       end
     end
+
+    context "with the plain HTML flow of the lecture home page" do
+      let(:lecture) do
+        create(:lecture, :released_for_all, passphrase: "secret")
+      end
+
+      def subscribe_html(lecture, passphrase: nil)
+        patch(subscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   passphrase: passphrase,
+                                   parent: "redirect" } })
+      end
+
+      it "redirects to the lecture content after a successful subscription" do
+        subscribe_html(lecture, passphrase: "secret")
+
+        expect(response).to redirect_to(lecture_path(lecture))
+        expect(user.reload.lectures).to include(lecture)
+      end
+
+      it "redirects back to the lecture home page with an alert on a " \
+         "wrong passphrase" do
+        subscribe_html(lecture, passphrase: "wrong")
+
+        expect(response)
+          .to redirect_to(lecture_user_registrations_path(lecture))
+        expect(flash[:alert]).to eq(I18n.t("errors.profile.passphrase"))
+        expect(user.reload.lectures).not_to include(lecture)
+      end
+
+      it "redirects with an alert when the lecture is not published" do
+        unpublished = create(:lecture)
+
+        subscribe_html(unpublished)
+
+        expect(response)
+          .to redirect_to(lecture_user_registrations_path(unpublished))
+        expect(flash[:alert]).to eq(I18n.t("admin.lecture.no_rights"))
+      end
+    end
   end
 end

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe("Profile", type: :request) do
+  let(:user) { create(:confirmed_user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "PATCH /profile/subscribe_lecture" do
+    def subscribe(lecture, passphrase: nil)
+      patch(subscribe_lecture_path,
+            params: { lecture: { id: lecture.id, passphrase: passphrase } },
+            xhr: true)
+    end
+
+    context "with a passphrase-protected lecture" do
+      let(:lecture) do
+        create(:lecture, :released_for_all, passphrase: "secret")
+      end
+
+      it "subscribes the user with the correct passphrase" do
+        subscribe(lecture, passphrase: "secret")
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.lectures).to include(lecture)
+      end
+
+      it "does not subscribe the user without the passphrase" do
+        subscribe(lecture)
+
+        expect(user.reload.lectures).not_to include(lecture)
+      end
+
+      it "subscribes roster members without the passphrase" do
+        create(:lecture_membership, user: user, lecture: lecture)
+
+        subscribe(lecture)
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.lectures).to include(lecture)
+      end
+    end
+  end
+end

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe("Profile", type: :request) do
         expect(user.reload.lectures).not_to include(lecture)
       end
 
+      it "redirects with an alert also for Turbo form submissions" do
+        # Turbo intercepts even local forms and negotiates the
+        # turbo_stream format
+        patch(subscribe_lecture_path,
+              params: { lecture: { id: lecture.id, passphrase: "wrong",
+                                   parent: "redirect" } },
+              headers: { "ACCEPT" => "text/vnd.turbo-stream.html, " \
+                                     "text/html, application/xhtml+xml" })
+
+        expect(response)
+          .to redirect_to(lecture_user_registrations_path(lecture))
+        expect(flash[:alert]).to eq(I18n.t("errors.profile.passphrase"))
+      end
+
       it "redirects with an alert when the lecture is not published" do
         unpublished = create(:lecture)
 

--- a/spec/requests/registration/user_registrations_spec.rb
+++ b/spec/requests/registration/user_registrations_spec.rb
@@ -116,8 +116,32 @@ RSpec.describe("Registration::UserRegistrations", type: :request) do
       get lecture_user_registrations_path(lecture_id: lecture.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("lecture-home-subscribe-link")
-      expect(response.body).to include(subscribe_lecture_page_path(lecture.id))
+      expect(response.body).to include("lecture-home-subscribe-button")
+      expect(response.body).to include(subscribe_lecture_path)
+    end
+
+    it "shows a passphrase field for passphrase-protected lectures" do
+      passphrase_lecture = create(:lecture, :released_for_all,
+                                  passphrase: "secret")
+      unsubscribed_student = create(:confirmed_user)
+      sign_in unsubscribed_student
+
+      get lecture_user_registrations_path(lecture_id: passphrase_lecture.id)
+
+      expect(response.body).to include("lecture-home-passphrase")
+    end
+
+    it "does not show a passphrase field to roster members" do
+      passphrase_lecture = create(:lecture, :released_for_all,
+                                  passphrase: "secret")
+      member = create(:confirmed_user)
+      create(:lecture_membership, user: member, lecture: passphrase_lecture)
+      sign_in member
+
+      get lecture_user_registrations_path(lecture_id: passphrase_lecture.id)
+
+      expect(response.body).to include("lecture-home-subscribe-button")
+      expect(response.body).not_to include("lecture-home-passphrase")
     end
 
     it "is accessible for students without the passphrase" do

--- a/spec/requests/registration/user_registrations_spec.rb
+++ b/spec/requests/registration/user_registrations_spec.rb
@@ -108,13 +108,16 @@ RSpec.describe("Registration::UserRegistrations", type: :request) do
   end
 
   describe "GET lecture home page (access)" do
-    it "is accessible for students who are not subscribed" do
+    it "is accessible for students who are not subscribed and offers them " \
+       "the subscription page" do
       unsubscribed_student = create(:confirmed_user)
       sign_in unsubscribed_student
 
       get lecture_user_registrations_path(lecture_id: lecture.id)
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("lecture-home-subscribe-link")
+      expect(response.body).to include(subscribe_lecture_page_path(lecture.id))
     end
 
     it "is accessible for students without the passphrase" do

--- a/spec/requests/registration/user_registrations_spec.rb
+++ b/spec/requests/registration/user_registrations_spec.rb
@@ -107,6 +107,34 @@ RSpec.describe("Registration::UserRegistrations", type: :request) do
     end
   end
 
+  describe "GET lecture home page (access)" do
+    it "is accessible for students who are not subscribed" do
+      unsubscribed_student = create(:confirmed_user)
+      sign_in unsubscribed_student
+
+      get lecture_user_registrations_path(lecture_id: lecture.id)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "is accessible for students without the passphrase" do
+      passphrase_lecture = create(:lecture, :released_for_all,
+                                  passphrase: "secret")
+
+      get lecture_user_registrations_path(lecture_id: passphrase_lecture.id)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "is accessible for the teacher of the lecture" do
+      teacher_lecture = create(:lecture, teacher: user)
+
+      get lecture_user_registrations_path(lecture_id: teacher_lecture.id)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "GET lectures/:lecture_id/campaign_registrations" do
     context "open + first-come-first-served tutorial campaign" do
       let(:campaign) do
@@ -225,8 +253,18 @@ RSpec.describe("Registration::UserRegistrations", type: :request) do
       end
     end
 
-    context "when the user is not allowed to enroll" do
+    context "when the user is the lecture's teacher" do
       let(:lecture) { create(:lecture, teacher: user) }
+
+      it "renders the home page (viewing is decoupled from enrolling)" do
+        get lecture_user_registrations_path(lecture_id: lecture.id)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the lecture is not published" do
+      let(:lecture) { create(:lecture) }
 
       it "redirects to root" do
         get lecture_user_registrations_path(lecture_id: lecture.id)


### PR DESCRIPTION
Proposed corrections on top of #1169, offered as concrete commits to take, adapt, or reject. They complete the premise of the new lecture home page: with passphrase-gated lectures, students must be able to **register without being able to subscribe** — so the organizational front door and the registration flow cannot require a subscription.

Four commits, each self-contained:

1. **Decouple registration access from subscription and passphrase**
   - Viewing the home page (`:index`) is open to any signed-in user for published lectures, and to staff at any time. As written on `lecture-home`, `student_registration_participant?` requires a subscription (unreachable for passphrase lectures before content access) and returns `false` for staff (`!can_edit?`) — yet the home template renders an edit button for them, so teachers were locked out of their own home page.
   - Registering (`create`/`destroy`/`add`, `self_materialize`/`enroll`) requires only a **published** lecture + not being staff. No subscription, no passphrase.
   - In return, the roster ⇒ subscription implication is enforced: `ensure_roster_membership!` auto-subscribes members, and roster members may subscribe **without the passphrase** (a roster seat is a stronger credential than a shared secret).

2. **Route non-subscribers to the lecture home page** — `check_for_subscribe` redirects to the home page instead of the subscribe page, so every legacy content link (search cards, bookmarks) funnels through the organizational front door. The home page in turn offers non-subscribers an inline subscribe.

3. **Subscribe directly from the lecture home page** — inline subscribe form (passphrase field only when required, omitted for roster members) as a plain-HTML flow; the legacy JS subscribe flows are format-keyed and untouched. Also: passphrase inputs are now `password_field`s (they echoed the passphrase in clear text), and the sidebar Outline entry is disabled for users without content access.

4. **Staff bypass the subscription gate for content** — teachers/editors/admins reach the outline without subscribing.

## Testing

- New/updated specs across abilities, profile, lectures, and user_registrations (incl. home-page access for unsubscribed students, passphrase lectures, teachers; passphrase bypass for roster members; HTML subscribe flow success/failure).
- Full registration + roster request suites green (228 examples at time of writing).
- Exercised end to end in the integration preview #1171 (register on a passphrase lecture without subscription → finalize → auto-subscribed → content unlocks).

One deliberate trade-off to review: `student_registration_participant?` now checks `lecture.published?` instead of `visible_for_user?` — this intentionally opens registration for passphrase-gated lectures. If some campaigns should be limited further, that is what registration policies are for.