### PR TITLE
Fix datetimepicker init in the publish modal via Stimulus

### DIFF
--- a/app/frontend/js/datetimepicker.js
+++ b/app/frontend/js/datetimepicker.js
@@ -11,7 +11,7 @@ export function initializeDatetimePickers(container = document) {
     element = $(element);
     // Skip elements handled by the datetimepicker Stimulus controller; it inits
     // them on connect(), so initializing here too would create a second picker.
-    if ((element.attr("data-controller") || "").split(/\s+/).includes("datetimepicker")) {
+    if (element.attr("data-controller")?.split(/\s+/).includes("datetimepicker")) {
       return;
     }
     if (element.data("td-initialized")) {

--- a/app/frontend/js/datetimepicker.js
+++ b/app/frontend/js/datetimepicker.js
@@ -9,6 +9,11 @@ export function initializeDatetimePickers(container = document) {
 
   pickerElements.each((i, element) => {
     element = $(element);
+    // Skip elements handled by the datetimepicker Stimulus controller; it inits
+    // them on connect(), so initializing here too would create a second picker.
+    if ((element.attr("data-controller") || "").split(/\s+/).includes("datetimepicker")) {
+      return;
+    }
     if (element.data("td-initialized")) {
       return;
     }

--- a/app/frontend/js/media.coffee
+++ b/app/frontend/js/media.coffee
@@ -279,41 +279,40 @@ $(document).on 'turbo:load', ->
   if trixElement?
     content = trixElement.dataset.content
     editor = trixElement.editor
-    if !editor
-      return
-    editor.setSelectedRange([0,65535])
-    editor.deleteInDirection("forward")
-    editor.insertHTML(content)
-    document.activeElement.blur()
-    trixElement.addEventListener 'trix-change', ->
-      $('#medium-basics-warning').show()
-      $('#medium-content-preview').html($('#medium-content-trix').html())
-      mediumContentDetails = document.getElementById('medium-content-preview')
-      renderMathInElement mediumContentDetails,
-        delimiters: [
-          {
-            left: '$$'
-            right: '$$'
-            display: true
-          }
-          {
-            left: '$'
-            right: '$'
-            display: false
-          }
-          {
-            left: '\\('
-            right: '\\)'
-            display: false
-          }
-          {
-            left: '\\['
-            right: '\\]'
-            display: true
-          }
-        ]
-        throwOnError: false
-      return
+    if editor
+      editor.setSelectedRange([0,65535])
+      editor.deleteInDirection("forward")
+      editor.insertHTML(content)
+      document.activeElement.blur()
+      trixElement.addEventListener 'trix-change', ->
+        $('#medium-basics-warning').show()
+        $('#medium-content-preview').html($('#medium-content-trix').html())
+        mediumContentDetails = document.getElementById('medium-content-preview')
+        renderMathInElement mediumContentDetails,
+          delimiters: [
+            {
+              left: '$$'
+              right: '$$'
+              display: true
+            }
+            {
+              left: '$'
+              right: '$'
+              display: false
+            }
+            {
+              left: '\\('
+              right: '\\)'
+              display: false
+            }
+            {
+              left: '\\['
+              right: '\\]'
+              display: true
+            }
+          ]
+          throwOnError: false
+        return
 
   $(document).on 'click', '.triggerDownload', ->
     mediumId = $(this).data('medium')
@@ -340,6 +339,10 @@ $(document).on 'turbo:load', ->
   $('#release_date').on 'focus', ->
     # Select other option if user clicks on release date input field
     $('#medium_release_now_0').prop('checked', true)
+    return
+
+  $('#medium_release_now_0').on 'click', ->
+    setTimeout((-> document.getElementById('release_date')?.focus()), 100)
     return
 
   $('#medium_create_assignment').on 'click', ->

--- a/app/views/media/_publish_modal.html.erb
+++ b/app/views/media/_publish_modal.html.erb
@@ -63,7 +63,6 @@
             <%= f.text_field :release_date,
                              class: 'form-control td-input',
                              id: 'release_date',
-                             "data-testid": 'release-date-datetimepicker',
                              autocomplete: 'off',
                              value: medium.planned_release_date,
                             'data-td-target': '#release-date-picker'%>

--- a/app/views/media/_publish_modal.html.erb
+++ b/app/views/media/_publish_modal.html.erb
@@ -57,6 +57,7 @@
           <div
             class="mb-3 input-group td-picker"
             id="release-date-picker"
+            data-controller="datetimepicker"
             data-td-target-input="nearest"
             data-td-target-toggle="nearest">
             <%= f.text_field :release_date,
@@ -113,6 +114,7 @@
                 <div
                   class="input-group td-picker"
                   id="assignment-date-picker"
+                  data-controller="datetimepicker"
                   data-td-target-input="nearest"
                   data-td-target-toggle="nearest">
                   <%= f.text_field :assignment_deadline,
@@ -124,7 +126,7 @@
                   <span
                     class="input-group-text td-picker-button"
                     role="button"
-                    data-td-target="#release-date-picker"
+                    data-td-target="#assignment-date-picker"
                     data-td-toggle="datetimepicker">
                     <i class="bi bi-calendar-fill"></i>
                   </span>

--- a/e2e/medium.spec.ts
+++ b/e2e/medium.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from "./_support/fixtures";
-import { selectDate } from "./page-objects/datepicker";
+import { dateLabel, selectDate } from "./page-objects/datepicker";
 import { LecturePage } from "./page-objects/lecture_page";
 
 test("can schedule medium publication with datetimepicker",
   async ({ factory, teacher: { page, user } }) => {
+    const releaseDate = new Date();
+    releaseDate.setDate(releaseDate.getDate() + 2);
+    const releaseDateLabel = dateLabel(releaseDate);
+
     const lecture = await factory.create("lecture", ["released_for_all"],
       { teacher_id: user.id, content_mode: "manuscript" });
     const medium = await factory.create("lecture_medium", ["with_lecture_by_id"],
@@ -12,8 +16,11 @@ test("can schedule medium publication with datetimepicker",
     await new LecturePage(page, lecture.id).gotoEdit();
     await page.getByRole("link", { name: medium.description }).click();
     await page.getByRole("button", { name: "publish" }).click();
-    await page.getByTestId("release-date-datetimepicker").click();
-    const dayName = await selectDate(page);
+
+    await page.getByRole("radio", { name: "at the following time" }).click();
+    await expect(page.getByRole("gridcell", { name: releaseDateLabel })).toBeVisible();
+    const dayName = await selectDate(page, releaseDate);
+
     await page.getByRole("checkbox", { name: "I hereby confirm that" }).click();
     await page.getByRole("button", { name: "Save" }).click();
 

--- a/e2e/page-objects/datepicker.ts
+++ b/e2e/page-objects/datepicker.ts
@@ -3,15 +3,19 @@ import { Page } from "../_support/fixtures";
 const DEFAULT_DATE_FUTURE = new Date();
 DEFAULT_DATE_FUTURE.setDate(DEFAULT_DATE_FUTURE.getDate() + 2);
 
+export function dateLabel(date = DEFAULT_DATE_FUTURE) {
+  const monthName = date.toLocaleString("en-US", { month: "long" });
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${monthName} ${day}`;
+}
+
 /**
  * Selects a date in the datepicker widget (only based on month and day, not year).
  *
  * @returns the name of the selected day (e.g. "March 15") for further use in assertions.
  */
 export async function selectDate(page: Page, date = DEFAULT_DATE_FUTURE) {
-  const monthName = date.toLocaleString("en-US", { month: "long" });
-  const day = String(date.getDate()).padStart(2, "0");
-  const dayString = `${monthName} ${day}`;
+  const dayString = dateLabel(date);
   await page.getByRole("gridcell", { name: dayString }).click();
   return dayString;
 }


### PR DESCRIPTION
Teachers reported that creation of assignments in the media publish modal is not always working

The release-date and assignment-deadline pickers are initialized imperatively (`$(document).ready` + a `turbo:load` call), which loses the race with the per-page module on Turbo navigations and sometimes left the pickers uninitialized, blocking assignment creation. In this PR we change this: We manage them with the existing datetimepicker Stimulus controller, guard the imperative initializer against double-initializing Stimulus-managed elements, and fix the assignment button targeting the wrong picker.

**Note:** Even better would be to migrate all existing datetimepickers to the stimulus controller, but I don't have the time to do this now.

<img width="400" src="https://github.com/user-attachments/assets/a3375e54-8f94-4972-828b-e7ee8c53939c" />

