### PR TITLE
Move announcements above navbar

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -41,7 +41,6 @@ class MainController < ApplicationController
                                                                    :term)
                                        .sort
     end
-    announcements
     next_term_banner
     @talks = current_user.talks.includes(lecture: :term)
                          .select { |t| t.visible_for_user?(current_user) }

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -7,11 +7,6 @@ class MainController < ApplicationController
     @current_ability ||= MainAbility.new(current_user)
   end
 
-  def home
-    cookies[:locale] = current_user.locale if user_signed_in?
-    announcements
-  end
-
   def error
     redirect_to :root, alert: I18n.t("controllers.no_page")
   end
@@ -56,12 +51,6 @@ class MainController < ApplicationController
       return unless user_signed_in?
 
       redirect_to consent_profile_path unless current_user.consents
-    end
-
-    def announcements
-      @announcements = Announcement.where(on_main_page: true, lecture: nil)
-                                   .pluck(:details)
-                                   .join('<hr class="my-3" w-100>')
     end
 
     # Transitional banner pointing to the lectures of the upcoming term

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -1,6 +1,8 @@
 $primary: #223e62;
 // $secondary: #3F395C;
 
+$enable-negative-margins: true;
+
 @import "bootstrap/scss/bootstrap";
 
 /* set the overriding variables */

--- a/app/frontend/styles/navbar.scss
+++ b/app/frontend/styles/navbar.scss
@@ -62,10 +62,3 @@
         color: #ffe5ed;
     }
 }
-
-#site-announcement-banner {
-    margin-bottom: 0;
-    padding: 0.5rem 1rem;
-    text-align: center;
-    font-weight: 500;
-}

--- a/app/frontend/styles/navbar.scss
+++ b/app/frontend/styles/navbar.scss
@@ -63,9 +63,7 @@
     }
 }
 
-// Admin-level announcements, shown full-width above the navbar on every page.
-.site-announcement-banner {
-    border: 0;
+#site-announcement-banner {
     margin-bottom: 0;
     padding: 0.5rem 1rem;
     text-align: center;

--- a/app/frontend/styles/navbar.scss
+++ b/app/frontend/styles/navbar.scss
@@ -62,3 +62,12 @@
         color: #ffe5ed;
     }
 }
+
+// Admin-level announcements, shown full-width above the navbar on every page.
+.site-announcement-banner {
+    border: 0;
+    margin-bottom: 0;
+    padding: 0.5rem 1rem;
+    text-align: center;
+    font-weight: 500;
+}

--- a/app/helpers/announcements_helper.rb
+++ b/app/helpers/announcements_helper.rb
@@ -1,5 +1,10 @@
 # Announcements Helper
 module AnnouncementsHelper
+  # Returns joined HTML of all admin-level announcements shown above the navbar.
+  def site_announcements_html
+    Announcement.active_on_main.pluck(:details).join('<hr class="my-2">')
+  end
+
   # create text for notification about new announcement in notification dropdown
   # menu
   def announcement_notification_item_header(announcement)

--- a/app/helpers/announcements_helper.rb
+++ b/app/helpers/announcements_helper.rb
@@ -3,7 +3,7 @@ module AnnouncementsHelper
   # Returns joined HTML of all admin-level announcements shown above the navbar.
   def site_announcements_html
     @site_announcements_html ||=
-      Announcement.active_on_main.pluck(:details).join('<hr class="my-2">')
+      Announcement.active_on_main.pluck(:details).join('<hr class="my-2 mx-n3">')
   end
 
   # create text for notification about new announcement in notification dropdown

--- a/app/helpers/announcements_helper.rb
+++ b/app/helpers/announcements_helper.rb
@@ -2,7 +2,8 @@
 module AnnouncementsHelper
   # Returns joined HTML of all admin-level announcements shown above the navbar.
   def site_announcements_html
-    Announcement.active_on_main.pluck(:details).join('<hr class="my-2">')
+    @site_announcements_html ||=
+      Announcement.active_on_main.pluck(:details).join('<hr class="my-2">')
   end
 
   # create text for notification about new announcement in notification dropdown

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  # Returns joined HTML of all admin-level announcements shown above the navbar.
+  def site_announcements_html
+    Announcement.active_on_main.pluck(:details).join('<hr class="my-2">')
+  end
+
   # returns the path that is associated to the MaMpf brand in the navbar
   def home_path
     return start_path if user_signed_in?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -311,15 +311,6 @@ module ApplicationHelper
                 &.first&.term_independent
   end
 
-  def main_page_announcements
-    megaphone_icon_str = '<i class="bi bi-megaphone p-2"></i>'
-    separator_str = "<hr class=\"my-3 w-100\">#{megaphone_icon_str}"
-    Announcement.active_on_main
-                .pluck(:details)
-                .join(separator_str)
-                .prepend(megaphone_icon_str)
-  end
-
   # Navbar items styling based on which page we are on
   # https://gist.github.com/mynameispj/5692162
   ACTIVE_CSS_CLASS = "active-item".freeze

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,4 @@
 module ApplicationHelper
-  # Returns joined HTML of all admin-level announcements shown above the navbar.
-  def site_announcements_html
-    Announcement.active_on_main.pluck(:details).join('<hr class="my-2">')
-  end
-
   # returns the path that is associated to the MaMpf brand in the navbar
   def home_path
     return start_path if user_signed_in?

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -8,7 +8,9 @@ class Announcement < ApplicationRecord
 
   validates :details, presence: true
 
-  scope :active_on_main, -> { where(on_main_page: true, lecture: nil) }
+  scope :active_on_main, lambda {
+    where(on_main_page: true, lecture: nil).order(:created_at)
+  }
 
   # does there (still) exist a notification for the announcement for
   # the given user

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -9,7 +9,7 @@ class Announcement < ApplicationRecord
   validates :details, presence: true
 
   scope :active_on_main, lambda {
-    where(on_main_page: true, lecture: nil).order(:created_at)
+    where(on_main_page: true, lecture: nil).order(created_at: :desc)
   }
 
   # does there (still) exist a notification for the announcement for

--- a/app/views/administration/_navbar.html.erb
+++ b/app/views/administration/_navbar.html.erb
@@ -1,6 +1,8 @@
 <% I18n.with_locale(current_user.try(:locale)) do %>
 <%= vite_stylesheet_tag "styles/navbar.scss" %>
 
+<%= render partial: "shared/announcement_banner" %>
+
 <div class="admin-navbars-container">
   <nav class="navbar navbar-expand" id="first-admin-nav">
     <%= link_to image_tag("/images/mampf-logo.svg",

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -1,12 +1,6 @@
 <%= vite_stylesheet_tag "dashboard/dashboard.scss" %>
 
 <div style="min-height: 100vh; display: flex; flex-direction: column; padding-left: 1em; padding-right: 1em;">
-  <% if @announcements.present? %>
-    <div class="alert alert-secondary"
-         role="alert">
-      <%= sanitize(@announcements) %>
-    </div>
-  <% end %>
   <% if @next_term_lecture_count.to_i.positive? %>
     <%= render partial: "main/start/next_term_banner",
                locals: { next_term: @next_term,

--- a/app/views/shared/_announcement_banner.html.erb
+++ b/app/views/shared/_announcement_banner.html.erb
@@ -1,0 +1,6 @@
+<% announcements_html = site_announcements_html %>
+<% if announcements_html.present? %>
+  <div class="alert alert-warning" id="site-announcement-banner" role="alert">
+    <%= sanitize(announcements_html) %>
+  </div>
+<% end %>

--- a/app/views/shared/_announcement_banner.html.erb
+++ b/app/views/shared/_announcement_banner.html.erb
@@ -1,5 +1,6 @@
 <% if site_announcements_html.present? %>
-  <div class="alert alert-warning" id="site-announcement-banner" role="alert">
+  <div class="alert alert-warning mb-0 rounded-0 border-0 text-center fw-medium py-2 px-3"
+       role="alert">
     <%= sanitize(site_announcements_html) %>
   </div>
 <% end %>

--- a/app/views/shared/_announcement_banner.html.erb
+++ b/app/views/shared/_announcement_banner.html.erb
@@ -1,6 +1,5 @@
-<% announcements_html = site_announcements_html %>
-<% if announcements_html.present? %>
+<% if site_announcements_html.present? %>
   <div class="alert alert-warning" id="site-announcement-banner" role="alert">
-    <%= sanitize(announcements_html) %>
+    <%= sanitize(site_announcements_html) %>
   </div>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,13 @@
 <% I18n.with_locale(current_user.try(:locale)) do %>
 <%= vite_stylesheet_tag "styles/navbar.scss" %>
 
+<% announcements_html = site_announcements_html %>
+<% if announcements_html.present? %>
+  <div class="alert alert-warning site-announcement-banner" role="alert">
+    <%= sanitize(announcements_html) %>
+  </div>
+<% end %>
+
 <%= render partial: "feedbacks/form/modal" %>
 
 <div class="navbars-container">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -3,7 +3,7 @@
 
 <% announcements_html = site_announcements_html %>
 <% if announcements_html.present? %>
-  <div class="alert alert-warning site-announcement-banner" role="alert">
+  <div class="alert alert-warning" id="site-announcement-banner" role="alert">
     <%= sanitize(announcements_html) %>
   </div>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,12 +1,7 @@
 <% I18n.with_locale(current_user.try(:locale)) do %>
 <%= vite_stylesheet_tag "styles/navbar.scss" %>
 
-<% announcements_html = site_announcements_html %>
-<% if announcements_html.present? %>
-  <div class="alert alert-warning" id="site-announcement-banner" role="alert">
-    <%= sanitize(announcements_html) %>
-  </div>
-<% end %>
+<%= render partial: "shared/announcement_banner" %>
 
 <%= render partial: "feedbacks/form/modal" %>
 

--- a/e2e/announcement-banner.spec.ts
+++ b/e2e/announcement-banner.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for the site-wide announcement banner that is rendered above the
+ * navbar, both for the regular navbar and the administration navbar.
+ */
+
+import { expect, test } from "./_support/fixtures";
+
+test("shows the site announcement banner above the regular navbar",
+  async ({ factory, student: { page } }) => {
+    await factory.create("announcement", [], {
+      details: "Scheduled maintenance tonight",
+      on_main_page: true,
+    });
+
+    await page.goto("/main/start");
+
+    await expect(page.getByRole("alert").filter({ hasText: "Scheduled maintenance tonight" }))
+      .toBeVisible();
+  });
+
+test("shows the site announcement banner above the administration navbar",
+  async ({ factory, admin: { page } }) => {
+    await factory.create("announcement", [], {
+      details: "Scheduled maintenance tonight",
+      on_main_page: true,
+    });
+
+    await page.goto("/administration");
+
+    await expect(page.getByRole("alert").filter({ hasText: "Scheduled maintenance tonight" }))
+      .toBeVisible();
+  });
+
+test("does not show a banner when there is no active announcement",
+  async ({ admin: { page } }) => {
+    await page.goto("/administration");
+
+    await expect(page.getByRole("alert").filter({ hasText: "Scheduled maintenance tonight" }))
+      .not.toBeVisible();
+  });


### PR DESCRIPTION
Beforehand, announcements were only visible on the `/main/start` page. To carve some space for the upcoming dashboard, we move these announcements _above_ the navbar and show it everywhere. I think admin-wide announcements deserve that spot as they are very important (and should be used sparingly).

<img width="1909" height="106" alt="image" src="https://github.com/user-attachments/assets/7f131a9d-d5d6-4c07-8056-227dbe5114c8" />


<img width="1909" height="146" alt="image" src="https://github.com/user-attachments/assets/c8b635d5-2198-418f-aa29-56ef755948a2" />


