### PR TITLE
Consent to the privacy policy

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,8 +118,11 @@ class User < ApplicationRecord
   # set some default values before saving if they are not set
   before_save :set_defaults
 
+  # a user must consent to the privacy policy to exist
+  validates :consents, acceptance: true, on: :create
+
   # add timestamp for DSGVO consent
-  after_create :set_consented_at
+  before_save :set_consented_at, if: -> { consents? && consented_at.nil? }
   before_destroy :destroy_single_submissions, prepend: true
 
   attr_accessor :skip_destroy_talk_media
@@ -821,7 +824,7 @@ class User < ApplicationRecord
 
     # sets time for DSGVO consent to current time
     def set_consented_at
-      update(consented_at: Time.zone.now)
+      self.consented_at = Time.zone.now
     end
 
     # returns array of ids of all courses that preced the subscribed courses

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4252,6 +4252,8 @@ de:
               does_not_match_tutorial: stimmt nicht mit der Veranstaltung des Tutoriums überein.
         user:
           attributes:
+            consents:
+              accepted: 'Du musst der Datenschutzerklärung zustimmen, um ein Konto anzulegen.'
             courses:
               blank: 'Es muss mindestens ein Modul abonniert werden.'
             name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4026,6 +4026,8 @@ en:
               does_not_match_tutorial: does not match the tutorial's lecture.
         user:
           attributes:
+            consents:
+              accepted: 'You need to accept the privacy policy to create an account.'
             courses:
               blank: 'You need to subscribe at least one course.'
             name:

--- a/db/migrate/20260824000001_require_consent_on_users.rb
+++ b/db/migrate/20260824000001_require_consent_on_users.rb
@@ -1,0 +1,19 @@
+class RequireConsentOnUsers < ActiveRecord::Migration[8.0]
+  class User < ApplicationRecord
+  end
+
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    User.where(consents: nil).update_all(consents: false)
+    User.where(consents: false).update_all(consented_at: nil)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    change_column_default :users, :consents, from: nil, to: false
+    change_column_null :users, :consents, false
+  end
+
+  def down
+    change_column_null :users, :consents, true
+    change_column_default :users, :consents, from: false, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_18_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_24_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1072,7 +1072,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_000000) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "admin"
     t.integer "subscription_type"
-    t.boolean "consents"
+    t.boolean "consents", default: false, null: false
     t.datetime "consented_at", precision: nil
     t.text "name"
     t.text "homepage"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     password { Faker::Internet.password }
     name { Faker::Name.name }
     locale { "en" }
+    consents { true }
 
     transient do
       lecture_count { 2 }
@@ -27,12 +28,6 @@ FactoryBot.define do
       end
     end
 
-    trait :consented do
-      after(:create) do |user|
-        user.update(consents: true, consented_at: Time.zone.now)
-      end
-    end
-
     # call it with build(:user, :with_lectures, lecture_count: n) if you want
     # n subscribed lectures associated to the user
     trait :with_lectures do
@@ -43,12 +38,10 @@ FactoryBot.define do
     end
 
     factory :confirmed_user, traits: [:skip_confirmation_notification,
-                                      :auto_confirmed,
-                                      :consented]
+                                      :auto_confirmed]
 
     factory :confirmed_user_en, traits: [:skip_confirmation_notification,
-                                         :auto_confirmed,
-                                         :consented] do
+                                         :auto_confirmed] do
       locale { "en" }
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe(User, type: :model) do
     expect(FactoryBot.build(:user)).to be_valid
   end
 
+  it "cannot be created without consent to the privacy policy" do
+    user = build(:user, consents: false)
+
+    expect(user).not_to be_valid
+    expect(user.errors[:consents]).to include(
+      I18n.t("activerecord.errors.models.user.attributes.consents.accepted")
+    )
+  end
+
+  it "stamps the consent date when consent is given" do
+    user = create(:user)
+
+    expect(user.consented_at).to be_present
+  end
+
   it "uses the profile image uploader for user images" do
     user = build(:user)
     file = fixture_file("image.png")

--- a/spec/requests/auth/registrations_spec.rb
+++ b/spec/requests/auth/registrations_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe("Auth registrations", type: :request) do
       expect(ActionMailer::Base.deliveries.last.to).to include(email)
     end
 
+    it "does not create a user without consent to the privacy policy" do
+      allow(Altcha).to receive(:verify).and_return(true)
+      params = base_params.merge(altcha: "valid")
+      params[:user] = params[:user].except(:consents)
+
+      expect do
+        post(user_registration_path, params: params)
+      end.not_to change(User, :count)
+    end
+
     it "does not create a user when captcha validation fails" do
       allow(Altcha).to receive(:verify).and_return(false)
 


### PR DESCRIPTION
The sign-up checkbox is only `required` in the browser. A POST that skips it creates an account with `consents` unset, and `after_create` stamps `consented_at` anyway — so the field claims a consent that was never given.

Reproduction (request spec, red before this branch):

```ruby
post user_registration_path, params: { altcha: "valid",
  user: { email: …, password: …, password_confirmation: … } }
# => user created, consents nil, consented_at set
```

Consent is now a condition of creation: `validates :consents, acceptance: true, on: :create`, `null: false` with default `false` in the table, and the timestamp is written when consent is given instead of for every new record. Existing rows without consent are set to `false` and their timestamp cleared; the migration rolls back cleanly.

The `check_for_consent` filters in six controllers were the only net catching such accounts. They can go once this has shipped and production confirms no rows are left — separate PR.