### PR TITLE
Fix the recipe that updates Node.js dependencies

### DIFF
--- a/.config/commands/deps.justfile
+++ b/.config/commands/deps.justfile
@@ -15,9 +15,15 @@ update-bundler:
 update-gems:
     bundle update --all
 
-# Updates Node.js packages
+# Updates Node.js packages within the ranges declared in package.json
 update-nodejs:
-    yarn up
+    yarn up -R '*'
+
+# Unlike `update-nodejs` this can pull in major versions, so read the
+# changelogs and expect to fix things.
+# Raises the ranges in package.json themselves to the newest versions
+update-nodejs-ranges:
+    yarn up '*'
 
 # Simulates a production asset build
 simulate-production-asset-build:

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,7 +4,9 @@ import { coffee } from "vite-plugin-coffee3";
 import FullReload from "vite-plugin-full-reload";
 import RubyPlugin from "vite-plugin-ruby";
 
-// also see config/vite.rb
+// GEM_PATHS is set by config/vite.rb, so a bare `vite build` resolves no gem
+// asset at all and dies on the first @import from one. Build through
+// `bundle exec vite build`.
 const gemPaths = JSON.parse(process.env.GEM_PATHS || "[]");
 
 export default defineConfig({


### PR DESCRIPTION
`just deps update-nodejs` ran `yarn up` with no pattern, which Yarn 4 rejects outright. The obvious repair is worse than it looks: `yarn up '*'` resolves against the newest releases and rewrites the ranges in `package.json`, so it raises dependencies rather than updating them. That is why the recipe's purpose had become unclear.

Yarn draws the line with `-R`. From its own help for `yarn up`:

> If `-R,--recursive` is set […] `yarn up` will force all ranges matching the selected packages to be resolved again […] It however **won't touch your manifests anymore**.

Both operations are wanted, so there is a recipe for each:

| recipe | command | effect |
|---|---|---|
| `update-nodejs` | `yarn up -R '*'` | resolves the existing ranges again; `package.json` untouched |
| `update-nodejs-ranges` | `yarn up '*'` | raises the ranges themselves, can pull in majors |

Verified by running the first one: `package.json` came out byte-identical, only `yarn.lock` moved. That result is a separate PR.

**Also in here:** a bare `vite build` finds no gem assets and dies on the first `@import` from one, because the aliases come from `GEM_PATHS`, which `config/vite.rb` sets. `vite.config.mjs` now says it where the variable is read.