### PR TITLE
Wait for the sign-in response in the Playwright login helper

### DIFF
--- a/e2e/page-objects/login_page.ts
+++ b/e2e/page-objects/login_page.ts
@@ -16,6 +16,12 @@ export class LoginPage {
     if (password) {
       await this.page.getByLabel("Password", { exact: true }).fill(password);
     }
+    // Without this wait, the next attempt fills the form while the answer to
+    // this one is still on its way, and the click submits the wrong values.
+    const submitted = this.page.waitForResponse(response =>
+      response.request().method() === "POST"
+      && response.url().includes("/users/sign_in"));
     await this.page.getByRole("button", { name: "Login", exact: true }).click();
+    await submitted;
   }
 }


### PR DESCRIPTION
The two lock tests in `sessions.spec.ts` submit five logins in a row, and `LoginPage.login()` returned as soon as it had clicked. The assertion in between (`expect(alert).toBeVisible()`) is satisfied by the *previous* attempt’s alert, so the loop could fill the form again while an answer was still on its way. The account then never collected the five failures that lock it, and the last attempt submitted the wrong password — which is exactly what CI showed: `Invalid email or password.` instead of `Your account is locked.`

`login()` now waits for the `POST /users/sign_in` answer. Reproduced before the fix (`--repeat-each=4 --workers=2`: 3 of 8 failed), green after it: 30 of 30 across `sessions`, `passwords`, `profile` and `registration`, and `sessions.spec.ts` runs in 9.7 s instead of 21.6 s.