### PR TITLE
Architecture book: Add point entry and extraction steps for exams in documentation

### DIFF
--- a/architecture/src/SUMMARY.md
+++ b/architecture/src/SUMMARY.md
@@ -29,6 +29,10 @@
 ## Extensions (Optional Features)
 - [Multiple Choice Exams](features/05c-multiple-choice-exams.md)
 
+## Point Entry for Exams
+- [Point Entry for Exams](features/13-point-entry-generalisation.md)
+  - [The Extraction, Step by Step](features/13a-point-entry-extraction-steps.md)
+
 ## Future Development
 - [Future Extensions](features/10-future-extensions.md)
 

--- a/architecture/src/features/13-point-entry-generalisation.md
+++ b/architecture/src/features/13-point-entry-generalisation.md
@@ -1,0 +1,137 @@
+# Point Entry for Exams
+
+Exams are the third assessable to need a marking interface. Assignments have one;
+talks acquired a second one beside it. That second build was the right call — a third
+value on the `mode:` flag would have been worse than a second table — but it means the
+question is now open rather than settled: does an exam become a third build, or does it
+reuse what exists?
+
+This page argues for reuse, and says exactly how far the existing code already reaches.
+[The extraction sequence](13a-point-entry-extraction-steps.md) turns that into steps.
+
+## What already carries an exam
+
+`Exam` includes `Assessment::Pointable` and `Assessment::Gradable`, so it is given an
+assessment with tasks on create, exactly as an assignment is.
+
+`Assessment::PointEntryService` only ever touches a participation and its assessment:
+
+```ruby
+def self.enter_points(participation, task_points, grader, submission = nil)
+```
+
+The submission is already optional, and `TaskPoint#submission_id` is nullable. The
+schema anticipated points without a submission from the start.
+
+On the reading side, `GradeTableComponent` is written against the assessment and is
+explicitly prepared for exams.
+
+```admonish warning title="One reading component is not ready"
+`PointGridComponent` filters its main table with `.where.not(submitted_at: nil)`. An
+exam participation that is `reviewed` with no `submitted_at` — which
+[Assessments & Grading](04-assessments-and-grading.md) documents as valid — disappears
+from it entirely. It also renders a tutorial column for everything that is not a talk,
+including exams.
+```
+
+## What holds the writing half back
+
+### The lifecycle question is answered in three places
+
+The model asks `assessment.grading_open?`. `SubmissionGraderService` and both row
+components ask `!assignment.active?`. Those are different moments — the plain deadline
+against the friendly one — so inside a lecture's grace period the view enables fields
+that `Participation` and `TaskPoint` then refuse.
+
+For an exam the divergence stops being a nuisance. `Exam` has no `active?` at all, so
+the service raises `NoMethodError` before `PointEntryService`, which would have worked,
+is ever reached. Asking the model's own hook removes the obstacle instead of adding a
+branch — and no assessable then needs an `active?` of its own, because
+`Assessment::Assessable` supplies `grading_open? == true` by default and `Assignment`
+overrides it with `totally_expired?`.
+
+### The row components are tied to `Assignment` and `Tutorial`
+
+`ParticipationRowComponent` reaches through `@assignment` three times, and each reach
+has a generic equivalent:
+
+| today | equivalent |
+|---|---|
+| `@assignment.assessment.persisted_tasks` | `assessment.persisted_tasks` |
+| `@assignment.active?` | `assessment.grading_open?` |
+| `@assignment.assessable?` | falls away — holding an assessment *is* the answer |
+
+The grading scope can be a value too: `User#can_grade_in_scope?` already accepts a
+`Lecture` **or** a `Tutorial` and raises on anything else.
+
+The other half is the endpoint. The row builds its own route — `point_user_tutorial_path`,
+`refresh_point_user_tutorial_path`. **A component that constructs its own route can only
+ever serve one kind of assessable.** Handed the URL from outside, the same row serves any.
+
+The `mode:` flag has to go at the same time, not later: the template branches on it to
+render a tutorial column for teachers and a correction column for tutors. Neither shape
+fits an exam, so a generic row that still carries the flag would force exams to choose
+between two wrong answers.
+
+### The controller is told its type by the client
+
+`case params[:type] when "Tutorial"` has one branch and no `else`; handed any other type
+the action does nothing at all — no exception, no flash, an empty 200. The routes feed
+it a constant, `defaults: { type: "Tutorial" }`.
+
+None of it is necessary. The assessable and the grading scope both follow from the
+participation being scored:
+
+```text
+participation → assessment → assessable
+                          → grading scope
+```
+
+The same assumption sits one level deeper, in the resource loader, which refuses a
+participation that has no tutorial — which is what every exam participation looks like.
+
+### The dashboard hands every `Pointable` to the assignment table
+
+`build_tabs` adds the points tab for any pointable assessable, and that tab renders the
+tutorial pointing table with the assessable passed as `assignment:`. For an exam that
+means assignment-specific methods called on an `Exam`. The dispatch has to happen on the
+assessable rather than being left to a component that cannot serve it.
+
+## What an exam needs that no assignment does
+
+Not everything is subtraction. The exam workflow is *seed the roster, mark the no-shows
+`absent`, treat certificates as `exempt`, then grade the rest*.
+`Assessment::AbsenceHandling` provides `mark_absent` and `mark_exempt(note:)`, both
+specced, but nothing in the application calls them yet. Without those two actions an
+exam table cannot express what a real examination day produces.
+
+And exams have roster entries, not participations. Nothing in the application turns one
+into the other today; only the demo seeder ever has. Without that projection an exam
+point table has nothing to render at all, which is why it comes before the table rather
+than after it.
+
+## The axes
+
+The useful cut is not tutor against teacher. Stated in full there are two axes:
+
+| assessable | what is entered | what carries it | permission scope |
+|---|---|---|---|
+| Assignment | task points | submission (team) or participation (person) | tutorial or lecture |
+| Exam | task points | participation | lecture |
+| Talk | one final grade | participation | lecture |
+
+Assignment and exam share the participation row and `PointEntryService`. The submission
+fan-out stays in `SubmissionGraderService`. Talk keeps its own grade-entry path, because
+entering one final grade is not the same act as entering task points.
+
+`mode:` scales along *who is looking*. The axis that keeps arriving is *what is being
+assessed*, and a flag carries only one axis. Talk grading meets the same wall from the
+other side as soon as it needs a view for whoever supervises a talk, beside the teacher
+view it has now.
+
+```admonish note title="What deliberately stays"
+`SubmissionGraderService` keeps its name and its submission-shaped API. It is the
+assignment-specific wrapper around a generic core, and that is the right division — the
+mistake would be to widen it into something that serves exams badly in order to avoid a
+second, smaller caller.
+```

--- a/architecture/src/features/13-point-entry-generalisation.md
+++ b/architecture/src/features/13-point-entry-generalisation.md
@@ -110,24 +110,64 @@ into the other today; only the demo seeder ever has. Without that projection an 
 point table has nothing to render at all, which is why it comes before the table rather
 than after it.
 
-## The axes
+## Both halves of marking, and what an exam needs of each
 
-The useful cut is not tutor against teacher. Stated in full there are two axes:
+An exam is the only assessable that is *both* pointable and gradable, so it is the only
+one where the two halves of marking meet. They are built the same way, and both stop at
+the same place:
+
+| | generic core | assessable-specific wrapper | interface |
+|---|---|---|---|
+| points | `PointEntryService` — takes a participation, submission optional | `SubmissionGraderService` — the team fan-out | tutorial pointing table |
+| grades | `GradeEntryService` — takes a participation, checks only that the assessable is `Gradable` | `TalkGraderService` — resolves and authorises through the talk | talk grading table |
+
+Both cores would serve an exam today. Both wrappers are for something an exam does not
+have — a submission, a talk — and both interfaces are written against the wrapper rather
+than the core.
+
+### The grade half is not simply derived
+
+An exam grade usually comes out of a grade scheme: points, bands, grade. That path
+exists and works — the grading tab renders the scheme editor beside `GradeTableComponent`,
+and `GradeScheme` requires an assessable that is both pointable and gradable, which only
+an exam is.
+
+```admonish important title="A scheme cannot be the only way in"
+Entering a grade by hand has to remain possible for an exam, because a scheme is often
+the wrong instrument:
+
+- With five candidates nobody builds a distribution. The grade is a judgement, written
+  down directly.
+- An oral examination produces no points at all. There is nothing for a scheme to band.
+- A single case — a hardship, an appeal, a re-mark — needs a correction that does not
+  disturb everyone else's grade.
+
+`GradeSchemeApplier` already assumes this: it narrows to participations that have **no**
+grade yet, so a hand-entered grade survives a scheme being applied afterwards. What is
+missing is any way to enter one.
+```
+
+An exam without tasks is a legitimate exam, not a misconfigured one. Anything that
+reasons about "no task carries points" has to leave room for it.
+
+### The axes, stated in full
 
 | assessable | what is entered | what carries it | permission scope |
 |---|---|---|---|
 | Assignment | task points | submission (team) or participation (person) | tutorial or lecture |
-| Exam | task points | participation | lecture |
+| Exam | task points, **or a grade directly** | participation | lecture |
 | Talk | one final grade | participation | lecture |
 
-Assignment and exam share the participation row and `PointEntryService`. The submission
-fan-out stays in `SubmissionGraderService`. Talk keeps its own grade-entry path, because
-entering one final grade is not the same act as entering task points.
+Assignment and exam share the participation point row and `PointEntryService`. Exam and
+talk share `GradeEntryService` and, once the talk row loses its talk, a participation
+grade row. The submission fan-out stays in `SubmissionGraderService`, the talk
+resolution in `TalkGraderService`.
 
 `mode:` scales along *who is looking*. The axis that keeps arriving is *what is being
-assessed*, and a flag carries only one axis. Talk grading meets the same wall from the
-other side as soon as it needs a view for whoever supervises a talk, beside the teacher
-view it has now.
+assessed*, and a flag carries only one axis.
+
+Talk grading meets the same wall from the other side as soon as it needs a view for
+whoever supervises a talk, beside the teacher view it has now.
 
 ```admonish note title="What deliberately stays"
 `SubmissionGraderService` keeps its name and its submission-shaped API. It is the

--- a/architecture/src/features/13a-point-entry-extraction-steps.md
+++ b/architecture/src/features/13a-point-entry-extraction-steps.md
@@ -1,0 +1,126 @@
+# The Extraction, Step by Step
+
+The sequence that turns [Point Entry for Exams](13-point-entry-generalisation.md) into
+code. Steps 1 and 2 are corrections worth having whether or not exams follow; from step 3
+onward each step is a precondition for the next.
+
+```admonish info title="Which state this applies to"
+The assessment work does not live on `next`. The tutor grading view is based on the
+Müsli integration branch, and the talk grading view on the tutor branch, so the combined
+state is the head of the talk grading work. That is the baseline the steps below assume.
+```
+
+## 1 · One answer to "may this be graded now?"
+
+`SubmissionGraderService` and both row components ask `!assignment.active?`; the model
+asks `assessment.grading_open?`. Point all three at the model's hook. The submission row
+keeps `valid_for_pointing?` on top — that is a real extra condition, not a duplicate.
+
+The boundary moves from the plain deadline to the friendly one, so parts of the task
+point request specs will move with it. Read each failure before adjusting it: some of
+them may be pinning the old boundary deliberately.
+
+## 2 · Refuse `reviewed` when no task carries points
+
+`update_status_if_all_scored!` promotes a `pending` participation the moment no task is
+missing points — and with no tasks at all that condition is vacuously true. An empty
+save then yields `reviewed` with a total of `0.0`.
+
+```admonish warning
+[Slice 5](../slices/05-exam-grading.md) describes this fallback as a guard rather than a
+feature and expects a nil total. The measured value is `0.0`; the guard has to cover
+both.
+```
+
+Not reachable through the interface today — the row's save button never becomes enabled
+without inputs to dirty — so this closes a latent gap rather than a live defect. It is
+worth closing before exams arrive, because a premature `reviewed` enters
+`StudentPerformance::ComputationService` as a final result of zero, and that record
+carries exam eligibility.
+
+## 3 · Extract the participation row
+
+Move it out of the tutorials namespace; it stops being a tutorial thing. It takes the
+participation, the assessment, the grading scope and its two URLs, and it takes **no
+`mode`**. The columns that differ between callers become optional slots rather than
+branches on a flag.
+
+Two things are worth correcting while the file is open:
+
+- The row loads its points with one query per row. A large exam roster makes that hurt
+  immediately; take a preloaded association instead.
+- The point input carries `max` from the task, and the Stimulus controller enforces it —
+  but `TaskPoint` validates only that points are non-negative. Points above the maximum
+  are deliberately allowed, which is how a bonus works. Reusing the row unchanged would
+  carry an interface inconsistency into exams; decide it here rather than inherit it.
+
+Nothing about assignments should change. If a spec has to move, something else moved
+with it.
+
+## 4 · Derive the assessable instead of being told it
+
+Drop `params[:type]`. The assessable and the grading scope both follow from the
+participation — for an assignment the scope is its tutorial or, failing that, the
+lecture; for an exam it is the lecture.
+
+This is more than the branch statements in the actions. The resource loader also
+requires a tutorial and names the assessable `assignment`, so an exam participation
+fails there before any branch is reached. An unknown assessable class should be answered
+deliberately, with 400 or 404 — not with an uncaught exception, and not, as today, with
+an empty 200.
+
+The submission actions stay assignment-specific. They are about a team handing something
+in, which exams do not do.
+
+## 5 · Project the exam roster onto participations
+
+`Assessment#seed_participations_from!` already exists, is idempotent through a unique
+index, serves achievements and the assignment backfill, and writes `pending` with no
+`submitted_at` — precisely what an exam needs.
+
+```admonish danger title="A single callback at finalisation is not enough"
+Participants can still be added and removed after a campaign is finalised. A one-shot
+seeding hook lets the roster and the gradebook drift apart. What is needed is a
+projection, idempotent throughout: finalisation seeds every active entry; a manual add
+or a reactivation ensures a participation; a removal without grading data takes it away
+again; a removal *with* grading data stays blocked, as it already is.
+```
+
+Do not widen `SubmissionGraderService.init_participation` to accept a missing tutorial.
+That service stays assignment-specific, and going through it would contradict the
+division the rest of this sequence rests on.
+
+## 6 · The exam point table, and a dashboard that dispatches
+
+The table takes an assessment and a grading scope and renders the header plus
+participation rows from step 3. Exams need none of the non-submitter zone, the "mark as
+participated" action, bulk download, bulk upload, or the team column.
+
+The dashboard has to choose the table by assessable rather than handing every pointable
+to the assignment one.
+
+## 7 · Absence, and what `submitted_at` means for an exam
+
+`mark_absent` and `mark_exempt(note:)` need a controller and a route. Excusing must go
+through `mark_exempt`: it clears the grade along with the status, and setting the status
+directly would leave a failing grade that re-applying a scheme will not remove either.
+
+`PointGridComponent` needs to stop treating a missing `submitted_at` as absence from the
+table, and to stop showing a tutorial column for assessables that have no tutorials.
+
+## Afterwards, if it still grates
+
+Small shared primitives between the talk and point interfaces — the person cell, the
+status badge, the save and refresh buttons, the dirty-state behaviour. A shared *grading
+row* across both would be premature: a talk carries one final grade, an assignment and an
+exam carry task points.
+
+## Leave alone
+
+- `SubmissionGraderService` keeps its name and its submission-shaped API.
+- `seed_participations_from!` is the seeding API. A second one is not needed.
+- The `||=` on a participation's `tutorial_id` is deliberate. The pointer records *where
+  this is graded*, decided once; it does not follow a roster move, and a spec pins that.
+- A talk cannot carry a grade scheme — `GradeScheme` requires an assessable that is both
+  pointable and gradable, and a talk is only gradable. Any reasoning about schemes
+  applies to exams, never to talks or assignments.

--- a/architecture/src/features/13a-point-entry-extraction-steps.md
+++ b/architecture/src/features/13a-point-entry-extraction-steps.md
@@ -32,6 +32,14 @@ feature and expects a nil total. The measured value is `0.0`; the guard has to c
 both.
 ```
 
+```admonish caution title="Do not overreach"
+The guard belongs to the points-driven promotion — the path that runs when points are
+entered. An exam with no tasks is legitimate (an oral examination has nothing to score),
+and it must still be gradable by hand. Manual grading sets the status through
+`GradeEntryService` and never touches this method, so the two do not collide as long as
+the guard is written about *points*, not about the assessment.
+```
+
 Not reachable through the interface today — the row's save button never becomes enabled
 without inputs to dirty — so this closes a latent gap rather than a live defect. It is
 worth closing before exams arrive, because a premature `reviewed` enters
@@ -107,6 +115,27 @@ directly would leave a failing grade that re-applying a scheme will not remove e
 
 `PointGridComponent` needs to stop treating a missing `submitted_at` as absence from the
 table, and to stop showing a tutorial column for assessables that have no tutorials.
+
+## 8 · A grade a person can type
+
+The exam grade normally comes out of a scheme, but a scheme is the wrong instrument for
+a cohort of five, for an oral examination that produced no points, and for a single
+correction after the fact. Entering a grade by hand has to be possible.
+
+`GradeEntryService.set_grade` is already generic — it asks only that the assessable is
+`Gradable` — and `GradeSchemeApplier` already narrows to participations without a grade,
+so a typed grade survives a scheme applied afterwards. What is missing is everything
+above the service:
+
+- `TalkGraderService` resolves and authorises through the talk; an exam needs the same
+  service scoped to the lecture instead. The talk wrapper stays where it is.
+- The grades controller finds a `Talk` from `params[:talk_id]` before it does anything
+  else. Derive the assessable from the participation, exactly as step 4 does for points.
+- `GradeTalkRowComponent` takes a talk. Loosened the same way as the point row in step 3,
+  it becomes a participation grade row that serves both.
+
+This is the point-entry work over again on the other axis, and the same rule decides it:
+a component that resolves its own subject can only ever serve one kind of assessable.
 
 ## Afterwards, if it still grates
 


### PR DESCRIPTION
We add a chapter on the upcoming exam pointing and grading