### PR TITLE
Remove registration_campaigns and roster_maintenance feature flags

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -306,21 +306,17 @@ class LecturesController < ApplicationController
       current_user.lecture_user_joins
                   .where(lecture_id: page_lecture_ids)
                   .pluck(:lecture_id).to_set
-    if Flipper.enabled?(:registration_campaigns)
-      @registered_lecture_ids =
-        Registration::UserRegistration
-        .where(user: current_user, status: [:pending, :confirmed])
-        .joins(:registration_campaign)
-        .where(registration_campaigns: { campaignable_type: "Lecture",
-                                         campaignable_id: page_lecture_ids })
-        .pluck("registration_campaigns.campaignable_id")
-        .to_set
-    end
-    if Flipper.enabled?(:roster_maintenance)
-      status = Rosters::SelfEnrollmentStatusQuery.new(current_user, page_lecture_ids)
-      @rosterized_lecture_ids = status.rosterized_lecture_ids
-      @self_enrollable_lecture_ids = status.enrollable_lecture_ids
-    end
+    @registered_lecture_ids =
+      Registration::UserRegistration
+      .where(user: current_user, status: [:pending, :confirmed])
+      .joins(:registration_campaign)
+      .where(registration_campaigns: { campaignable_type: "Lecture",
+                                       campaignable_id: page_lecture_ids })
+      .pluck("registration_campaigns.campaignable_id")
+      .to_set
+    status = Rosters::SelfEnrollmentStatusQuery.new(current_user, page_lecture_ids)
+    @rosterized_lecture_ids = status.rosterized_lecture_ids
+    @self_enrollable_lecture_ids = status.enrollable_lecture_ids
 
     respond_to do |format|
       format.js { render template: "lectures/search/old/search" }

--- a/app/frontend/lectures/edit/_roster.html.erb
+++ b/app/frontend/lectures/edit/_roster.html.erb
@@ -29,11 +29,9 @@
     </div>
   <% end %>
 
-  <% if Flipper.enabled?(:registration_campaigns) %>
-    <p class="text-muted small mt-3">
-      <%= t("registration.student_message.crosslink_html",
-            link: link_to(t("admin.lecture.communication"),
-                          edit_lecture_path(lecture, tab: "communication"))) %>
-    </p>
-  <% end %>
+  <p class="text-muted small mt-3">
+    <%= t("registration.student_message.crosslink_html",
+          link: link_to(t("admin.lecture.communication"),
+                        edit_lecture_path(lecture, tab: "communication"))) %>
+  </p>
 </div>

--- a/app/frontend/lectures/edit/_seminar_content.html.erb
+++ b/app/frontend/lectures/edit/_seminar_content.html.erb
@@ -1,27 +1,13 @@
 <div class="card bg-mdb-color-lighten-5">
   <div class="card-header">
-    <div class="row">
-      <div class="col-6">
-        <h5>
-          <%= t("admin.lecture.#{lecture.sort}_content") %>
-          <i id="show-media-button"
-             class="far fa-list-alt clickable"
-             data-bs-toggle="tooltip"
-             title="<%= t('admin.lecture.show_media') %>">
-          </i>
-        </h5>
-      </div>
-      <div class="col-6">
-        <% unless Flipper.enabled?(:roster_maintenance) %>
-          <%= link_to t("buttons.create_talk"),
-                      new_talk_path(lecture_id: lecture.id),
-                      remote: true,
-                      class: 'btn btn-sm btn-secondary new-in-lecture',
-                      data: { cy: 'new-talk-btn' },
-                      id: 'new_talk_button' %>
-        <% end %>
-      </div>
-    </div>
+    <h5>
+      <%= t("admin.lecture.#{lecture.sort}_content") %>
+      <i id="show-media-button"
+         class="far fa-list-alt clickable"
+         data-bs-toggle="tooltip"
+         title="<%= t('admin.lecture.show_media') %>">
+      </i>
+    </h5>
   </div>
   <div class="card-body">
     <% if lecture.talks.any? %>

--- a/app/frontend/lectures/edit/edit.html.erb
+++ b/app/frontend/lectures/edit/edit.html.erb
@@ -46,35 +46,33 @@
         </div>
       <% end %>
 
-      <% show_new_roster = Flipper.enabled?(:roster_maintenance) && !@lecture.legacy_seminar %>
-      <% people_label = show_new_roster ? t('basics.personnel') : "#{t('basics.people')}/#{t('basics.tutorials')}" %>
+      <% legacy_seminar = @lecture.legacy_seminar %>
+      <% people_label = legacy_seminar ? "#{t('basics.people')}/#{t('basics.tutorials')}" : t('basics.personnel') %>
 
       <% component.with_tab(name: "people", label: people_label) do %>
         <div class="container small-width lecture-pane">
           <div id="edit_people"><%= render partial: 'lectures/edit/people', locals: { lecture: @lecture } %></div>
-          <% unless show_new_roster %>
+          <% if legacy_seminar %>
             <%= render partial: 'lectures/edit/tutorials', locals: { lecture: @lecture } %>
           <% end %>
           <%= render partial: 'lectures/edit/vouchers', locals: { lecture: @lecture } %>
         </div>
       <% end %>
 
-      <% if Flipper.enabled?(:roster_maintenance) %>
-        <% if !@lecture.legacy_seminar %>
-          <% component.with_tab(name: "groups", label: t("roster.tabs.groups")) do %>
-            <div class="container small-width lecture-pane">
-              <%= render partial: 'lectures/edit/roster',
-                         locals: { lecture: @lecture,
-                                   group_type: roster_group_types(@lecture) } %>
-            </div>
-          <% end %>
+      <% unless legacy_seminar %>
+        <% component.with_tab(name: "groups", label: t("roster.tabs.groups")) do %>
+          <div class="container small-width lecture-pane">
+            <%= render partial: 'lectures/edit/roster',
+                       locals: { lecture: @lecture,
+                                 group_type: roster_group_types(@lecture) } %>
+          </div>
+        <% end %>
 
-          <% component.with_tab(name: "participants", label: t("basics.participants")) do %>
-            <div class="container small-width lecture-pane">
-              <%= render partial: 'lectures/edit/participants',
-                         locals: { lecture: @lecture } %>
-            </div>
-          <% end %>
+        <% component.with_tab(name: "participants", label: t("basics.participants")) do %>
+          <div class="container small-width lecture-pane">
+            <%= render partial: 'lectures/edit/participants',
+                       locals: { lecture: @lecture } %>
+          </div>
         <% end %>
       <% end %>
 
@@ -89,10 +87,8 @@
         <div class="container small-width lecture-pane">
           <%= render partial: 'lectures/edit/announcements',
                      locals: { lecture: @lecture, announcements: @announcements } %>
-          <% if Flipper.enabled?(:registration_campaigns) %>
-            <%= render partial: 'lectures/edit/student_mail',
-                       locals: { lecture: @lecture } %>
-          <% end %>
+          <%= render partial: 'lectures/edit/student_mail',
+                     locals: { lecture: @lecture } %>
           <%= render partial: 'lectures/edit/forum',
                      locals: { lecture: @lecture } %>
           <%= render partial: 'lectures/edit/comments',

--- a/app/helpers/lectures_helper.rb
+++ b/app/helpers/lectures_helper.rb
@@ -2,7 +2,6 @@
 module LecturesHelper
   def registration_sidebar_visible?(lecture)
     return false unless lecture && user_signed_in?
-    return false unless Flipper.enabled?(:registration_campaigns)
 
     RegistrationUserRegistrationAbility.new(current_user).can?(:index, lecture)
   end
@@ -10,8 +9,6 @@ module LecturesHelper
   # Whether the lecture currently has an open registration campaign
   # (one building block of the search-card badges, see _lecture.html.erb).
   def registration_open?(lecture)
-    return false unless Flipper.enabled?(:registration_campaigns)
-
     lecture.registration_campaigns.any?(&:open_for_registrations?)
   end
 

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -928,14 +928,10 @@ class Lecture < ApplicationRecord
     lecture_memberships
   end
 
-  def roster_eligible_tutorials?
-    tutorials.merge(Tutorial.roster_eligible).exists?
-  end
-
   # Whether the roster decides which tutorial a student belongs to, rather than
   # the student picking one.
   def roster_managed?
-    Flipper.enabled?(:roster_maintenance) && roster_eligible_tutorials?
+    tutorials.merge(Tutorial.roster_eligible).exists?
   end
 
   private

--- a/app/models/voucher/voucher.rb
+++ b/app/models/voucher/voucher.rb
@@ -42,6 +42,8 @@ class Voucher < ApplicationRecord
   self.implicit_order_column = :created_at
 
   def self.roles_for_lecture(lecture)
+    # Seminars only have talk, not tutorials, so there is no point in creating
+    # a tutor voucher for a seminar. That's why we exclude the tutor role here.
     return ROLE_HASH.keys - [:tutor] if lecture.seminar?
 
     ROLE_HASH.keys - [:speaker]

--- a/app/models/voucher/voucher.rb
+++ b/app/models/voucher/voucher.rb
@@ -42,11 +42,7 @@ class Voucher < ApplicationRecord
   self.implicit_order_column = :created_at
 
   def self.roles_for_lecture(lecture)
-    if lecture.seminar?
-      return ROLE_HASH.keys - [:tutor] if Flipper.enabled?(:roster_maintenance)
-
-      return ROLE_HASH.keys
-    end
+    return ROLE_HASH.keys - [:tutor] if lecture.seminar?
 
     ROLE_HASH.keys - [:speaker]
   end

--- a/app/views/talks/_basics.html.erb
+++ b/app/views/talks/_basics.html.erb
@@ -18,17 +18,15 @@
       </div>
     </div>
 
-    <% if Flipper.enabled?(:roster_maintenance) %>
-      <div class="row">
-        <div class="col-12 mb-3">
-          <%= f.label :capacity, t('basics.capacity'), class: "form-label" %>
-          <%= f.number_field :capacity,
-                             class: 'form-control',
-                             placeholder: '∞',
-                             min: 0 %>
-        </div>
+    <div class="row">
+      <div class="col-12 mb-3">
+        <%= f.label :capacity, t('basics.capacity'), class: "form-label" %>
+        <%= f.number_field :capacity,
+                           class: 'form-control',
+                           placeholder: '∞',
+                           min: 0 %>
       </div>
-    <% end %>
+    </div>
 
     <!-- 📅 Dates -->
     <div class="row">

--- a/app/views/talks/_form.html.erb
+++ b/app/views/talks/_form.html.erb
@@ -31,13 +31,6 @@
       <%= link_to t('buttons.parent_lecture'),
                   edit_lecture_path(talk.lecture),
                   class: 'btn btn-sm btn-outline-primary mb-2' %>
-      <% unless Flipper.enabled?(:roster_maintenance) %>
-        <%= link_to t('buttons.delete'),
-                    talk_path(talk),
-                    method: :delete,
-                    data: { confirm: t('confirmation.delete_talk') },
-                    class: 'btn btn-sm btn-danger mb-2' %>
-      <% end %>
     </div>
   </div>
   <div class="row p-2">

--- a/architecture/src/features/05a-exam-model.md
+++ b/architecture/src/features/05a-exam-model.md
@@ -105,8 +105,7 @@ class Exam < ApplicationRecord
   validate :registration_deadline_in_future
 
   after_create :setup_assessment, if: -> { Flipper.enabled?(:assessment_grading) }
-  after_create :create_registration_campaign,
-               if: -> { !skip_campaigns && Flipper.enabled?(:registration_campaigns) }
+  after_create :create_registration_campaign, unless: -> { skip_campaigns }
   after_update :update_campaign_deadline, if: -> { registration_deadline.present? && ... }
   before_destroy :destroy_draft_campaign
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3854,7 +3854,6 @@ de:
       Achtung, es gibt ungespeicherte Änderungen!
   confirmation:
     generic: 'Bist Du sicher?'
-    delete_talk: 'Bist Du sicher, dass Du diesen Vortrag löschen möchtest?'
     delete_graph: >
       Bist Du sicher? Es wird nur der Quiz-Graph gelöscht,
       nicht das Medium.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3642,7 +3642,6 @@ en:
     remove_from_list: 'Remove from List'
   confirmation:
     generic: 'Are you sure?'
-    delete_talk: 'Are you sure you want to delete this talk?'
     delete_graph: >
       Are you sure? Note: Only the quiz graph will be deleted,
       not the medium.#

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,79 +313,73 @@ Rails.application.routes.draw do
       as: "lecture_outline"
 
   resources :lectures, except: [:index] do
-    constraints ->(_req) { Flipper.enabled?(:roster_maintenance) } do
-      get "roster", to: "roster/maintenance#index"
-      get "roster/participants", to: "roster/maintenance#participants"
+    get "roster", to: "roster/maintenance#index"
+    get "roster/participants", to: "roster/maintenance#participants"
 
-      member do
-        scope "roster", controller: "roster/maintenance", defaults: { type: "Lecture" } do
-          patch "self_materialization", action: :update_self_materialization,
-                                        as: :roster_update_self_materialization
-          patch "bulk_self_materialization", action: :bulk_update_self_materialization,
-                                             as: :roster_bulk_update_self_materialization
-          post "members", action: :add_member, as: :add_member
-          delete "members/:user_id", action: :remove_member, as: :remove_member
-          patch "members/:user_id/move", action: :move_member, as: :move_member
-        end
+    member do
+      scope "roster", controller: "roster/maintenance", defaults: { type: "Lecture" } do
+        patch "self_materialization", action: :update_self_materialization,
+                                      as: :roster_update_self_materialization
+        patch "bulk_self_materialization", action: :bulk_update_self_materialization,
+                                           as: :roster_bulk_update_self_materialization
+        post "members", action: :add_member, as: :add_member
+        delete "members/:user_id", action: :remove_member, as: :remove_member
+        patch "members/:user_id/move", action: :move_member, as: :move_member
       end
     end
 
-    constraints ->(_req) { Flipper.enabled?(:registration_campaigns) } do
-      resources :campaigns,
-                controller: "registration/campaigns",
-                only: [:index, :new, :create],
-                as: :registration_campaigns
-      resources :student_messages,
-                controller: "registration/student_messages",
-                only: [:create]
-    end
-  end
-
-  constraints ->(_req) { Flipper.enabled?(:registration_campaigns) } do
     resources :campaigns,
               controller: "registration/campaigns",
-              only: [:show, :edit, :update, :destroy],
-              as: :registration_campaigns do
+              only: [:index, :new, :create],
+              as: :registration_campaigns
+    resources :student_messages,
+              controller: "registration/student_messages",
+              only: [:create]
+  end
+
+  resources :campaigns,
+            controller: "registration/campaigns",
+            only: [:show, :edit, :update, :destroy],
+            as: :registration_campaigns do
+    member do
+      patch :open
+      patch :close
+      patch :reopen
+      patch :self_service
+      get :rejected
+      get :unassigned
+    end
+    resource :allocation,
+             controller: "registration/allocations",
+             only: [:show, :create] do
+      patch :finalize
+    end
+    resources :policies,
+              controller: "registration/policies",
+              only: [:new, :create, :edit, :update, :destroy] do
+      collection do
+        patch :reorder
+      end
       member do
-        patch :open
-        patch :close
-        patch :reopen
-        patch :self_service
-        get :rejected
-        get :unassigned
+        patch :move_up
+        patch :move_down
       end
-      resource :allocation,
-               controller: "registration/allocations",
-               only: [:show, :create] do
-        patch :finalize
-      end
-      resources :policies,
-                controller: "registration/policies",
-                only: [:new, :create, :edit, :update, :destroy] do
-        collection do
-          patch :reorder
-        end
-        member do
-          patch :move_up
-          patch :move_down
-        end
-      end
+    end
 
-      resources :items,
-                controller: "registration/items",
-                only: [:create, :destroy, :update] do
-        member do
-          get :roster
-        end
+    resources :items,
+              controller: "registration/items",
+              only: [:create, :destroy, :update] do
+      member do
+        get :roster
       end
+    end
 
-      resources :registrations,
-                controller: "registration/user_registrations",
-                only: [] do
-        collection do
-          delete "user/:user_id/reject", to: "registration/user_registrations#reject_for_user",
-                                         as: :reject_for_user
-        end
+    resources :registrations,
+              controller: "registration/user_registrations",
+              only: [] do
+      collection do
+        delete "user/:user_id/reject", to: "registration/user_registrations#reject_for_user",
+                                       as: :reject_for_user
       end
     end
   end
@@ -889,21 +883,19 @@ Rails.application.routes.draw do
        as: "modify_talk"
 
   resources :talks, except: [:index] do
-    constraints ->(_req) { Flipper.enabled?(:roster_maintenance) } do
-      get "roster", to: "roster/maintenance#show", defaults: { type: "Talk" }
+    get "roster", to: "roster/maintenance#show", defaults: { type: "Talk" }
 
-      member do
-        scope "roster", controller: "roster/maintenance", defaults: { type: "Talk" } do
-          patch "self_materialization", action: :update_self_materialization,
-                                        as: :update_self_materialization
-          post "members", action: :add_member, as: :add_member
-          delete "members/:user_id", action: :remove_member, as: :remove_member
-          patch "members/:user_id/move", action: :move_member, as: :move_member
-        end
-        scope "roster", controller: "roster/self_materialization", defaults: { type: "Talk" } do
-          post "self_add", action: :self_add, as: :self_add
-          delete "self_remove", action: :self_remove, as: :self_remove
-        end
+    member do
+      scope "roster", controller: "roster/maintenance", defaults: { type: "Talk" } do
+        patch "self_materialization", action: :update_self_materialization,
+                                      as: :update_self_materialization
+        post "members", action: :add_member, as: :add_member
+        delete "members/:user_id", action: :remove_member, as: :remove_member
+        patch "members/:user_id/move", action: :move_member, as: :move_member
+      end
+      scope "roster", controller: "roster/self_materialization", defaults: { type: "Talk" } do
+        post "self_add", action: :self_add, as: :self_add
+        delete "self_remove", action: :self_remove, as: :self_remove
       end
     end
   end
@@ -941,22 +933,20 @@ Rails.application.routes.draw do
       as: "export_teams_to_csv"
 
   resources :tutorials, only: [:new, :edit, :create, :update, :destroy] do
-    constraints ->(_req) { Flipper.enabled?(:roster_maintenance) } do
-      get "roster", to: "roster/maintenance#show", defaults: { type: "Tutorial" }
+    get "roster", to: "roster/maintenance#show", defaults: { type: "Tutorial" }
 
-      member do
-        scope "roster", controller: "roster/maintenance", defaults: { type: "Tutorial" } do
-          patch "self_materialization", action: :update_self_materialization,
-                                        as: :update_self_materialization
-          post "members", action: :add_member, as: :add_member
-          delete "members/:user_id", action: :remove_member, as: :remove_member
-          patch "members/:user_id/move", action: :move_member, as: :move_member
-        end
-        scope "roster", controller: "roster/self_materialization",
-                        defaults: { type: "Tutorial" } do
-          post "self_add", action: :self_add, as: :self_add
-          delete "self_remove", action: :self_remove, as: :self_remove
-        end
+    member do
+      scope "roster", controller: "roster/maintenance", defaults: { type: "Tutorial" } do
+        patch "self_materialization", action: :update_self_materialization,
+                                      as: :update_self_materialization
+        post "members", action: :add_member, as: :add_member
+        delete "members/:user_id", action: :remove_member, as: :remove_member
+        patch "members/:user_id/move", action: :move_member, as: :move_member
+      end
+      scope "roster", controller: "roster/self_materialization",
+                      defaults: { type: "Tutorial" } do
+        post "self_add", action: :self_add, as: :self_add
+        delete "self_remove", action: :self_remove, as: :self_remove
       end
     end
   end
@@ -964,21 +954,19 @@ Rails.application.routes.draw do
   # cohorts routes
 
   resources :cohorts, only: [:new, :create, :edit, :update, :destroy] do
-    constraints ->(_req) { Flipper.enabled?(:roster_maintenance) } do
-      get "roster", to: "roster/maintenance#show", defaults: { type: "Cohort" }
+    get "roster", to: "roster/maintenance#show", defaults: { type: "Cohort" }
 
-      member do
-        scope "roster", controller: "roster/maintenance", defaults: { type: "Cohort" } do
-          patch "self_materialization", action: :update_self_materialization,
-                                        as: :update_self_materialization
-          post "members", action: :add_member, as: :add_member
-          delete "members/:user_id", action: :remove_member, as: :remove_member
-          patch "members/:user_id/move", action: :move_member, as: :move_member
-        end
-        scope "roster", controller: "roster/self_materialization", defaults: { type: "Cohort" } do
-          post "self_add", action: :self_add, as: :self_add
-          delete "self_remove", action: :self_remove, as: :self_remove
-        end
+    member do
+      scope "roster", controller: "roster/maintenance", defaults: { type: "Cohort" } do
+        patch "self_materialization", action: :update_self_materialization,
+                                      as: :update_self_materialization
+        post "members", action: :add_member, as: :add_member
+        delete "members/:user_id", action: :remove_member, as: :remove_member
+        patch "members/:user_id/move", action: :move_member, as: :move_member
+      end
+      scope "roster", controller: "roster/self_materialization", defaults: { type: "Cohort" } do
+        post "self_add", action: :self_add, as: :self_add
+        delete "self_remove", action: :self_remove, as: :self_remove
       end
     end
   end
@@ -1074,18 +1062,16 @@ Rails.application.routes.draw do
 
   # registration routes
   scope module: "registration", path: "" do
-    constraints ->(_req) { Flipper.enabled?(:registration_campaigns) } do
-      post "campaign_registrations/:campaign_id/items/:item_id/register",
-           to: "user_registrations#create",
-           as: :register_item
-      delete "campaign_registrations/:campaign_id/items/:item_id/withdraw",
-             to: "user_registrations#destroy",
-             as: :withdraw_item
+    post "campaign_registrations/:campaign_id/items/:item_id/register",
+         to: "user_registrations#create",
+         as: :register_item
+    delete "campaign_registrations/:campaign_id/items/:item_id/withdraw",
+           to: "user_registrations#destroy",
+           as: :withdraw_item
 
-      post "campaign_registrations/:campaign_id/preferences",
-           to: "user_registrations#save_preferences",
-           as: :save_preferences
-    end
+    post "campaign_registrations/:campaign_id/preferences",
+         to: "user_registrations#save_preferences",
+         as: :save_preferences
   end
 
   # main routes

--- a/e2e/group_tab_visibility.spec.ts
+++ b/e2e/group_tab_visibility.spec.ts
@@ -1,31 +1,17 @@
 import { test, expect } from "./_support/fixtures";
-import { enableFeature, disableFeature } from "./_support/backend";
 import { LectureEditPage } from "./page-objects/lecture_edit_page";
 
 /**
  * Integration test for the visibility of the group tab.
  */
-test("Group tab visibility toggles with feature flag", async ({
-  request,
+test("Group tab is offered on the lecture edit page", async ({
   factory,
   teacher: { page, user },
 }) => {
   const lecture = await factory.create("lecture", [], { teacher_id: user.id });
 
   const lectureEditPage = new LectureEditPage(page, lecture.id);
-
-  // 1. Feature disabled
-  await disableFeature(request, "roster_maintenance");
   await lectureEditPage.goto();
-  await expect(lectureEditPage.groupsTab).not.toBeVisible();
 
-  // 2. Enable feature
-  await enableFeature(request, "roster_maintenance");
-  await page.reload();
   await expect(lectureEditPage.groupsTab).toBeVisible();
-
-  // 3. Disable feature
-  await disableFeature(request, "roster_maintenance");
-  await page.reload();
-  await expect(lectureEditPage.groupsTab).not.toBeVisible();
 });

--- a/e2e/lecture_groups_registration_sections.spec.ts
+++ b/e2e/lecture_groups_registration_sections.spec.ts
@@ -1,12 +1,6 @@
-import { enableFeature } from "./_support/backend";
 import { expect, test } from "./_support/fixtures";
 
 test.describe("lecture group registration sections", () => {
-  test.beforeEach(async ({ request }) => {
-    await enableFeature(request, "roster_maintenance");
-    await enableFeature(request, "registration_campaigns");
-  });
-
   test("asks for a section choice when no groups exist yet",
     async ({ factory, teacher: { page, user } }) => {
       const lecture = await factory.create("lecture", [], { teacher_id: user.id });

--- a/e2e/registration/self_service_after_finalization.spec.ts
+++ b/e2e/registration/self_service_after_finalization.spec.ts
@@ -1,4 +1,3 @@
-import { enableFeature } from "../_support/backend";
 import { expect, test, Page } from "../_support/fixtures";
 import { FactoryBot, FactoryBotObject } from "../_support/factorybot";
 
@@ -8,11 +7,6 @@ import { FactoryBot, FactoryBotObject } from "../_support/factorybot";
  * teacher decide.
  */
 test.describe("self-enrollment prompt after finalization", () => {
-  test.beforeEach(async ({ request }) => {
-    await enableFeature(request, "roster_maintenance");
-    await enableFeature(request, "registration_campaigns");
-  });
-
   async function finalizeCampaign(
     page: Page, factory: FactoryBot, teacherId: number,
   ): Promise<FactoryBotObject> {

--- a/e2e/user_registration/campaign_registration.spec.ts
+++ b/e2e/user_registration/campaign_registration.spec.ts
@@ -1,5 +1,4 @@
 import { Page, test, expect } from "../_support/fixtures";
-import { enableFeature } from "../_support/backend";
 import { confirmationLinkFor } from "../_support/mail";
 import {
   createReleasedLecture,
@@ -54,11 +53,6 @@ async function admitRejectedStudentThroughTeacherRoster(
 }
 
 test.describe("campaign registration", () => {
-  test.beforeEach(async ({ request }) => {
-    await enableFeature(request, "registration_campaigns");
-    await enableFeature(request, "roster_maintenance");
-  });
-
   test("can be opened from the lecture home tab", async ({ factory, student }) => {
     const lecture = await createReleasedLecture(factory);
     await subscribeToLecture(factory, lecture, student.user.id);

--- a/e2e/user_registration/self_enrollment.spec.ts
+++ b/e2e/user_registration/self_enrollment.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "../_support/fixtures";
-import { enableFeature } from "../_support/backend";
 import {
   createReleasedLecture,
   subscribeToLecture,
@@ -7,11 +6,6 @@ import {
 import { CampaignRegistrationPage } from "../page-objects/campaign_registrations_page";
 
 test.describe("student self-enrollment", () => {
-  test.beforeEach(async ({ request }) => {
-    await enableFeature(request, "registration_campaigns");
-    await enableFeature(request, "roster_maintenance");
-  });
-
   test("adds and removes the student from a self-managed tutorial", async ({
     factory,
     student,

--- a/lib/demo/campaign_setup_support.rb
+++ b/lib/demo/campaign_setup_support.rb
@@ -11,7 +11,6 @@ module Demo
 
     def setup!
       ensure_non_production!
-      Demo::SetupSupport.setup_flags!
       Demo::QuietLoggingSupport.with_quiet_logging do
         setup_preference_campaign!
         seed_preference_campaign_registrations!

--- a/lib/demo/next_term_banner_support.rb
+++ b/lib/demo/next_term_banner_support.rb
@@ -24,9 +24,6 @@ module Demo
     def setup!
       ensure_non_production!
 
-      # roster_maintenance + registration_campaigns, reused from the
-      # existing demo bundle
-      Demo::SetupSupport.setup_flags!
       enable_banner_flag!
 
       term = next_term!

--- a/lib/demo/setup_support.rb
+++ b/lib/demo/setup_support.rb
@@ -5,7 +5,6 @@ module Demo
     LECTURE_CAMPAIGN_DESCRIPTION = "Demo Lecture Roster Campaign".freeze
     SEMINAR_CAMPAIGN_DESCRIPTION = "Demo Seminar Roster Campaign".freeze
     SEMINAR_COURSE_TITLE = "Demo Roster Seminar".freeze
-    ROSTER_ENABLED_FLAGS = ["roster_maintenance", "registration_campaigns"].freeze
     LECTURE_TUTORIAL_CAPACITIES = [10, 8, 8, 6].freeze
     LECTURE_TUTORIAL_TITLES = [
       "Demo Tutorial 1",
@@ -15,11 +14,6 @@ module Demo
     ].freeze
     SEMINAR_TALK_TITLES = (1..10).map { |i| "Demo Talk #{i}" }.freeze
 
-    def setup_flags!
-      ensure_non_production!
-      configure_feature_flags!(enabled: ROSTER_ENABLED_FLAGS)
-    end
-
     def setup_campaigns!
       ensure_non_production!
       Demo::CampaignSetupSupport.setup!
@@ -27,7 +21,6 @@ module Demo
 
     def setup_rosters!
       ensure_non_production!
-      setup_flags!
 
       Rails.logger.debug("=== Demo Roster Setup ===")
       Demo::QuietLoggingSupport.with_quiet_logging do
@@ -49,36 +42,6 @@ module Demo
         abort("Cannot run in production!") if Rails.env.production?
       end
       # rubocop:enable Rails/Exit
-
-      def configure_feature_flags!(enabled:, disabled: [])
-        messages = []
-
-        Rails.logger.debug("Configuring feature flags...")
-        Demo::QuietLoggingSupport.with_quiet_logging do
-          enabled.each do |flag|
-            feature = ensure_feature_exists!(flag)
-            feature.enable
-            messages << "  enabled #{flag}"
-          end
-
-          disabled.each do |flag|
-            feature = ensure_feature_exists!(flag)
-            feature.disable
-            messages << "  disabled #{flag}"
-          end
-        end
-
-        messages.each do |message|
-          Rails.logger.debug(message)
-        end
-        Rails.logger.debug("")
-      end
-
-      def ensure_feature_exists!(flag)
-        feature_name = flag.to_s
-        Flipper::Adapters::ActiveRecord::Feature.find_or_create_by!(key: feature_name)
-        Flipper[feature_name]
-      end
 
       def lecture!
         lecture = Lecture.find_by(id: 1)

--- a/lib/tasks/demo_setup.rake
+++ b/lib/tasks/demo_setup.rake
@@ -1,9 +1,4 @@
 namespace :demo do
-  desc "Set the feature flags relevant for the current slice"
-  task flags: :environment do
-    Demo::SetupSupport.setup_flags!
-  end
-
   desc "Create reusable campaign playground scenarios"
   task campaigns: :environment do
     Demo::SetupSupport.setup_campaigns!

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -13,120 +13,7 @@ describe SubmissionsController do
     sign_in user
   end
 
-  context "when feature flag roster_maintenance is enabled" do
-    before do
-      Flipper.enable(:roster_maintenance)
-      Flipper.enable(:registration_campaigns)
-    end
-
-    after do
-      Flipper.disable(:roster_maintenance)
-      Flipper.disable(:registration_campaigns)
-    end
-
-    context "when lecture has no roster-eligible tutorials" do
-      describe "#submission_create_params" do
-        before do
-          controller.params = ActionController::Parameters.new(
-            submission: { tutorial_id: other_tutorial.id,
-                          assignment_id: assignment.id }
-          )
-        end
-        it "uses tutorial_id with from the params" do
-          permitted = controller.send(:submission_create_params)
-          expect(permitted[:tutorial_id]).to eq(other_tutorial.id)
-        end
-      end
-
-      describe "#submission_update_params" do
-        before do
-          controller.params = ActionController::Parameters.new(
-            submission: { tutorial_id: other_tutorial.id,
-                          assignment_id: assignment.id }
-          )
-        end
-        it "uses tutorial_id with from the params" do
-          controller.instance_variable_set(:@submission, submission)
-          permitted = controller.send(:submission_update_params)
-          expect(permitted[:tutorial_id]).to eq(other_tutorial.id)
-        end
-      end
-    end
-
-    context "when lecture has roster-eligible tutorials but user is not rostered" do
-      before do
-        # create a tutorial membership for another user in the same lecture
-        # so that the lecture has roster-eligible tutorials,
-        # but the user is not rostered in any of them
-        other_user = create(:confirmed_user)
-        create(:lecture_membership, lecture: lecture, user: user)
-        create(:tutorial_membership, tutorial: other_tutorial, user: other_user)
-      end
-      describe "#submission_create_params" do
-        before do
-          controller.params = ActionController::Parameters.new(
-            submission: { tutorial_id: other_tutorial.id,
-                          assignment_id: assignment.id }
-          )
-        end
-
-        it "raises an error instead of silently nilling out tutorial_id" do
-          expect { controller.send(:submission_create_params) }
-            .to raise_error(SubmissionsController::TutorialNotRosteredError)
-        end
-      end
-
-      describe "#submission_update_params" do
-        before do
-          controller.params = ActionController::Parameters.new(
-            submission: { tutorial_id: other_tutorial.id,
-                          assignment_id: assignment.id }
-          )
-          controller.instance_variable_set(:@submission, submission)
-        end
-
-        it "raises an error instead of silently nilling out tutorial_id" do
-          expect { controller.send(:submission_update_params) }
-            .to raise_error(SubmissionsController::TutorialNotRosteredError)
-        end
-      end
-    end
-
-    context "when lecture has roster-eligible tutorials and student is enrolled" do
-      before do
-        create(:lecture_membership, lecture: lecture, user: user)
-        create(:tutorial_membership, tutorial: tutorial, user: user)
-      end
-      describe "#submission_create_params" do
-        before do
-          controller.params = ActionController::Parameters.new(
-            submission: { tutorial_id: tutorial.id,
-                          assignment_id: assignment.id }
-          )
-        end
-        it "overrides tutorial_id with rosterized tutorial id" do
-          permitted = controller.send(:submission_create_params)
-          expect(permitted[:tutorial_id]).to eq(tutorial.id)
-        end
-      end
-
-      describe "#submission_update_params" do
-        before do
-          controller.params = ActionController::Parameters.new(
-            submission: { tutorial_id: other_tutorial.id,
-                          assignment_id: assignment.id }
-          )
-        end
-        it "overrides tutorial_id with rosterized tutorial id" do
-          controller.instance_variable_set(:@submission, submission)
-          permitted = controller.send(:submission_update_params)
-          expect(permitted[:tutorial_id]).to eq(tutorial.id)
-        end
-      end
-    end
-  end
-
-  context "when feature flag not enabled" do
+  context "when lecture has no roster-eligible tutorials" do
     describe "#submission_create_params" do
       before do
         controller.params = ActionController::Parameters.new(
@@ -151,6 +38,78 @@ describe SubmissionsController do
         controller.instance_variable_set(:@submission, submission)
         permitted = controller.send(:submission_update_params)
         expect(permitted[:tutorial_id]).to eq(other_tutorial.id)
+      end
+    end
+  end
+
+  context "when lecture has roster-eligible tutorials but user is not rostered" do
+    before do
+      # create a tutorial membership for another user in the same lecture
+      # so that the lecture has roster-eligible tutorials,
+      # but the user is not rostered in any of them
+      other_user = create(:confirmed_user)
+      create(:lecture_membership, lecture: lecture, user: user)
+      create(:tutorial_membership, tutorial: other_tutorial, user: other_user)
+    end
+    describe "#submission_create_params" do
+      before do
+        controller.params = ActionController::Parameters.new(
+          submission: { tutorial_id: other_tutorial.id,
+                        assignment_id: assignment.id }
+        )
+      end
+
+      it "raises an error instead of silently nilling out tutorial_id" do
+        expect { controller.send(:submission_create_params) }
+          .to raise_error(SubmissionsController::TutorialNotRosteredError)
+      end
+    end
+
+    describe "#submission_update_params" do
+      before do
+        controller.params = ActionController::Parameters.new(
+          submission: { tutorial_id: other_tutorial.id,
+                        assignment_id: assignment.id }
+        )
+        controller.instance_variable_set(:@submission, submission)
+      end
+
+      it "raises an error instead of silently nilling out tutorial_id" do
+        expect { controller.send(:submission_update_params) }
+          .to raise_error(SubmissionsController::TutorialNotRosteredError)
+      end
+    end
+  end
+
+  context "when lecture has roster-eligible tutorials and student is enrolled" do
+    before do
+      create(:lecture_membership, lecture: lecture, user: user)
+      create(:tutorial_membership, tutorial: tutorial, user: user)
+    end
+    describe "#submission_create_params" do
+      before do
+        controller.params = ActionController::Parameters.new(
+          submission: { tutorial_id: tutorial.id,
+                        assignment_id: assignment.id }
+        )
+      end
+      it "overrides tutorial_id with rosterized tutorial id" do
+        permitted = controller.send(:submission_create_params)
+        expect(permitted[:tutorial_id]).to eq(tutorial.id)
+      end
+    end
+
+    describe "#submission_update_params" do
+      before do
+        controller.params = ActionController::Parameters.new(
+          submission: { tutorial_id: other_tutorial.id,
+                        assignment_id: assignment.id }
+        )
+      end
+      it "overrides tutorial_id with rosterized tutorial id" do
+        controller.instance_variable_set(:@submission, submission)
+        permitted = controller.send(:submission_update_params)
+        expect(permitted[:tutorial_id]).to eq(tutorial.id)
       end
     end
   end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -21,7 +21,7 @@ describe SubmissionsController do
                         assignment_id: assignment.id }
         )
       end
-      it "uses tutorial_id with from the params" do
+      it "uses the tutorial_id from the params" do
         permitted = controller.send(:submission_create_params)
         expect(permitted[:tutorial_id]).to eq(other_tutorial.id)
       end
@@ -34,7 +34,7 @@ describe SubmissionsController do
                         assignment_id: assignment.id }
         )
       end
-      it "uses tutorial_id with from the params" do
+      it "uses the tutorial_id from the params" do
         controller.instance_variable_set(:@submission, submission)
         permitted = controller.send(:submission_update_params)
         expect(permitted[:tutorial_id]).to eq(other_tutorial.id)

--- a/spec/cypress/e2e/vouchers_redemptions_spec.cy.js
+++ b/spec/cypress/e2e/vouchers_redemptions_spec.cy.js
@@ -10,7 +10,9 @@ function testVoucherRedemptionWithNothingToClaim(context, role, itemType) {
 
   cy.then(() => {
     helpers.visitEditPage(context, itemType);
-    helpers.verifyNoClaimsYetButUserEligibleForRole(context, role);
+    if (itemType === "talk") {
+      helpers.verifyNoTalksYet(context);
+    }
     helpers.verifyRoleNotification(context, role);
     helpers.verifyNothingClaimedInNotification(context, itemType);
   });
@@ -35,10 +37,12 @@ function testVoucherRedemptionWithSomethingClaimed(context, itemType, role) {
   helpers.verifyLectureIsSubscribed(context);
   helpers.logoutAndLoginAsTeacher(context);
 
-  cy.then(() => {
-    helpers.visitEditPage(context, itemType);
-    helpers.verifyClaimsContainUserName(context, itemType, itemIds);
-  });
+  if (itemType === "talk") {
+    cy.then(() => {
+      helpers.visitEditPage(context, itemType);
+      helpers.verifyClaimsContainUserName(context, itemIds);
+    });
+  }
 
   cy.then(() => {
     helpers.verifyRoleNotification(context, role);
@@ -241,10 +245,5 @@ describe("User & Redemption deletion", () => {
     cy.getBySelector("delete-account-confirm-btn").click();
     cy.wait("@deleteUserRequest");
     cy.getBySelector("login-form").should("be.visible");
-
-    cy.login(this.teacher).then(() => {
-      helpers.visitEditPage(this, "tutorial");
-      helpers.verifyNoTutorialsButUserEligibleAsTutor(this, false);
-    });
   });
 });

--- a/spec/cypress/e2e/vouchers_redemptions_spec_helpers.js
+++ b/spec/cypress/e2e/vouchers_redemptions_spec_helpers.js
@@ -92,11 +92,11 @@ export function selectClaimsAndSubmit(entityIds) {
   cy.getBySelector("flash-notice").should("be.visible");
 }
 
-// Verifies that the tutorials or talks that were claimed are
-// displayed in the lecture edit page and contain the user's name
+// Verifies that the talks that were claimed are displayed in the
+// lecture edit page and contain the user's name
 // (and all the other ones do not)
 // If totalCount is specified, it is used to check the total number of
-// tutorials or talks in the lecture.
+// talks in the lecture.
 export function verifyClaimsContainUserName(context, claimIds, totalCount = 3) {
   cy.getBySelector("talk-header").should("have.length", totalCount).each(($el) => {
     const dataId = parseInt($el.attr("data-id"), 10);

--- a/spec/cypress/e2e/vouchers_redemptions_spec_helpers.js
+++ b/spec/cypress/e2e/vouchers_redemptions_spec_helpers.js
@@ -97,9 +97,8 @@ export function selectClaimsAndSubmit(entityIds) {
 // (and all the other ones do not)
 // If totalCount is specified, it is used to check the total number of
 // tutorials or talks in the lecture.
-export function verifyClaimsContainUserName(context, claimType, claimIds, totalCount = 3) {
-  let claimSelector = claimType === "tutorial" ? "tutorial-row" : "talk-header";
-  cy.getBySelector(claimSelector).should("have.length", totalCount).each(($el) => {
+export function verifyClaimsContainUserName(context, claimIds, totalCount = 3) {
+  cy.getBySelector("talk-header").should("have.length", totalCount).each(($el) => {
     const dataId = parseInt($el.attr("data-id"), 10);
     if (claimIds.includes(dataId)) {
       cy.wrap($el).should("contain", context.user.name_in_tutorials);
@@ -113,20 +112,6 @@ export function verifyClaimsContainUserName(context, claimType, claimIds, totalC
 export function logoutAndLoginAsTeacher(context) {
   cy.logout().then(() => {
     cy.login(context.teacher);
-  });
-}
-
-export function verifyNoTutorialsButUserEligibleAsTutor(context, shouldBeEligible = true) {
-  cy.getBySelector("tutorial-row").should("not.exist");
-  cy.getBySelector("new-tutorial-btn").should("be.visible").click();
-  cy.then(() => {
-    cy.getBySelector("tutorial-form").should("be.visible");
-    cy.getBySelector("tutor-select").within(() => {
-      const containStr = shouldBeEligible ? "contain" : "not.contain";
-      cy.get("option").should(containStr, context.user.name_in_tutorials)
-        .and(containStr, context.user.email)
-        .and("not.contain", context.user.name);
-    });
   });
 }
 
@@ -232,26 +217,12 @@ export function visitEditPage(context, type) {
   return cy.getBySelector("lecture-area").should("be.visible");
 }
 
-export function verifyNoTalksYetButUserEligibleAsSpeaker(context) {
+export function verifyNoTalksYet(context) {
   cy.i18n("admin.lecture.no_talks").as("noTalksYet");
 
   cy.then(() => {
     cy.getBySelector("no-talks-yet").should("contain", context.noTalksYet);
-    cy.getBySelector("new-talk-btn").click();
   });
-
-  cy.then(() => {
-    cy.getBySelector("talk-form").should("be.visible");
-    cy.getBySelector("speaker-select").within(() => {
-      cy.get("option").should("contain", context.user.name_in_tutorials)
-        .and("contain", context.user.email)
-        .and("not.contain", context.user.name);
-    });
-  });
-}
-
-export function verifyNoClaimsYetButUserEligibleForRole(context, role) {
-  role === "tutor" ? verifyNoTutorialsButUserEligibleAsTutor(context) : verifyNoTalksYetButUserEligibleAsSpeaker(context);
 }
 
 export function verifyUserIsEditor(context) {

--- a/spec/cypress/e2e/vouchers_spec.cy.js
+++ b/spec/cypress/e2e/vouchers_spec.cy.js
@@ -2,7 +2,10 @@ import FactoryBot from "../support/factorybot";
 import Timecop from "../support/timecop";
 
 const ROLES = ["tutor", "editor", "teacher", "speaker"];
-const ROLES_WITHOUT_SEMINAR = ROLES.filter(role => role !== "speaker");
+// A seminar's groups are talks, so it offers no tutor role; conversely,
+// only a seminar has speakers.
+const LECTURE_ROLES = ROLES.filter(role => role !== "speaker");
+const SEMINAR_ROLES = ROLES.filter(role => role !== "tutor");
 
 function createLectureScenario(context, type = "lecture") {
   cy.createUserAndLogin("teacher").as("teacher");
@@ -52,7 +55,7 @@ context("When the lecture is not a seminar", () => {
     it("shows buttons for creating tutor, editor and teacher vouchers", function () {
       cy.contains(this.vouchers).should("be.visible");
 
-      ROLES_WITHOUT_SEMINAR.forEach((role) => {
+      LECTURE_ROLES.forEach((role) => {
         cy.getBySelector(`create-${role}-voucher-btn`).should("be.visible");
       });
 
@@ -60,20 +63,20 @@ context("When the lecture is not a seminar", () => {
     });
 
     it("displays the voucher and invalidate button after the create button is clicked", function () {
-      ROLES_WITHOUT_SEMINAR.forEach((role) => {
+      LECTURE_ROLES.forEach((role) => {
         testCreateVoucher(role);
       });
     });
 
     it("displays that there is no active voucher after the invalidate button is clicked", function () {
-      ROLES_WITHOUT_SEMINAR.forEach((role) => {
+      LECTURE_ROLES.forEach((role) => {
         testCreateVoucher(role);
         testInvalidateVoucher(role);
       });
     });
 
     it.skip("copies the voucher hash to the clipboard", function () {
-      ROLES_WITHOUT_SEMINAR.forEach((role) => {
+      LECTURE_ROLES.forEach((role) => {
         cy.getBySelector(`create-${role}-voucher-btn`).click();
         cy.getBySelector(`${role}-voucher-secure-hash`).then(($hash) => {
           const hashText = $hash.text();
@@ -91,21 +94,24 @@ context("When the lecture is a seminar", () => {
   });
 
   describe("People tab in lecture edit page", () => {
-    it("shows buttons for creating tutor, editor, teacher, and speaker vouchers", function () {
+    it("shows buttons for creating editor, teacher and speaker vouchers", function () {
       cy.contains(this.vouchers).should("be.visible");
-      ROLES.forEach((role) => {
+
+      SEMINAR_ROLES.forEach((role) => {
         cy.getBySelector(`create-${role}-voucher-btn`).should("be.visible");
       });
+
+      cy.getBySelector("create-tutor-voucher-btn").should("not.exist");
     });
 
     it("displays the voucher and invalidate button after the create button is clicked", function () {
-      ROLES.forEach((role) => {
+      SEMINAR_ROLES.forEach((role) => {
         testCreateVoucher(role);
       });
     });
 
     it("displays that there is no active voucher after the invalidate button is clicked", function () {
-      ROLES.forEach((role) => {
+      SEMINAR_ROLES.forEach((role) => {
         testCreateVoucher(role);
         testInvalidateVoucher(role);
       });
@@ -123,7 +129,7 @@ context("When traveling into the future", () => {
   });
 
   it("does not show expired vouchers (far in the future)", function () {
-    ROLES.forEach((role) => {
+    SEMINAR_ROLES.forEach((role) => {
       testCreateVoucher(role);
     });
 
@@ -131,14 +137,14 @@ context("When traveling into the future", () => {
     // This is just a sanity check where we travel *far* into the future.
     Timecop.moveAheadDays(1000).then(() => {
       cy.reload();
-      ROLES.forEach((role) => {
+      SEMINAR_ROLES.forEach((role) => {
         assertVoucherNotShown(role);
       });
     });
   });
 
   it("does not show expired vouchers (near future)", function () {
-    ROLES.forEach((role) => {
+    SEMINAR_ROLES.forEach((role) => {
       testCreateVoucher(role);
       textExpiresAtWithTimeTravel(role);
     });

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -9,21 +9,13 @@ RSpec.describe(SubmissionsHelper, type: :helper) do
 
   before do
     allow(helper).to receive(:current_user).and_return(user)
-
-    Flipper.enable(:roster_maintenance)
-    Flipper.enable(:registration_campaigns)
-  end
-
-  after do
-    Flipper.disable(:roster_maintenance)
-    Flipper.disable(:registration_campaigns)
   end
 
   describe "#enabled_roster_for_lecture?" do
     before { create(:tutorial_membership, tutorial: tutorial) } # makes lecture roster-eligible
 
-    it "only queries roster_eligible_tutorials? once per lecture (memoized)" do
-      expect(lecture).to receive(:roster_eligible_tutorials?).once.and_call_original
+    it "only queries roster_managed? once per lecture (memoized)" do
+      expect(lecture).to receive(:roster_managed?).once.and_call_original
 
       first  = helper.enabled_roster_for_lecture?(lecture)
       second = helper.enabled_roster_for_lecture?(lecture)

--- a/spec/models/lecture_spec.rb
+++ b/spec/models/lecture_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe(Lecture, type: :model) do
     end
   end
 
-  describe "#roster_eligible_tutorials?" do
+  describe "#roster_managed?" do
     let(:lecture) { create(:lecture) }
 
     it "returns true if any tutorial has memberships" do
@@ -203,7 +203,7 @@ RSpec.describe(Lecture, type: :model) do
                                    self_materialization_mode: "add_and_remove")
       create(:tutorial, lecture: lecture, skip_campaigns: false)
       create(:tutorial_membership, tutorial: tutorial)
-      expect(lecture.roster_eligible_tutorials?).to eq(true)
+      expect(lecture.roster_managed?).to eq(true)
     end
 
     it "returns true if any tutorial has registration items" do
@@ -214,17 +214,17 @@ RSpec.describe(Lecture, type: :model) do
              registration_campaign: campaign,
              registerable: tutorial)
 
-      expect(lecture.roster_eligible_tutorials?).to eq(true)
+      expect(lecture.roster_managed?).to eq(true)
     end
 
     it "returns true if any tutorial has self_materialization_mode enabled" do
       create(:tutorial, lecture: lecture, self_materialization_mode: "add_and_remove")
-      expect(lecture.roster_eligible_tutorials?).to eq(true)
+      expect(lecture.roster_managed?).to eq(true)
     end
 
     it "returns false if no tutorials meet any condition" do
       create(:tutorial, lecture: lecture, self_materialization_mode: "disabled")
-      expect(lecture.roster_eligible_tutorials?).to eq(false)
+      expect(lecture.roster_managed?).to eq(false)
     end
   end
 

--- a/spec/models/voucher_spec.rb
+++ b/spec/models/voucher_spec.rb
@@ -79,10 +79,7 @@ RSpec.describe(Voucher, type: :model) do
 
     describe "#ensure_role_valid_for_lecture" do
       context "when the role is not offered for the lecture" do
-        before { Flipper.enable(:roster_maintenance) }
-        after { Flipper.disable(:roster_maintenance) }
-
-        # roster_maintenance excludes :tutor from a seminar's offered roles
+        # a seminar's groups are talks, so it offers no tutor role
         let(:voucher) { build(:voucher, :tutor, lecture: seminar) }
 
         it "rolls back and adds an error" do
@@ -132,22 +129,8 @@ RSpec.describe(Voucher, type: :model) do
   describe "class methods" do
     describe ".roles_for_lecture" do
       context "when lecture is a seminar" do
-        after { Flipper.disable(:roster_maintenance) }
-
-        context "when roster_maintenance is enabled" do
-          before { Flipper.enable(:roster_maintenance) }
-
-          it "returns all roles except :tutor" do
-            expect(Voucher.roles_for_lecture(seminar)).to eq(Voucher::ROLE_HASH.keys - [:tutor])
-          end
-        end
-
-        context "when roster_maintenance is disabled" do
-          before { Flipper.disable(:roster_maintenance) }
-
-          it "returns all roles" do
-            expect(Voucher.roles_for_lecture(seminar)).to eq(Voucher::ROLE_HASH.keys)
-          end
+        it "returns all roles except :tutor" do
+          expect(Voucher.roles_for_lecture(seminar)).to eq(Voucher::ROLE_HASH.keys - [:tutor])
         end
       end
 

--- a/spec/requests/lectures_spec.rb
+++ b/spec/requests/lectures_spec.rb
@@ -91,71 +91,51 @@ RSpec.describe("Lectures", type: :request) do
             as: :turbo_stream)
       end
 
-      context "when the feature flag is enabled" do
-        before do
-          Flipper.enable(:registration_campaigns)
-        end
+      it "shows a badge for lectures with an open registration campaign" do
+        create(:registration_campaign, :open, :first_come_first_served,
+               campaignable: lecture_algebra)
 
-        after do
-          Flipper.disable(:registration_campaigns)
-        end
+        search_algebra
 
-        it "shows a badge for lectures with an open registration campaign" do
-          create(:registration_campaign, :open, :first_come_first_served,
-                 campaignable: lecture_algebra)
-
-          search_algebra
-
-          expect(response.body).to include("lecture-search-registration-badge")
-        end
-
-        it "does not show a badge for draft campaigns" do
-          create(:registration_campaign, :first_come_first_served,
-                 campaignable: lecture_algebra)
-
-          search_algebra
-
-          expect(response.body)
-            .not_to include("lecture-search-registration-badge")
-        end
-
-        it "shows a registered badge instead when the user has registered" do
-          campaign = create(:registration_campaign, :open,
-                            :first_come_first_served,
-                            campaignable: lecture_algebra)
-          create(:registration_user_registration,
-                 registration_campaign: campaign, user: user)
-
-          search_algebra
-
-          expect(response.body).to include("lecture-search-registered-badge")
-          expect(response.body)
-            .not_to include("lecture-search-registration-badge")
-        end
-
-        it "still shows the open badge when the registration was rejected" do
-          campaign = create(:registration_campaign, :open,
-                            :first_come_first_served,
-                            campaignable: lecture_algebra)
-          create(:registration_user_registration, :rejected,
-                 registration_campaign: campaign, user: user)
-
-          search_algebra
-
-          expect(response.body).to include("lecture-search-registration-badge")
-          expect(response.body)
-            .not_to include("lecture-search-registered-badge")
-        end
+        expect(response.body).to include("lecture-search-registration-badge")
       end
 
-      it "does not show a badge when the feature flag is disabled" do
-        create(:registration_campaign, :open, :first_come_first_served,
+      it "does not show a badge for draft campaigns" do
+        create(:registration_campaign, :first_come_first_served,
                campaignable: lecture_algebra)
 
         search_algebra
 
         expect(response.body)
           .not_to include("lecture-search-registration-badge")
+      end
+
+      it "shows a registered badge instead when the user has registered" do
+        campaign = create(:registration_campaign, :open,
+                          :first_come_first_served,
+                          campaignable: lecture_algebra)
+        create(:registration_user_registration,
+               registration_campaign: campaign, user: user)
+
+        search_algebra
+
+        expect(response.body).to include("lecture-search-registered-badge")
+        expect(response.body)
+          .not_to include("lecture-search-registration-badge")
+      end
+
+      it "still shows the open badge when the registration was rejected" do
+        campaign = create(:registration_campaign, :open,
+                          :first_come_first_served,
+                          campaignable: lecture_algebra)
+        create(:registration_user_registration, :rejected,
+               registration_campaign: campaign, user: user)
+
+        search_algebra
+
+        expect(response.body).to include("lecture-search-registration-badge")
+        expect(response.body)
+          .not_to include("lecture-search-registered-badge")
       end
     end
 
@@ -165,10 +145,6 @@ RSpec.describe("Lectures", type: :request) do
             params: { search: { fulltext: "Algebra" }, infinite_scroll: true },
             as: :turbo_stream)
       end
-
-      before { Flipper.enable(:roster_maintenance) }
-
-      after { Flipper.disable(:roster_maintenance) }
 
       it "shows the open badge for a lecture with a self-enrollment group" do
         create(:tutorial, lecture: lecture_algebra,
@@ -276,7 +252,6 @@ RSpec.describe("Lectures", type: :request) do
     let(:lecture) { create(:lecture, :released_for_all, locale: "en") }
 
     before do
-      Flipper.enable(:registration_campaigns)
       create(:lecture_user_join, user: user, lecture: lecture)
       create(:lecture_medium,
              teachable: lecture,
@@ -618,12 +593,7 @@ RSpec.describe("Lectures", type: :request) do
     let(:term) { create(:term, :winter, year: 2026) }
     let(:lecture) { create(:lecture, term: term) }
 
-    before { Flipper.enable(:roster_maintenance) }
-
-    after do
-      Flipper.disable(:roster_maintenance)
-      Flipper.disable(:term_uses_mampf_registration)
-    end
+    after { Flipper.disable(:term_uses_mampf_registration) }
 
     it "shows the banner, naming the lecture's term, while it is not on MaMpf" do
       get edit_lecture_path(lecture, tab: "groups")

--- a/spec/requests/registration/allocations_spec.rb
+++ b/spec/requests/registration/allocations_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe("Registration::Allocations", type: :request) do
   let!(:campaign) { create(:registration_campaign, :closed, campaignable: lecture) }
 
   before do
-    Flipper.enable(:registration_campaigns)
     create(:editable_user_join, user: editor, editable: lecture)
   end
 

--- a/spec/requests/registration/campaigns_spec.rb
+++ b/spec/requests/registration/campaigns_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe("Registration::Campaigns", type: :request) do
   let!(:campaign) { create(:registration_campaign, campaignable: lecture, status: :draft) }
 
   before do
-    Flipper.enable(:registration_campaigns)
     create(:editable_user_join, user: editor, editable: lecture)
   end
 

--- a/spec/requests/registration/items_spec.rb
+++ b/spec/requests/registration/items_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe("Registration::Items", type: :request) do
   let(:tutorial) { create(:tutorial, lecture: lecture) }
 
   before do
-    Flipper.enable(:registration_campaigns)
     create(:editable_user_join, user: editor, editable: lecture)
   end
 

--- a/spec/requests/registration/policies_spec.rb
+++ b/spec/requests/registration/policies_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe("Registration::Policies", type: :request) do
   end
 
   before do
-    Flipper.enable(:registration_campaigns)
     create(:editable_user_join, user: editor, editable: lecture)
   end
 

--- a/spec/requests/registration/student_messages_spec.rb
+++ b/spec/requests/registration/student_messages_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe("Registration::StudentMessages", type: :request) do
            registration_campaign: campaign, user: create(:confirmed_user))
   end
 
-  before do
-    Flipper.enable(:registration_campaigns)
-  end
-
-  after do
-    Flipper.disable(:registration_campaigns)
-  end
-
   describe "POST /lectures/:lecture_id/student_messages" do
     def send_message(params = {})
       post(lecture_student_messages_path(lecture),

--- a/spec/requests/registration/user_registrations_spec.rb
+++ b/spec/requests/registration/user_registrations_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe("Registration::UserRegistrations", type: :request) do
   end
 
   before do
-    Flipper.enable(:registration_campaigns)
     sign_in user
   end
 
@@ -103,7 +102,6 @@ RSpec.describe("Registration::UserRegistrations", type: :request) do
   let(:stub_success) { UserRegistrations::Handler::Result.new(true, []) }
 
   before do
-    Flipper.enable(:registration_campaigns)
     create(:lecture_user_join, user: user, lecture: lecture)
     create(:lecture_user_join, user: user, lecture: seminar)
     sign_in user

--- a/spec/requests/roster/maintenance_spec.rb
+++ b/spec/requests/roster/maintenance_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe("Roster::Maintenance", type: :request) do
   let(:student) { create(:confirmed_user, locale: "en") }
 
   before do
-    Flipper.enable(:roster_maintenance)
     create(:editable_user_join, user: editor, editable: lecture)
     editor.reload
     lecture.reload

--- a/spec/requests/roster/self_materialization_controller_spec.rb
+++ b/spec/requests/roster/self_materialization_controller_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe("Roster::SelfMaterializationController", type: :request) do
   before do
     create(:lecture_user_join, user: user, lecture: lecture)
     sign_in user
-    Flipper.enable(:registration_campaigns)
-    Flipper.enable(:roster_maintenance)
   end
 
   describe "POST /tutorials/:id/roster/self_add" do

--- a/spec/requests/rosters/stream_builder_spec.rb
+++ b/spec/requests/rosters/stream_builder_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe(Rosters::StreamBuilder, type: :request) do
   let(:tutorial) { create(:tutorial, lecture: lecture, skip_campaigns: true) }
 
   before do
-    Flipper.enable(:roster_maintenance)
     create(:editable_user_join, user: editor, editable: lecture)
     editor.reload
     lecture.reload

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -110,50 +110,40 @@ RSpec.describe("Submissions", type: :request) do
         .not_to change(Submission, :count)
     end
 
-    context "when feature flag enabled" do
-      let(:other_tutorial) { create(:tutorial, lecture: lecture) }
+    let(:other_tutorial) { create(:tutorial, lecture: lecture) }
+
+    context "roster-eligible lecture, student not enrolled" do
       before do
-        Flipper.enable(:roster_maintenance)
-        Flipper.enable(:registration_campaigns)
+        other_user = create(:confirmed_user)
+        create(:lecture_membership, lecture: lecture, user: user)
+        create(:tutorial_membership, tutorial: other_tutorial, user: other_user)
       end
 
-      after do
-        Flipper.disable(:roster_maintenance)
-        Flipper.disable(:registration_campaigns)
+      it "does not create a submission and redirects to lecture submissions with an alert" do
+        user.lectures << lecture
+        expect { post(submissions_path(format: :js), params: create_params) }
+          .not_to change(Submission, :count)
+
+        expect(response).to redirect_to(start_path)
+        follow_redirect!
+        expect(flash[:alert]).to eq(
+          I18n.t("submission.tutorial_not_assigned")
+        )
       end
-      context "roster-eligible lecture, student not enrolled" do
-        before do
-          other_user = create(:confirmed_user)
-          create(:lecture_membership, lecture: lecture, user: user)
-          create(:tutorial_membership, tutorial: other_tutorial, user: other_user)
-        end
+    end
 
-        it "does not create a submission and redirects to lecture submissions with an alert" do
-          user.lectures << lecture
-          expect { post(submissions_path(format: :js), params: create_params) }
-            .not_to change(Submission, :count)
-
-          expect(response).to redirect_to(start_path)
-          follow_redirect!
-          expect(flash[:alert]).to eq(
-            I18n.t("submission.tutorial_not_assigned")
-          )
-        end
+    context "roster-eligible lecture, student enrolled" do
+      before do
+        create(:lecture_membership, lecture: lecture, user: user)
+        create(:tutorial_membership, tutorial: tutorial, user: user)
       end
 
-      context "roster-eligible lecture, student enrolled" do
-        before do
-          create(:lecture_membership, lecture: lecture, user: user)
-          create(:tutorial_membership, tutorial: tutorial, user: user)
-        end
+      it "creates the submission on the student's rostered tutorial" do
+        user.lectures << lecture
+        expect { post(submissions_path(format: :js), params: create_params_no_tutorial) }
+          .to change(Submission, :count).by(1)
 
-        it "creates the submission on the student's rostered tutorial" do
-          user.lectures << lecture
-          expect { post(submissions_path(format: :js), params: create_params_no_tutorial) }
-            .to change(Submission, :count).by(1)
-
-          expect(Submission.last.tutorial).to eq(tutorial)
-        end
+        expect(Submission.last.tutorial).to eq(tutorial)
       end
     end
   end
@@ -169,13 +159,6 @@ RSpec.describe("Submissions", type: :request) do
     before do
       create(:tutorial_membership, tutorial: tutorial, user: rostered)
       user.lectures << lecture
-      Flipper.enable(:roster_maintenance)
-      Flipper.enable(:registration_campaigns)
-    end
-
-    after do
-      Flipper.disable(:roster_maintenance)
-      Flipper.disable(:registration_campaigns)
     end
 
     it "is not offered a way to create or join a submission" do
@@ -206,50 +189,39 @@ RSpec.describe("Submissions", type: :request) do
       { submission: { tutorial_id: tutorial_id, manuscript: "" } }
     end
 
-    context "when feature flag enabled" do
-      let(:other_tutorial) { create(:tutorial, lecture: lecture) }
+    let(:other_tutorial) { create(:tutorial, lecture: lecture) }
 
+    context "roster-eligible lecture, student not enrolled" do
       before do
-        Flipper.enable(:roster_maintenance)
-        Flipper.enable(:registration_campaigns)
-      end
-      after do
-        Flipper.disable(:roster_maintenance)
-        Flipper.disable(:registration_campaigns)
+        other_user = create(:confirmed_user)
+        create(:lecture_membership, lecture: lecture, user: user)
+        create(:tutorial_membership, tutorial: other_tutorial, user: other_user)
       end
 
-      context "roster-eligible lecture, student not enrolled" do
-        before do
-          other_user = create(:confirmed_user)
-          create(:lecture_membership, lecture: lecture, user: user)
-          create(:tutorial_membership, tutorial: other_tutorial, user: other_user)
-        end
+      it "does not update the submission and redirects to lecture submissions with an alert" do
+        # The form sends no tutorial_id in roster mode.
+        patch submission_path(submission, format: :js),
+              params: { submission: { manuscript: "" } }
 
-        it "does not update the submission and redirects to lecture submissions with an alert" do
-          # The form sends no tutorial_id in roster mode.
-          patch submission_path(submission, format: :js),
-                params: { submission: { manuscript: "" } }
+        expect(response).to redirect_to(start_path)
+        follow_redirect!
+        expect(flash[:alert]).to eq(
+          I18n.t("submission.tutorial_not_assigned")
+        )
+      end
+    end
 
-          expect(response).to redirect_to(start_path)
-          follow_redirect!
-          expect(flash[:alert]).to eq(
-            I18n.t("submission.tutorial_not_assigned")
-          )
-        end
+    context "roster-eligible lecture, student enrolled" do
+      before do
+        create(:lecture_membership, lecture: lecture, user: user)
+        create(:tutorial_membership, tutorial: tutorial, user: user)
       end
 
-      context "roster-eligible lecture, student enrolled" do
-        before do
-          create(:lecture_membership, lecture: lecture, user: user)
-          create(:tutorial_membership, tutorial: tutorial, user: user)
-        end
+      it "updates the submission, keeping it on the student's rostered tutorial" do
+        patch submission_path(submission, format: :js),
+              params: update_params(tutorial_id: other_tutorial.id)
 
-        it "updates the submission, keeping it on the student's rostered tutorial" do
-          patch submission_path(submission, format: :js),
-                params: update_params(tutorial_id: other_tutorial.id)
-
-          expect(submission.reload.tutorial).to eq(tutorial)
-        end
+        expect(submission.reload.tutorial).to eq(tutorial)
       end
     end
   end
@@ -257,38 +229,29 @@ RSpec.describe("Submissions", type: :request) do
   describe "GET /lectures/:id/submissions" do
     let!(:assignments) { create_list(:assignment, 5, lecture: lecture, accepted_file_type: ".pdf") }
 
-    context "when feature flag enabled" do
-      before do
-        Flipper.enable(:roster_maintenance)
-        Flipper.enable(:registration_campaigns)
-        create(:tutorial_membership, tutorial: tutorial, user: user)
-        user.lectures << lecture
-      end
+    before do
+      create(:tutorial_membership, tutorial: tutorial, user: user)
+      user.lectures << lecture
+    end
 
-      after do
-        Flipper.disable(:roster_maintenance)
-        Flipper.disable(:registration_campaigns)
-      end
+    it "queries roster_managed? once per lecture across all assignment rows" do
+      expect_any_instance_of(Lecture).to receive(:roster_managed?)
+        .once.and_call_original
 
-      it "queries roster_eligible_tutorials? once per lecture across all assignment rows" do
-        expect_any_instance_of(Lecture).to receive(:roster_eligible_tutorials?)
-          .once.and_call_original
+      get lecture_submissions_path(lecture)
+    end
 
-        get lecture_submissions_path(lecture)
-      end
+    it "queries rostered_tutorial_in once per lecture across all assignment rows" do
+      expect_any_instance_of(User).to receive(:rostered_tutorial_in)
+        .once.and_call_original
 
-      it "queries rostered_tutorial_in once per lecture across all assignment rows" do
-        expect_any_instance_of(User).to receive(:rostered_tutorial_in)
-          .once.and_call_original
+      get lecture_submissions_path(lecture)
+    end
 
-        get lecture_submissions_path(lecture)
-      end
+    it "renders successfully with multiple assignment rows sharing the cache" do
+      get lecture_submissions_path(lecture)
 
-      it "renders successfully with multiple assignment rows sharing the cache" do
-        get lecture_submissions_path(lecture)
-
-        expect(response).to have_http_status(:success)
-      end
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/requests/tutorials_spec.rb
+++ b/spec/requests/tutorials_spec.rb
@@ -12,35 +12,26 @@ RSpec.describe("Tutorials", type: :request) do
   describe "GET /lectures/:id/tutorials" do
     let(:assignment) { create(:assignment, lecture: lecture, accepted_file_type: ".pdf") }
 
-    context "when feature flag enabled" do
-      before do
-        Flipper.enable(:roster_maintenance)
-        Flipper.enable(:registration_campaigns)
-        # The submission rows only render their action menu for a tutor of the
-        # group, and #index lists submissions that carry a manuscript.
-        tutorial.tutors << editor
-        5.times do
-          student = create(:confirmed_user)
-          create(:tutorial_membership, tutorial: tutorial, user: student)
-          create(:submission, :with_manuscript, assignment: assignment,
-                                                tutorial: tutorial).users << student
-        end
-        sign_in editor
+    before do
+      # The submission rows only render their action menu for a tutor of the
+      # group, and #index lists submissions that carry a manuscript.
+      tutorial.tutors << editor
+      5.times do
+        student = create(:confirmed_user)
+        create(:tutorial_membership, tutorial: tutorial, user: student)
+        create(:submission, :with_manuscript, assignment: assignment,
+                                              tutorial: tutorial).users << student
       end
+      sign_in editor
+    end
 
-      after do
-        Flipper.disable(:roster_maintenance)
-        Flipper.disable(:registration_campaigns)
-      end
+    it "queries roster_managed? once per lecture across all submission rows" do
+      expect_any_instance_of(Lecture).to receive(:roster_managed?)
+        .once.and_call_original
 
-      it "queries roster_eligible_tutorials? once per lecture across all submission rows" do
-        expect_any_instance_of(Lecture).to receive(:roster_eligible_tutorials?)
-          .once.and_call_original
+      get lecture_tutorials_path(lecture, params: { tutorial: tutorial.id })
 
-        get lecture_tutorials_path(lecture, params: { tutorial: tutorial.id })
-
-        expect(response).to have_http_status(:success)
-      end
+      expect(response).to have_http_status(:success)
     end
   end
 
@@ -51,6 +42,28 @@ RSpec.describe("Tutorials", type: :request) do
       it "returns http success" do
         get new_tutorial_path(lecture_id: lecture.id), as: :turbo_stream
         expect(response).to have_http_status(:success)
+      end
+
+      context "with a user who became a tutor by redeeming a voucher" do
+        let(:redeemer) { create(:confirmed_user, name_in_tutorials: "Ada L.") }
+        let!(:redemption) do
+          Redemption.create!(voucher: create(:voucher, :tutor, lecture: lecture),
+                             user: redeemer)
+        end
+
+        it "offers them in the tutor select, under their tutorial name" do
+          get new_tutorial_path(lecture_id: lecture.id), as: :turbo_stream
+
+          expect(response.body).to include("Ada L.")
+        end
+
+        it "stops offering them once the account is gone" do
+          redeemer.destroy
+
+          get new_tutorial_path(lecture_id: lecture.id), as: :turbo_stream
+
+          expect(response.body).not_to include("Ada L.")
+        end
       end
     end
   end


### PR DESCRIPTION
When we rolled the first Müsli features out in production, we didn't actually make use of the two feature flags `registration_campaigns` and `roster_maintenance`: We set both of them to `true` immediately.  This means that beside case-switches that are not necessary, we also have a lot of dead code in the project now. This PR removes the feature flags and the dead code.