### PR TITLE
Fix: lecture content for editors

### DIFF
--- a/app/abilities/lecture_ability.rb
+++ b/app/abilities/lecture_ability.rb
@@ -29,7 +29,7 @@ class LectureAbility
 
     can [:show_announcements, :organizational, :show_random_quizzes,
          :display_course], Lecture do |lecture|
-      lecture.in?(user.lectures)
+      lecture.in?(user.lectures) || user.can_edit?(lecture)
     end
 
     can :subscribe_page, Lecture do |lecture|

--- a/e2e/lecture_sidebar_content.spec.ts
+++ b/e2e/lecture_sidebar_content.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "./_support/fixtures";
+
+// #1231: the sidebar enables these entries for anyone who may edit the lecture,
+// but LectureAbility grants them to subscribers only. An editor who never
+// subscribed to their own lecture is redirected away, the redirect carries no
+// matching frame, and Turbo writes "Content missing" into the sidebar's target.
+test.describe("lecture content for an editor who is not subscribed", () => {
+  test("opens the general information", async ({ factory, teacher: { page, user } }) => {
+    const lecture = await factory.create("lecture", ["released_for_all"], {
+      teacher_id: user.id,
+      organizational: true,
+      organizational_concept: "<p>Exercise sheets appear on Wednesdays</p>",
+    });
+
+    await page.goto(`/lectures/${lecture.id}`);
+    await page.getByRole("link", { name: "General Information" }).click();
+
+    await expect(page.getByText("Exercise sheets appear on Wednesdays")).toBeVisible();
+  });
+
+  test("opens the course page", async ({ factory, teacher: { page, user } }) => {
+    const lecture = await factory.create("lecture", ["released_for_all"], {
+      teacher_id: user.id,
+    });
+
+    await page.goto(`/lectures/${lecture.id}`);
+    await page.getByRole("link", { name: "Course" }).click();
+
+    await expect(page.getByRole("heading", { name: "Course Editors" })).toBeVisible();
+  });
+});

--- a/e2e/lecture_sidebar_content.spec.ts
+++ b/e2e/lecture_sidebar_content.spec.ts
@@ -12,6 +12,8 @@ test.describe("lecture content for an editor who is not subscribed", () => {
       organizational_concept: "<p>Exercise sheets appear on Wednesdays</p>",
     });
 
+    expect(await lecture.__call("subscribed_by?", user)).toBe(false);
+
     await page.goto(`/lectures/${lecture.id}`);
     await page.getByRole("link", { name: "General Information" }).click();
 
@@ -22,6 +24,8 @@ test.describe("lecture content for an editor who is not subscribed", () => {
     const lecture = await factory.create("lecture", ["released_for_all"], {
       teacher_id: user.id,
     });
+
+    expect(await lecture.__call("subscribed_by?", user)).toBe(false);
 
     await page.goto(`/lectures/${lecture.id}`);
     await page.getByRole("link", { name: "Course" }).click();

--- a/e2e/lecture_sidebar_content.spec.ts
+++ b/e2e/lecture_sidebar_content.spec.ts
@@ -1,9 +1,8 @@
 import { expect, test } from "./_support/fixtures";
 
-// #1231: the sidebar enables these entries for anyone who may edit the lecture,
-// but LectureAbility grants them to subscribers only. An editor who never
-// subscribed to their own lecture is redirected away, the redirect carries no
-// matching frame, and Turbo writes "Content missing" into the sidebar's target.
+/**
+ * See regression #1231.
+ */
 test.describe("lecture content for an editor who is not subscribed", () => {
   test("opens the general information", async ({ factory, teacher: { page, user } }) => {
     const lecture = await factory.create("lecture", ["released_for_all"], {

--- a/e2e/lecture_sidebar_content.spec.ts
+++ b/e2e/lecture_sidebar_content.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from "./_support/fixtures";
 test.describe("lecture content for an editor who is not subscribed", () => {
   test("opens the general information", async ({ factory, teacher: { page, user } }) => {
     const lecture = await factory.create("lecture", ["released_for_all"], {
+      locale: "en",
       teacher_id: user.id,
       organizational: true,
       organizational_concept: "<p>Exercise sheets appear on Wednesdays</p>",
@@ -22,6 +23,7 @@ test.describe("lecture content for an editor who is not subscribed", () => {
 
   test("opens the course page", async ({ factory, teacher: { page, user } }) => {
     const lecture = await factory.create("lecture", ["released_for_all"], {
+      locale: "en",
       teacher_id: user.id,
     });
 

--- a/spec/abilities/lecture_ability_spec.rb
+++ b/spec/abilities/lecture_ability_spec.rb
@@ -6,6 +6,34 @@ RSpec.describe(LectureAbility) do
   let(:user) { create(:confirmed_user) }
   let(:lecture) { create(:lecture, :released_for_all) }
 
+  describe "content pages of a lecture" do
+    let(:actions) do
+      [:show_announcements, :organizational, :show_random_quizzes, :display_course]
+    end
+
+    it "grants them to a subscriber" do
+      create(:lecture_user_join, lecture: lecture, user: user)
+
+      actions.each { |action| expect(ability.can?(action, lecture)).to be(true) }
+    end
+
+    it "grants them to an editor who is not subscribed" do
+      lecture.editors << user
+
+      actions.each { |action| expect(ability.can?(action, lecture)).to be(true) }
+    end
+
+    it "grants them to the teacher who is not subscribed" do
+      lecture.update!(teacher: user)
+
+      actions.each { |action| expect(ability.can?(action, lecture)).to be(true) }
+    end
+
+    it "denies them to everybody else" do
+      actions.each { |action| expect(ability.can?(action, lecture)).to be(false) }
+    end
+  end
+
   it "allows students to self-materialize for published lectures" do
     expect(ability.can?(:self_materialize, lecture)).to be(true)
     expect(ability.can?(:enroll, lecture)).to be(true)


### PR DESCRIPTION
This fixes #1231.

**Reproduce.** You need a lecture that satisfies three conditions at once:

1. you may edit it — you are its teacher or an editor;
2. you are **not** subscribed to it;
3. *General information visible* is ticked and the box below has some text (for *Course*, this one is not needed).

Then open the lecture and click **General Information** in the sidebar. The link is active — the sidebar enables it for anyone who may edit — and the pane says "Content missing".

The Playwright test in the first commit builds exactly such a lecture and fails on it; it turns green with the second.

**What went wrong.** Editors reach a lecture without subscribing on purpose: `LecturesController#check_for_subscribe` returns early for them, and the sidebar (`_sidebar.html.erb:6-8`) uses the same rule. Both gained that bypass in #1169; `LectureAbility` did not, and kept for `:organizational`, `:display_course`, `:show_announcements` and `:show_random_quizzes` the subscription-only rule it has had since 2021. So an editor walks through a lecture that lets them in everywhere and is turned away at exactly four places — refused the page they had just written.

**Fix.** The four content actions now accept editing rights as well as a subscription: `lecture.in?(user.lectures) || user.can_edit?(lecture)`. That admits admins, the lecture's teacher, its editors and the course's editors — the same circle the sidebar has always let through.