### PR TITLE
Fix PDF screenshot rendering and add tests

### DIFF
--- a/config/initializers/vips_pdf_loader.rb
+++ b/config/initializers/vips_pdf_loader.rb
@@ -1,0 +1,3 @@
+# Active Storage blocks libvips' unfuzzed loaders since Rails 8.0.5.1. MaMpf renders
+# a preview image from every uploaded manuscript, so the PDF loader has to come back.
+Vips.block("VipsForeignLoadPdf", false) if defined?(Vips)

--- a/config/initializers/vips_pdf_loader.rb
+++ b/config/initializers/vips_pdf_loader.rb
@@ -1,3 +1,4 @@
-# Active Storage blocks libvips' unfuzzed loaders since Rails 8.0.5.1. MaMpf renders
-# a preview image from every uploaded manuscript, so the PDF loader has to come back.
+# Active Storage blocks libvips' unfuzzed loaders since Rails 8.0.5.1, which takes the
+# PDF loader with it and 500s every manuscript upload. Re-enabling it accepts
+# CVE-2025-59933, unfixed in trixie's libvips. Delete this file at libvips 8.17.2+.
 Vips.block("VipsForeignLoadPdf", false) if defined?(Vips)

--- a/spec/uploaders/pdf_uploader_spec.rb
+++ b/spec/uploaders/pdf_uploader_spec.rb
@@ -103,4 +103,35 @@ RSpec.describe(PdfUploader) do
       expect(result).to be_nil
     end
   end
+
+  describe "screenshot derivative" do
+    it "renders the first page of the PDF" do
+      original = File.open("#{SPEC_FILES}/manuscript.pdf", "rb")
+
+      derivatives = described_class::Attacher.derivatives_processor(:default)
+                                             .call(original)
+
+      expect(derivatives[:screenshot]).to be_present
+      expect(Vips::Image.new_from_file(derivatives[:screenshot].path).width)
+        .to be_positive
+    ensure
+      original.close
+    end
+  end
+
+  # Active Storage blocks libvips' unfuzzed loaders since Rails 8.0.5.1, which took
+  # the PDF loader with it and broke every manuscript upload.
+  describe "the libvips PDF loader" do
+    it "is available" do
+      expect { Vips::Image.pdfload("#{SPEC_FILES}/manuscript.pdf") }
+        .not_to raise_error
+    end
+
+    it "is the only unfuzzed loader we unblock" do
+      ["svgload", "magickload", "fitsload", "jxlload"].each do |loader|
+        expect { Vips::Image.public_send(loader, "#{SPEC_FILES}/manuscript.pdf") }
+          .to raise_error(Vips::Error, /blocked/), "#{loader} is no longer blocked"
+      end
+    end
+  end
 end


### PR DESCRIPTION
When we did the last security update in #1201 I missed that this broke screenshot extraction. I fixed this and added tests against regressions.

**Follow-up:** rasterize with `mutool draw` instead of libvips. That drops poppler — and CVE-2025-59933 with it — out of the preview path, so this initializer can go. Debian will not fix 8.16.1 in trixie and there is no backport to upgrade to.

**Update** There is now a better alternative: #1216.
