### PR TITLE
Copy a roster member's email address from the side panel

### DIFF
--- a/app/frontend/controllers/clipboard.controller.js
+++ b/app/frontend/controllers/clipboard.controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus";
+
+const CONFIRMATION_DURATION = 1500;
+
+export default class extends Controller {
+  static targets = ["icon", "status"];
+  static values = { text: String, confirmation: String };
+
+  copy(event) {
+    event.preventDefault();
+
+    if (!navigator.clipboard) {
+      console.warn("No clipboard available; the page needs a secure context.");
+      return;
+    }
+
+    navigator.clipboard.writeText(this.textValue).then(() => this.confirm());
+  }
+
+  confirm() {
+    if (this.hasStatusTarget) {
+      this.statusTarget.textContent = this.confirmationValue;
+    }
+    if (!this.hasIconTarget) return;
+
+    clearTimeout(this.timeout);
+    this.iconTarget.classList.replace("bi-envelope", "bi-check2");
+    this.timeout = setTimeout(() => {
+      this.iconTarget.classList.replace("bi-check2", "bi-envelope");
+    }, CONFIRMATION_DURATION);
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout);
+  }
+}

--- a/app/frontend/controllers/clipboard.controller.js
+++ b/app/frontend/controllers/clipboard.controller.js
@@ -1,33 +1,40 @@
 import { Controller } from "@hotwired/stimulus";
 
-const CONFIRMATION_DURATION = 1500;
+const FEEDBACK_DURATION = 1500;
+const RESTING_ICON = "bi-envelope";
+const SUCCESS_ICON = "bi-check2";
+const FAILURE_ICON = "bi-exclamation-triangle";
 
 export default class extends Controller {
   static targets = ["icon", "status"];
-  static values = { text: String, confirmation: String };
+  static values = { text: String, confirmation: String, failure: String };
 
   copy(event) {
     event.preventDefault();
 
+    // Only a secure context has a clipboard, so plain http says so rather than
+    // leaving the button looking broken.
     if (!navigator.clipboard) {
-      console.warn("No clipboard available; the page needs a secure context.");
+      this.report(this.failureValue, FAILURE_ICON);
       return;
     }
 
-    navigator.clipboard.writeText(this.textValue).then(() => this.confirm());
+    navigator.clipboard.writeText(this.textValue)
+      .then(() => this.report(this.confirmationValue, SUCCESS_ICON))
+      .catch(() => this.report(this.failureValue, FAILURE_ICON));
   }
 
-  confirm() {
+  report(message, icon) {
     if (this.hasStatusTarget) {
-      this.statusTarget.textContent = this.confirmationValue;
+      this.statusTarget.textContent = message;
     }
     if (!this.hasIconTarget) return;
 
     clearTimeout(this.timeout);
-    this.iconTarget.classList.replace("bi-envelope", "bi-check2");
+    this.iconTarget.classList.replace(RESTING_ICON, icon);
     this.timeout = setTimeout(() => {
-      this.iconTarget.classList.replace("bi-check2", "bi-envelope");
-    }, CONFIRMATION_DURATION);
+      this.iconTarget.classList.replace(icon, RESTING_ICON);
+    }, FEEDBACK_DURATION);
   }
 
   disconnect() {

--- a/app/frontend/entrypoints/initHotwire.js
+++ b/app/frontend/entrypoints/initHotwire.js
@@ -92,6 +92,9 @@ window.Stimulus.register("roster-drag", RosterDragController);
 import AutoSubmitFormController from "~/controllers/auto_submit_form.controller.js";
 window.Stimulus.register("auto-submit-form", AutoSubmitFormController);
 
+import ClipboardController from "~/controllers/clipboard.controller.js";
+window.Stimulus.register("clipboard", ClipboardController);
+
 import PreferenceChoicesController from "~/user_registrations/preference_choices.controller.js";
 window.Stimulus.register("preference-choices", PreferenceChoicesController);
 

--- a/app/frontend/roster/components/roster_side_panel_component.html.erb
+++ b/app/frontend/roster/components/roster_side_panel_component.html.erb
@@ -157,9 +157,25 @@
                   <% end %>
                 </div>
 
-                <div class="text-muted small">
-                  <i class="bi bi-envelope me-1"></i>
+                <div
+                  class="text-muted small"
+                  data-controller="clipboard"
+                  data-clipboard-text-value="<%= student.email %>"
+                  data-clipboard-confirmation-value="<%= t("basics.email_copied_to_clipboard") %>"
+                >
+                  <button
+                    type="button"
+                    class="btn btn-link btn-sm p-0 border-0 align-baseline text-muted"
+                    data-action="clipboard#copy"
+                    title="<%= t("buttons.copy_email_address") %>"
+                    aria-label="<%= t("buttons.copy_email_address") %>"
+                  >
+                    <i class="bi bi-envelope" data-clipboard-target="icon"></i>
+                  </button>
                   <%= student.email %>
+                  <span class="visually-hidden"
+                        role="status"
+                        data-clipboard-target="status"></span>
                 </div>
 
                 <% if show_rejection_reasons?(student) %>

--- a/app/frontend/roster/components/roster_side_panel_component.html.erb
+++ b/app/frontend/roster/components/roster_side_panel_component.html.erb
@@ -172,10 +172,14 @@
                   >
                     <i class="bi bi-envelope" data-clipboard-target="icon"></i>
                   </button>
+
                   <%= student.email %>
-                  <span class="visually-hidden"
-                        role="status"
-                        data-clipboard-target="status"></span>
+
+                  <span
+                    class="visually-hidden"
+                    role="status"
+                    data-clipboard-target="status"
+                  ></span>
                 </div>
 
                 <% if show_rejection_reasons?(student) %>

--- a/app/frontend/roster/components/roster_side_panel_component.html.erb
+++ b/app/frontend/roster/components/roster_side_panel_component.html.erb
@@ -162,6 +162,7 @@
                   data-controller="clipboard"
                   data-clipboard-text-value="<%= student.email %>"
                   data-clipboard-confirmation-value="<%= t("basics.email_copied_to_clipboard") %>"
+                  data-clipboard-failure-value="<%= t("basics.email_copy_failed") %>"
                 >
                   <button
                     type="button"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3684,6 +3684,7 @@ de:
     code_copied_to_clipboard: Der Code wurde in die Zwischenablage kopiert.
     emails_copied_to_clipboard: Die Adressen wurden in die Zwischenablage kopiert.
     email_copied_to_clipboard: Die E-Mail-Adresse wurde in die Zwischenablage kopiert.
+    email_copy_failed: Die E-Mail-Adresse konnte nicht kopiert werden.
     lecture_search: Veranstaltungssuche
     course_search: Modulsuche
     immediately: sofort

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3683,6 +3683,7 @@ de:
     as_file_type: als %{type}-Datei
     code_copied_to_clipboard: Der Code wurde in die Zwischenablage kopiert.
     emails_copied_to_clipboard: Die Adressen wurden in die Zwischenablage kopiert.
+    email_copied_to_clipboard: Die E-Mail-Adresse wurde in die Zwischenablage kopiert.
     lecture_search: Veranstaltungssuche
     course_search: Modulsuche
     immediately: sofort
@@ -3834,6 +3835,7 @@ de:
     join: 'Beitreten'
     copy_to_clipboard: 'in die Zwischenablage kopieren'
     copy_email_to_clipboard: 'E-Mail-Adressen in die Zwischenablage kopieren'
+    copy_email_address: 'E-Mail-Adresse kopieren'
     leave: 'Austreten'
     upload: 'Hochladen'
     upload_success: 'Erfolgreich hochgeladen'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3476,6 +3476,7 @@ en:
     code_copied_to_clipboard: Code has been copied to the clipboard.
     emails_copied_to_clipboard: Mail adresses have been copied to the clipboard.
     email_copied_to_clipboard: The email address has been copied to the clipboard.
+    email_copy_failed: The email address could not be copied.
     lecture_search: Lecture Search
     course_search: Course Search
     immediately: immediately

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3475,6 +3475,7 @@ en:
     as_file_type: as %{type} file
     code_copied_to_clipboard: Code has been copied to the clipboard.
     emails_copied_to_clipboard: Mail adresses have been copied to the clipboard.
+    email_copied_to_clipboard: The email address has been copied to the clipboard.
     lecture_search: Lecture Search
     course_search: Course Search
     immediately: immediately
@@ -3628,6 +3629,7 @@ en:
     join: 'Join'
     copy_to_clipboard: 'Copy to Clipboard'
     copy_email_to_clipboard: 'Copy mail adresses to Clipboard'
+    copy_email_address: 'Copy email address'
     leave: 'Leave'
     upload: 'Upload'
     upload_success: 'Upload successful'

--- a/e2e/roster_panel_copy_email.spec.ts
+++ b/e2e/roster_panel_copy_email.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "./_support/fixtures";
+
+test("copies a member's email address from the roster panel",
+  async ({ factory, student, teacher: { page, user } }) => {
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const lecture = await factory.create("lecture", [], {
+      teacher_id: user.id, locale: "en",
+    });
+    const tutorial = await factory.create("tutorial", [], {
+      lecture_id: lecture.id, title: "Mo 10",
+    });
+    await tutorial.__call("add_user_to_roster!", student.user);
+
+    await page.goto(`/lectures/${lecture.id}/edit?tab=groups`);
+    await page.getByText("Mo 10").click();
+
+    await page.getByRole("button", { name: "Copy email address" }).click();
+
+    const copied = await page.evaluate(() => navigator.clipboard.readText());
+    expect(copied).toBe(student.user.email);
+  });

--- a/e2e/roster_panel_copy_email.spec.ts
+++ b/e2e/roster_panel_copy_email.spec.ts
@@ -1,22 +1,49 @@
 import { expect, test } from "./_support/fixtures";
 
-test("copies a member's email address from the roster panel",
-  async ({ factory, student, teacher: { page, user } }) => {
-    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+const ADDRESS_BUTTON = { name: "Copy email address" };
 
-    const lecture = await factory.create("lecture", [], {
-      teacher_id: user.id, locale: "en",
+test.describe("the roster panel's copy button", () => {
+  test("puts the member's address on the clipboard",
+    async ({ factory, student, teacher: { page, user } }) => {
+      await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+      const lecture = await factory.create("lecture", [], {
+        teacher_id: user.id, locale: "en",
+      });
+      const tutorial = await factory.create("tutorial", [], {
+        lecture_id: lecture.id, title: "Mo 10",
+      });
+      await tutorial.__call("add_user_to_roster!", student.user);
+
+      await page.goto(`/lectures/${lecture.id}/edit?tab=groups`);
+      await page.getByText("Mo 10").click();
+      await page.getByRole("button", ADDRESS_BUTTON).click();
+
+      const copied = await page.evaluate(() => navigator.clipboard.readText());
+      expect(copied).toBe(student.user.email);
     });
-    const tutorial = await factory.create("tutorial", [], {
-      lecture_id: lecture.id, title: "Mo 10",
+
+  test("says so when the browser refuses the clipboard",
+    async ({ factory, student, teacher: { page, user } }) => {
+      await page.addInitScript(() => {
+        Object.defineProperty(navigator, "clipboard", {
+          value: { writeText: () => Promise.reject(new Error("denied")) },
+        });
+      });
+
+      const lecture = await factory.create("lecture", [], {
+        teacher_id: user.id, locale: "en",
+      });
+      const tutorial = await factory.create("tutorial", [], {
+        lecture_id: lecture.id, title: "Mo 10",
+      });
+      await tutorial.__call("add_user_to_roster!", student.user);
+
+      await page.goto(`/lectures/${lecture.id}/edit?tab=groups`);
+      await page.getByText("Mo 10").click();
+      await page.getByRole("button", ADDRESS_BUTTON).click();
+
+      await expect(page.getByRole("status"))
+        .toHaveText("The email address could not be copied.");
     });
-    await tutorial.__call("add_user_to_roster!", student.user);
-
-    await page.goto(`/lectures/${lecture.id}/edit?tab=groups`);
-    await page.getByText("Mo 10").click();
-
-    await page.getByRole("button", { name: "Copy email address" }).click();
-
-    const copied = await page.evaluate(() => navigator.clipboard.readText());
-    expect(copied).toBe(student.user.email);
-  });
+});


### PR DESCRIPTION
The roster side panel shows a member and their email address next to an envelope icon, and there was no way to get the address out: the icon did nothing, and the panel starts a drag on mousedown, so selecting the text with the mouse is a fight.

The envelope is a button now and puts the address on the clipboard, with the icon turning into a checkmark for a moment. A small `clipboard` Stimulus controller does it via `navigator.clipboard`, rather than the jQuery `clipboard.js` helper the older pages use — that one carries its own TODO about deprecated browser APIs (#684).