### PR TITLE
Add a sign-out link to the forced password change page

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -93,8 +93,14 @@
 <% end %>
 
 <% if password_change_required %>
-  <%= button_to t('devise.shared.links.forgot_password'),
-                restart_user_password_path(locale: I18n.locale),
-                method: :post,
-                class: 'btn btn-link p-0' %>
+  <div class="d-flex gap-3">
+    <%= button_to t('devise.shared.links.forgot_password'),
+                  restart_user_password_path(locale: I18n.locale),
+                  method: :post,
+                  class: 'btn btn-link p-0' %>
+    <%= button_to t('navbar.logout'),
+                  destroy_user_session_path(locale: I18n.locale),
+                  method: :delete,
+                  class: 'btn btn-link p-0' %>
+  </div>
 <% end %>

--- a/spec/requests/auth/registrations_spec.rb
+++ b/spec/requests/auth/registrations_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe("Auth registrations", type: :request) do
       expect(response).to redirect_to(edit_user_registration_path)
     end
 
+    it "offers a way out while the change is due" do
+      user = create(:confirmed_user_en)
+      # rubocop:disable Rails/SkipsModelValidations
+      user.update_columns(password_policy_version: 0, password_changed_at: nil)
+      # rubocop:enable Rails/SkipsModelValidations
+      sign_in user
+
+      get edit_user_registration_path
+
+      expect(response.body).to include(destroy_user_session_path(locale: :en))
+
+      delete destroy_user_session_path
+
+      expect(controller.current_user).to be_nil
+    end
+
     it "says so when the required password is left blank" do
       password = "zitrone-diskette-vorhang-42"
       user = create(:confirmed_user_en, password: password)


### PR DESCRIPTION
An account that still has to change its password is held on `/users/edit`, and every other page redirects back to it. That is the point. What the page did not offer was a way out: it renders in the devise layout, which has no navigation, so there was no sign-out — you could not switch to another account, and on a shared machine you could not even leave your own session behind.

`enforce_password_change` has always let `sessions#destroy` through ([application_controller.rb](https://github.com/MaMpf-HD/mampf/blob/next/app/controllers/application_controller.rb)), so the intent was there; only the button was missing. It now sits next to "Forgot your password?".