### PR TITLE
Match the login button exactly

### DIFF
--- a/e2e/page-objects/login_page.ts
+++ b/e2e/page-objects/login_page.ts
@@ -16,6 +16,6 @@ export class LoginPage {
     if (password) {
       await this.page.getByLabel("Password", { exact: true }).fill(password);
     }
-    await this.page.getByRole("button", { name: "Login" }).click();
+    await this.page.getByRole("button", { name: "Login", exact: true }).click();
   }
 }


### PR DESCRIPTION
The Playwright login button added in #1188 is named 'Login as last created Playwright user', and getByRole matches names as substrings, so every test going through LoginPage#login hit a strict mode violation. This PR fixes this.