### PR TITLE
Lift the password policy while seeds:build resets passwords

### DIFF
--- a/lib/seeds/build_support.rb
+++ b/lib/seeds/build_support.rb
@@ -60,6 +60,9 @@ module Seeds
       ensure_development!
 
       User.find_each do |user|
+        # An account that is due a change may not be handed its own password
+        # back; stage_password_policy! puts the demo accounts back afterwards.
+        user.password_policy_version = User::CURRENT_PASSWORD_POLICY_VERSION
         user.password = PASSWORD
         user.password_confirmation = PASSWORD
         user.failed_attempts = 0


### PR DESCRIPTION
With #1141 merged, `rails seeds:build` stops at the first of the two demo accounts that are deliberately left on the old policy: they are due a password change, and the build hands them exactly the password they already have, which the new validation refuses.

```
Gültigkeitsprüfung ist fehlgeschlagen: Password muss sich von Deinem aktuellen Passwort unterscheiden
    lib/seeds/build_support.rb:68:in `block in reset_passwords!'
```

`reset_passwords!` now lifts the policy on the record before it sets the password; `stage_password_policy!` puts the two accounts back afterwards, as it did before. Measured on the seed database: the run goes through, 178 of 180 accounts end on the current policy, `moded@mampf.edu` and `student5@mampf.edu` on the old one, and the shared password still matches.