### PR TITLE
ci: retire the thruster deploy baseline

### DIFF
--- a/.github/workflows/build-deploy-image.yml
+++ b/.github/workflows/build-deploy-image.yml
@@ -19,11 +19,8 @@ on:
   push:
     # Baseline branches that build a deploy image. Topology: next -> staging,
     # main -> production. A push trigger fires from the workflow version on the
-    # branch pushed to, so next/main stay dormant until the baseline (incl. this
-    # file) actually reaches them -- safe to list ahead of cutover. thruster is
-    # dropped once retired.
+    # branch pushed to, so each baseline only builds once this file reaches it.
     branches:
-      - deploy/app-baseline-thruster
       - next
       - main
 

--- a/.github/workflows/schedule-deploy-image-rebuild.yml
+++ b/.github/workflows/schedule-deploy-image-rebuild.yml
@@ -2,17 +2,6 @@ name: Schedule Deploy Image Rebuild
 
 on:
   workflow_dispatch:
-    inputs:
-      build_ref:
-        description: Branch to rebuild
-        required: false
-        # Weekly OS-patch rebuild of the current baseline. Stays on thruster until
-        # cutover, then becomes a matrix over the live baselines (next -> staging,
-        # main -> production). Not pre-switched to next/main: the cron fires on a
-        # schedule, not on code arrival, so it must not target a branch that does
-        # not have the baseline yet.
-        default: deploy/app-baseline-thruster
-        type: string
   schedule:
     - cron: "17 3 * * 1"
 
@@ -23,9 +12,14 @@ jobs:
     permissions:
       actions: write
       contents: read
+    strategy:
+      # Weekly OS-patch rebuild of both live baselines: next -> staging,
+      # main -> production. For a one-off single-branch rebuild use
+      # `just build ref=<branch>` instead.
+      matrix:
+        build_ref: [next, main]
     env:
-      # TODO(cutover): rebuild both baselines via a matrix (next, main); see build_ref above.
-      BUILD_REF: ${{ inputs.build_ref || 'deploy/app-baseline-thruster' }}
+      BUILD_REF: ${{ matrix.build_ref }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Force an OS security refresh so the weekly rebuild actually re-pulls the


### PR DESCRIPTION
The weekly OS-refresh cron still dispatched deploy/app-baseline-thruster, so next and main never received auto-patched rebuilds. Fan the schedule out over a [next, main] matrix and drop the dead branch from the build push triggers, so both live baselines get their weekly apt-security image.