### PR TITLE
Give the course search results frame target=_top

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -35,6 +35,7 @@ module CoursesHelper
             style: "text-decoration: none;",
             data: { toggle: "tooltip",
                     placement: "bottom" },
+            "aria-label": t("buttons.edit"),
             title: t("buttons.edit")) do
       tag.i(class: "far fa-edit")
     end

--- a/app/views/administration/search.html.erb
+++ b/app/views/administration/search.html.erb
@@ -63,7 +63,7 @@
     </div>
     <div id="courseSearchArea">
       <%= render partial: 'search/course_search_form' %>
-      <%= turbo_frame_tag "courses-search-results" %>
+      <%= turbo_frame_tag "courses-search-results", target: "_top" %>
     </div>
   </div>
   <div class="tab-pane fade <%= show_tab(@tags) %>" id="tag_search">

--- a/e2e/courses.spec.ts
+++ b/e2e/courses.spec.ts
@@ -114,4 +114,9 @@ test("finds a course by title and keeps the results in their frame", async ({
   const results = page.locator("#courses-search-results");
   await expect(results.getByText("Zahlentheorie")).toBeVisible();
   await expect(results.getByText("Funktionalanalysis")).toBeHidden();
+
+  await results.getByRole("link", { name: "Edit" }).click();
+
+  await expect(page).toHaveURL(/\/courses\/\d+\/edit/);
+  await expect(page.getByRole("heading", { name: "Zahlentheorie" })).toBeVisible();
 });


### PR DESCRIPTION
Search for a course under Administration → Search, then click the edit icon: "Content missing" instead of the course form. The results live in the `courses-search-results` turbo frame, so Turbo looks for that frame in `/courses/:id/edit`, which has none.

The frame now carries `target: "_top"`, the way the tag search beside it already does, so its links navigate the whole page. The edit icon also gets an `aria-label`: it had only a `title`, which leaves screen readers with a last-resort name and role-based queries with nothing to match.