### PR TITLE
Replace the random values in the term factory with sequences

### DIFF
--- a/spec/factories/terms.rb
+++ b/spec/factories/terms.rb
@@ -1,9 +1,13 @@
-require "faker"
-
 FactoryBot.define do
   factory :term do
-    season { ["WS", "SS"].sample }
-    year { Faker::Number.between(from: 2000, to: 100_000) }
+    # Year and season are unique together, so they are counted out rather than
+    # drawn: two random draws that match make an unrelated example fail.
+    transient do
+      sequence(:index)
+    end
+
+    season { index.even? ? "SS" : "WS" }
+    year { 2000 + index }
 
     trait :summer do
       season { "SS" }


### PR DESCRIPTION
The term factory drew `season` from a coin flip and `year` from `Faker::Number.between(from: 2000, to: 100_000)`, while the model requires the pair to be unique. Two matching draws take down whichever example happens to be running — most recently `Search::Filters::LectureMediaScopeFilter`, which has nothing to do with terms:

```
Validation failed: Season This term already exists.
```

Every term now gets its own year, and the season alternates, so no two can collide — including `create(:term, :summer)` repeated, which a shared year would still have broken.