### PR TITLE
Give the outline edit icon back its place and its audience

### DIFF
--- a/app/frontend/lectures/show/_content.html.erb
+++ b/app/frontend/lectures/show/_content.html.erb
@@ -1,10 +1,10 @@
 <div class="card bg-mdb-color-lighten-6">
   <div class="card-header">
-    <div class="d-flex justify-content-between align-items-center gap-3">
+    <div class="d-flex align-items-center gap-2">
       <h5 class="mb-0">
         <%= t("admin.lecture.#{lecture.sort}_content") %>
       </h5>
-      <% if current_user.admin || lecture.course.edited_by?(current_user) %>
+      <% if current_user.can_edit?(lecture) %>
         <%= link_to "",
                     edit_lecture_path(lecture),
                     class: "far fa-edit text-dark",

--- a/app/frontend/lectures/show/_content.html.erb
+++ b/app/frontend/lectures/show/_content.html.erb
@@ -1,18 +1,20 @@
 <div class="card bg-mdb-color-lighten-6">
   <div class="card-header">
-    <h5 class="mb-0 d-flex align-items-center gap-2">
-      <%= t("admin.lecture.#{lecture.sort}_content") %>
+    <div class="d-flex align-items-center gap-2">
+      <h5 class="mb-0">
+        <%= t("admin.lecture.#{lecture.sort}_content") %>
+      </h5>
       <% if current_user.can_edit?(lecture) %>
         <%= link_to "",
                     edit_lecture_path(lecture),
-                    class: "far fa-edit text-dark",
+                    class: "far fa-edit text-dark fs-5",
                     data: { toggle: "tooltip",
                             placement: "bottom" },
               "aria-label": t("buttons.edit"),
                     title: t("buttons.edit"),
                     style: "text-decoration: none;" %>
       <% end %>
-    </h5>
+    </div>
   </div>
   <div class="card-body">
     <% if lecture.seminar? %>

--- a/app/frontend/lectures/show/_content.html.erb
+++ b/app/frontend/lectures/show/_content.html.erb
@@ -1,9 +1,7 @@
 <div class="card bg-mdb-color-lighten-6">
   <div class="card-header">
-    <div class="d-flex align-items-center gap-2">
-      <h5 class="mb-0">
-        <%= t("admin.lecture.#{lecture.sort}_content") %>
-      </h5>
+    <h5 class="mb-0 d-flex align-items-center gap-2">
+      <%= t("admin.lecture.#{lecture.sort}_content") %>
       <% if current_user.can_edit?(lecture) %>
         <%= link_to "",
                     edit_lecture_path(lecture),
@@ -14,7 +12,7 @@
                     title: t("buttons.edit"),
                     style: "text-decoration: none;" %>
       <% end %>
-    </div>
+    </h5>
   </div>
   <div class="card-body">
     <% if lecture.seminar? %>

--- a/e2e/lecture_outline_edit_icon.spec.ts
+++ b/e2e/lecture_outline_edit_icon.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "./_support/fixtures";
+
+// The icon sits beside the heading, and everyone who may edit the lecture
+// gets it -- a seminar's teacher is usually no editor of its course.
+test.describe("the edit icon on the outline", () => {
+  test("shows it to the teacher of a lecture", async ({ factory, teacher: { page, user } }) => {
+    const lecture = await factory.create("lecture", ["released_for_all"], {
+      teacher_id: user.id, locale: "en",
+    });
+
+    await page.goto(`/lectures/${lecture.id}/outline`);
+
+    await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+  });
+
+  test("shows it to the teacher of a seminar", async ({ factory, teacher: { page, user } }) => {
+    const seminar = await factory.create("lecture", ["released_for_all", "is_seminar"], {
+      teacher_id: user.id, locale: "en",
+    });
+
+    await page.goto(`/lectures/${seminar.id}/outline`);
+
+    await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+  });
+});

--- a/e2e/lecture_outline_edit_icon.spec.ts
+++ b/e2e/lecture_outline_edit_icon.spec.ts
@@ -25,8 +25,9 @@ test.describe("the edit icon on the outline", () => {
       const icon = page.getByRole("link", { name: "Edit" });
       await expect(icon).toBeVisible();
 
-      const headingBox = (await heading.boundingBox())!;
-      const iconBox = (await icon.boundingBox())!;
+      const headingBox = await heading.boundingBox();
+      const iconBox = await icon.boundingBox();
+      if (!headingBox || !iconBox) throw new Error("heading or icon not rendered");
 
       // Beside the heading rather than flushed to the far end of the row.
       expect(iconBox.x - (headingBox.x + headingBox.width)).toBeLessThan(24);

--- a/e2e/lecture_outline_edit_icon.spec.ts
+++ b/e2e/lecture_outline_edit_icon.spec.ts
@@ -13,6 +13,28 @@ test.describe("the edit icon on the outline", () => {
     await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
   });
 
+  test("puts it beside the heading, at the heading's size",
+    async ({ factory, teacher: { page, user } }) => {
+      const lecture = await factory.create("lecture", ["released_for_all"], {
+        teacher_id: user.id, locale: "en",
+      });
+
+      await page.goto(`/lectures/${lecture.id}/outline`);
+
+      const heading = page.getByRole("heading", { name: "Lecture Contents" });
+      const icon = page.getByRole("link", { name: "Edit" });
+      await expect(icon).toBeVisible();
+
+      const headingBox = (await heading.boundingBox())!;
+      const iconBox = (await icon.boundingBox())!;
+
+      // Beside the heading rather than flushed to the far end of the row.
+      expect(iconBox.x - (headingBox.x + headingBox.width)).toBeLessThan(24);
+      // And drawn at the same size as the text it belongs to.
+      expect(await icon.evaluate(el => getComputedStyle(el).fontSize))
+        .toBe(await heading.evaluate(el => getComputedStyle(el).fontSize));
+    });
+
   test("shows it to the teacher of a seminar", async ({ factory, teacher: { page, user } }) => {
     const seminar = await factory.create("lecture", ["released_for_all", "is_seminar"], {
       teacher_id: user.id, locale: "en",


### PR DESCRIPTION
Two regressions on `/lectures/:id/outline`, both from #1169. That PR removed the lecture header, whose `<h4>` carried the edit icon right after the title, and put a new icon into the content card instead. Two things came out different.

**Its place and its size.** `justify-content-between` pushed the icon to the far end of the header row, and it fell back to the card header's body size — measured 16px against the heading's 20px, where the old one inherited the `<h4>`'s. It now sits beside the heading and carries `fs-5`, the same step of the type scale the `<h5>` uses, so the size is stated as a relationship rather than a number.

Putting the link *inside* the heading would inherit the size directly, and that was the first attempt here — but it also puts the icon into the heading's accessible name, which then reads "Lecture Contents Edit". Measured with an exact-name query, so the link stays a sibling.

**Its audience**, which is the real defect:

```erb
<% if current_user.admin || lecture.course.edited_by?(current_user) %>   # was
<% if current_user.can_edit?(lecture) %>                                 # is
```

The old header asked `editors_with_inheritance` — the teacher, the lecture's editors, the course's editors, admins. #1169 narrowed that to editors *of the course*. Measured on the demo data:

| | `course.edited_by?` | `can_edit?` |
|---|---|---|
| lecture 1 | true | true |
| seminar 30 | **false** | true |

A seminar's teacher might not be an editor of its course, which is why the icon disappeared there. It is not limited to seminars: any teacher who is not also a course editor lost it. Both new tests fail without this change, including the plain-lecture one — the reporter's lecture 1 only kept its icon because that teacher happens to be a course editor too.

`can_edit?` is what the sidebar and `LecturesController#check_for_subscribe` already use for this lecture.

**Not touched:** `lectures/edit/_header.html.erb:23` carries the same narrow condition, but there it guards a link to edit the *course*, where it is correct.

