### PR TITLE
Update campaign wording to promote preference mode

### DIFF
--- a/config/locales/registration/de.yml
+++ b/config/locales/registration/de.yml
@@ -51,7 +51,9 @@ de:
             Wenn Du unsicher bist, empfehlen wir Dir ein Anmeldeverfahren.
             Damit kannst Du ein klares Registrierungsfenster festlegen, die
             Nachfrage vor der endgültigen Zuteilung besser überblicken und
-            Regeln oder begrenzte Plätze fairer verwalten.
+            Regeln oder begrenzte Plätze fairer verwalten. Außerdem kannst Du
+            die Zuteilung automatisch anhand der Präferenzen der Studierenden
+            berechnen lassen.
         columns:
           description: "Kurzbeschreibung"
           type: "Typ"

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -51,7 +51,9 @@ en:
             If you are unsure, we recommend choosing a registration process.
             It gives you a clear registration window, lets you review demand
             before assignments are finalized, and helps you handle
-            eligibility rules or limited capacities more fairly.
+            eligibility rules or limited capacities more fairly. It also lets
+            you compute the allocation automatically from the preferences
+            students submit.
         columns:
           description: "Short description"
           type: "Type"

--- a/config/locales/registration/en.yml
+++ b/config/locales/registration/en.yml
@@ -51,9 +51,9 @@ en:
             If you are unsure, we recommend choosing a registration process.
             It gives you a clear registration window, lets you review demand
             before assignments are finalized, and helps you handle
-            eligibility rules or limited capacities more fairly. It also lets
-            you compute the allocation automatically from the preferences
-            students submit.
+            eligibility rules or limited capacities more fairly. It can also
+            assign students to groups automatically, based on the preferences
+            they submit.
         columns:
           description: "Short description"
           type: "Type"


### PR DESCRIPTION
The text that explains camapaigns currently undersells one of their greatest points (preference mode) by merely declaring

> Benötigst Du ein Anmeldeverfahren?
Wenn Du unsicher bist, empfehlen wir Dir ein Anmeldeverfahren. Damit kannst Du ein klares Registrierungsfenster festlegen, die Nachfrage vor der endgültigen Zuteilung besser überblicken und Regeln oder begrenzte Plätze fairer verwalten.

This PR adds this as final sentence:

Außerdem kannst Du die Zuteilung automatisch anhand der Präferenzen der Studierenden berechnen lassen.

