### PR TITLE
Stop hiding the group tiles once a campaign exists

### DIFF
--- a/app/frontend/registration/campaigns/registration_campaigns_card_body_index_component.rb
+++ b/app/frontend/registration/campaigns/registration_campaigns_card_body_index_component.rb
@@ -44,8 +44,7 @@ class RegistrationCampaignsCardBodyIndexComponent < ViewComponent::Base
   end
 
   def collapse_no_campaign_section?
-    selected_campaign_section? ||
-      (campaigns.any? && no_campaign_groups.empty?)
+    campaigns.any? && no_campaign_groups.empty?
   end
 
   private
@@ -80,9 +79,5 @@ class RegistrationCampaignsCardBodyIndexComponent < ViewComponent::Base
 
     def campaigns
       @campaigns ||= lecture.registration_campaigns.order(created_at: :desc).to_a
-    end
-
-    def selected_campaign_section?
-      selected_section == "campaign" && active_campaigns.any?
     end
 end

--- a/e2e/lecture_groups_visible_with_campaign.spec.ts
+++ b/e2e/lecture_groups_visible_with_campaign.spec.ts
@@ -15,7 +15,6 @@ test("keeps the group tiles visible once a campaign exists",
     });
 
     await page.goto(`/lectures/${lecture.id}/edit?tab=groups&registration_section=campaign`);
-    await expect(page.getByTestId("registration-no-campaign-section")).toBeVisible();
 
     await expect(page.getByText("Mo 10")).toBeVisible();
   });

--- a/e2e/lecture_groups_visible_with_campaign.spec.ts
+++ b/e2e/lecture_groups_visible_with_campaign.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "./_support/fixtures";
+
+// The groups tab keeps `registration_section=campaign` in the URL once that
+// section has been chosen. As soon as a campaign exists, that combination
+// collapses the section holding the group tiles, so the tutorials look gone.
+test("keeps the group tiles visible once a campaign exists",
+  async ({ factory, teacher: { page, user } }) => {
+    const lecture = await factory.create("lecture", [], {
+      teacher_id: user.id, locale: "en",
+    });
+    await factory.create("tutorial", [], { lecture_id: lecture.id, title: "Mo 10" });
+    await factory.create("registration_campaign", [], {
+      campaignable_id: lecture.id, campaignable_type: "Lecture",
+    });
+
+    await page.goto(`/lectures/${lecture.id}/edit?tab=groups&registration_section=campaign`);
+    await expect(page.getByTestId("registration-no-campaign-section")).toBeVisible();
+
+    await expect(page.getByText("Mo 10")).toBeVisible();
+  });

--- a/e2e/lecture_groups_visible_with_campaign.spec.ts
+++ b/e2e/lecture_groups_visible_with_campaign.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "./_support/fixtures";
 
-// The groups tab keeps `registration_section=campaign` in the URL once that
-// section has been chosen. As soon as a campaign exists, that combination
-// collapses the section holding the group tiles, so the tutorials look gone.
+// The tab keeps `registration_section=campaign` in the URL once that section
+// has been chosen, which is why the test carries it. The group tiles stay
+// visible beside it; only a section with nothing left outside the campaigns
+// folds away.
 test("keeps the group tiles visible once a campaign exists",
   async ({ factory, teacher: { page, user } }) => {
     const lecture = await factory.create("lecture", [], {

--- a/spec/components/registration/campaigns/registration_campaigns_card_body_index_component_spec.rb
+++ b/spec/components/registration/campaigns/registration_campaigns_card_body_index_component_spec.rb
@@ -43,5 +43,29 @@ RSpec.describe(RegistrationCampaignsCardBodyIndexComponent, type: :component) do
       expect(component.collapse_campaign_section?).to be(true)
       expect(component.collapse_no_campaign_section?).to be(false)
     end
+
+    it "keeps the no-campaign section open while a campaign is active" do
+      lecture = create(:lecture)
+      create(:registration_campaign, campaignable: lecture)
+      tutorial = create(:tutorial, lecture: lecture)
+
+      component = described_class.new(lecture: lecture,
+                                      registration_section: "campaign")
+
+      allow(component).to receive(:no_campaign_groups).and_return([tutorial])
+
+      expect(component.collapse_no_campaign_section?).to be(false)
+    end
+
+    it "folds the no-campaign section away when no group is left outside" do
+      lecture = create(:lecture)
+      create(:registration_campaign, campaignable: lecture)
+
+      component = described_class.new(lecture: lecture)
+
+      allow(component).to receive(:no_campaign_groups).and_return([])
+
+      expect(component.collapse_no_campaign_section?).to be(true)
+    end
   end
 end

--- a/spec/components/registration/campaigns/registration_campaigns_card_body_index_component_spec.rb
+++ b/spec/components/registration/campaigns/registration_campaigns_card_body_index_component_spec.rb
@@ -47,12 +47,10 @@ RSpec.describe(RegistrationCampaignsCardBodyIndexComponent, type: :component) do
     it "keeps the no-campaign section open while a campaign is active" do
       lecture = create(:lecture)
       create(:registration_campaign, campaignable: lecture)
-      tutorial = create(:tutorial, lecture: lecture)
+      create(:tutorial, lecture: lecture)
 
       component = described_class.new(lecture: lecture,
                                       registration_section: "campaign")
-
-      allow(component).to receive(:no_campaign_groups).and_return([tutorial])
 
       expect(component.collapse_no_campaign_section?).to be(false)
     end
@@ -62,8 +60,6 @@ RSpec.describe(RegistrationCampaignsCardBodyIndexComponent, type: :component) do
       create(:registration_campaign, campaignable: lecture)
 
       component = described_class.new(lecture: lecture)
-
-      allow(component).to receive(:no_campaign_groups).and_return([])
 
       expect(component.collapse_no_campaign_section?).to be(true)
     end


### PR DESCRIPTION
Reported while working with demo campaigns: on `/lectures/:id/edit?tab=groups` the existing tutorials disappear as soon as a new registration process is created, and reappear after clicking *Anmeldung starten*.

**Reproduce.** You need three things at once: a lecture with a group, an active (non-completed) campaign, and `registration_section=campaign` in the URL — which the tab puts there itself once that section has been chosen, and keeps. Then the group tiles are gone.

Measured, holding everything else equal:

| `registration_section` | active campaign | tiles collapsed |
|---|---|---|
| — | no | no |
| — | yes | no |
| `campaign` | no | no |
| **`campaign`** | **yes** | **yes** |
| `no_campaign` | yes | no |

The parameter alone does nothing and a campaign alone does nothing; only the pair collapses the section. That is why it starts happening with the first campaign, and why any render that drops the parameter — opening the campaign, for instance — brings the tiles back. Nothing is lost: the tiles stay in the DOM, hidden behind a toggle that is easy to miss.

**Fix.** `collapse_no_campaign_section?` loses the `selected_campaign_section?` half. What remains is the sensible half: fold the section away when there are campaigns and no group is left outside them. An empty section still collapses, a full one no longer does. `selected_campaign_section?` had no other caller and goes with it.

That the section is meant to stay open is already written down: `lecture_groups_registration_sections.spec.ts` asserts exactly that after choosing the campaign section. It passed only because no campaign exists at that point in the test.

The Playwright test added here covers the combination that was missing.