### PR TITLE
Seed lecture 1 as a term in progress and make seeds:build repeatable

### DIFF
--- a/lib/demo/campaign_cleanup.rb
+++ b/lib/demo/campaign_cleanup.rb
@@ -1,0 +1,25 @@
+module Demo
+  # A campaign that is under way, or that somebody has already registered for,
+  # refuses to be destroyed -- rightly, in an app where that would drop what
+  # students did. The demo data has to be able to start over all the same.
+  module CampaignCleanup
+    module_function
+
+    def discard!(campaign)
+      return if campaign.nil?
+
+      campaign.user_registrations.destroy_all
+      # rubocop:disable Rails/SkipsModelValidations
+      campaign.update_columns(status: Registration::Campaign.statuses[:draft],
+                              updated_at: Time.current)
+      # rubocop:enable Rails/SkipsModelValidations
+      campaign.destroy!
+    end
+
+    def discard_all!(campaignable, except: nil)
+      Registration::Campaign.where(campaignable: campaignable)
+                            .where.not(description: except)
+                            .find_each { |campaign| discard!(campaign) }
+    end
+  end
+end

--- a/lib/demo/campaign_cleanup.rb
+++ b/lib/demo/campaign_cleanup.rb
@@ -9,17 +9,30 @@ module Demo
       return if campaign.nil?
 
       campaign.user_registrations.destroy_all
+      draft!(campaign)
+      campaign.destroy!
+    end
+
+    # Everything a campaignable has, in the order the app allows: a policy only
+    # goes while its campaign is a draft, and a campaign only goes once no other
+    # one names it as a prerequisite.
+    def discard_all!(campaignable, except: nil)
+      campaigns = Registration::Campaign.where(campaignable: campaignable)
+      campaigns = campaigns.where.not(description: except) if except.present?
+
+      campaigns.each do |campaign|
+        campaign.user_registrations.destroy_all
+        draft!(campaign)
+      end
+      Registration::Policy.where(registration_campaign: campaigns).destroy_all
+      campaigns.each(&:destroy!)
+    end
+
+    def draft!(campaign)
       # rubocop:disable Rails/SkipsModelValidations
       campaign.update_columns(status: Registration::Campaign.statuses[:draft],
                               updated_at: Time.current)
       # rubocop:enable Rails/SkipsModelValidations
-      campaign.destroy!
-    end
-
-    def discard_all!(campaignable, except: nil)
-      Registration::Campaign.where(campaignable: campaignable)
-                            .where.not(description: except)
-                            .find_each { |campaign| discard!(campaign) }
     end
   end
 end

--- a/lib/demo/campaign_setup_support.rb
+++ b/lib/demo/campaign_setup_support.rb
@@ -88,9 +88,11 @@ module Demo
     def seed_preference_campaign_registrations!
       ensure_non_production!
 
-      campaign = Registration::Campaign.where(
-        description: PREFERENCE_CAMPAIGN_DESCRIPTION
-      ).last
+      # Scoped to the playground: an earlier build may have left a campaign of
+      # the same name on the lecture this used to run on.
+      campaign = Registration::Campaign.find_by(
+        campaignable: lecture!, description: PREFERENCE_CAMPAIGN_DESCRIPTION
+      )
       unless campaign
         output("Campaign not found. Run demo:campaigns first.")
         return
@@ -283,9 +285,9 @@ module Demo
     def seed_mixed_fcfs_campaign_registrations!
       ensure_non_production!
 
-      campaign = Registration::Campaign.where(
-        description: MIXED_FCFS_CAMPAIGN_DESCRIPTION
-      ).last
+      campaign = Registration::Campaign.find_by(
+        campaignable: lecture!, description: MIXED_FCFS_CAMPAIGN_DESCRIPTION
+      )
       unless campaign
         output("Campaign not found. Run demo:campaigns first.")
         return
@@ -297,8 +299,8 @@ module Demo
       tutorials = campaign.registration_items.includes(:registerable)
                           .where(registerable_type: "Tutorial")
                           .to_a
-      repeaters = Cohort.find_by(title: "Repeaters")
-      waitlist = Cohort.find_by(title: "Waitlist")
+      repeaters = Cohort.find_by(context: lecture!, title: "Repeaters")
+      waitlist = Cohort.find_by(context: lecture!, title: "Waitlist")
       repeaters_item = campaign.registration_items.find_by(
         registerable_type: "Cohort",
         registerable: repeaters
@@ -403,13 +405,13 @@ module Demo
 
       seminar = Lecture.find_by(course: course, teacher: teacher)
       if seminar
-        # An earlier build left it in the term that has since started; its
-        # campaigns are staged below and are rebuilt from scratch.
-        unless seminar.term == Demo::TermSupport.next_term
-          Demo::CampaignCleanup.discard_all!(seminar)
-          Cohort.where(context: seminar).destroy_all
-          seminar.update!(term: Demo::TermSupport.next_term)
-        end
+        # The scenario is staged from scratch on every build: its campaigns
+        # cannot be rewound once students have registered, and its cohorts would
+        # collide by title. The term follows, in case an earlier build left the
+        # seminar in one that has since started.
+        Demo::CampaignCleanup.discard_all!(seminar)
+        Cohort.where(context: seminar).destroy_all
+        seminar.update!(term: Demo::TermSupport.next_term)
       else
         seminar = FactoryBot.create(
           :seminar,

--- a/lib/demo/campaign_setup_support.rb
+++ b/lib/demo/campaign_setup_support.rb
@@ -8,6 +8,7 @@ module Demo
     ALLOCATION_CAMPAIGN_DESCRIPTION = "Stage 2: Allocation".freeze
     NACHRUECKER_CAMPAIGN_DESCRIPTION = "Stage 3: Nachrücker (FCFS)".freeze
     TWO_STAGE_COURSE_TITLE = "Campaign Test Seminar".freeze
+    PLAYGROUND_COURSE_TITLE = "Registration Playground".freeze
 
     def setup!
       ensure_non_production!
@@ -401,18 +402,26 @@ module Demo
       end
 
       seminar = Lecture.find_by(course: course, teacher: teacher)
-      unless seminar
+      if seminar
+        # An earlier build left it in the term that has since started; its
+        # campaigns are staged below and are rebuilt from scratch.
+        unless seminar.term == Demo::TermSupport.next_term
+          Demo::CampaignCleanup.discard_all!(seminar)
+          Cohort.where(context: seminar).destroy_all
+          seminar.update!(term: Demo::TermSupport.next_term)
+        end
+      else
         seminar = FactoryBot.create(
           :seminar,
           course: course,
           teacher: teacher,
           released: true,
-          term: Term.active || FactoryBot.create(:term)
+          term: Demo::TermSupport.next_term
         )
         output("Created Seminar Lecture")
       end
 
-      unless teacher.favorite_lectures.exists?(seminar.id)
+      unless LectureUserJoin.exists?(lecture: seminar, user: teacher)
         teacher.lectures << seminar
         output("Subscribed teacher to seminar")
       end
@@ -663,13 +672,14 @@ module Demo
         fail_setup!("Cannot run in production!") if Rails.env.production?
       end
 
+      # Everything here is a registration in progress, and one of those belongs
+      # in the term that is still being planned -- not in the lecture the demo
+      # opens on, which is meant to look like a term well under way.
       def lecture!
-        lecture = Lecture.find_by(id: 1)
-        fail_setup!("Lecture 1 not found. Run just seed first.") unless lecture
-
-        teacher = teacher!
-        lecture.update!(teacher: teacher) if lecture.teacher != teacher
-        lecture
+        Demo::TermSupport.find_or_create_lecture!(
+          term: Demo::TermSupport.next_term, teacher: teacher!,
+          course_title: PLAYGROUND_COURSE_TITLE, short_title: "RP"
+        )
       end
 
       def teacher!

--- a/lib/demo/setup_support.rb
+++ b/lib/demo/setup_support.rb
@@ -197,15 +197,7 @@ module Demo
       end
 
       def destroy_campaign!(campaign)
-        return unless campaign
-
-        # rubocop:disable Rails/SkipsModelValidations
-        campaign.update_columns(
-          status: Registration::Campaign.statuses[:draft],
-          updated_at: Time.current
-        )
-        # rubocop:enable Rails/SkipsModelValidations
-        campaign.destroy!
+        Demo::CampaignCleanup.discard!(campaign)
       end
 
       def ensure_item!(campaign, registerable)

--- a/lib/demo/term_support.rb
+++ b/lib/demo/term_support.rb
@@ -1,0 +1,34 @@
+module Demo
+  # The demo data needs two terms: the one it plays in, where everything is
+  # settled, and the one after it, where anything still being registered for
+  # belongs.
+  module TermSupport
+    module_function
+
+    def active_term
+      Term.active || Term.order(:year, :season).last
+    end
+
+    def next_term
+      term = active_term
+      year, season = term.season == "SS" ? [term.year, "WS"] : [term.year + 1, "SS"]
+      Term.find_or_create_by!(year: year, season: season)
+    end
+
+    def label(term)
+      "#{term.season} #{term.year}"
+    end
+
+    def find_or_create_lecture!(term:, teacher:, course_title:, short_title:,
+                                sort: "lecture")
+      course = Course.find_or_create_by!(title: course_title) do |record|
+        record.short_title = short_title
+      end
+
+      Lecture.find_by(course: course, term: term) ||
+        FactoryBot.create(:lecture, :released_for_all,
+                          course: course, term: term, teacher: teacher,
+                          sort: sort, locale: "en")
+    end
+  end
+end

--- a/lib/seeds/build_support.rb
+++ b/lib/seeds/build_support.rb
@@ -43,6 +43,8 @@ module Seeds
     # by the same number of six-month steps and stay in step with each other.
     def advance!(semesters)
       ensure_development!
+      return if Integer(semesters).zero?
+
       months = 6 * Integer(semesters)
       # rubocop:disable Rails/SkipsModelValidations
       Term.update_all(rename_terms(semesters))
@@ -151,16 +153,17 @@ module Seeds
 
       # rubocop:disable Rails/Exit
       # Without a target the set moves on by a single semester, which is what
-      # the next edition of the seed data usually is.
+      # the next edition of the seed data usually is. Naming the term it is
+      # already in rebuilds it where it stands.
       def semesters_until(target_term)
         return 1 if target_term.blank?
 
         season, year = parse_term(target_term)
         steps = ((year * 2) + (season == "SS" ? 0 : 1)) - term_index(current_term)
-        return steps if steps.positive?
+        return steps unless steps.negative?
 
         abort("The seed data is in #{label(current_term)}; " \
-              "#{season} #{year} is not ahead of it.")
+              "#{season} #{year} is behind it.")
       end
 
       def parse_term(target_term)

--- a/lib/seeds/build_support.rb
+++ b/lib/seeds/build_support.rb
@@ -28,7 +28,9 @@ module Seeds
         Demo::CampaignSetupSupport.setup!
         Demo::NextTermBannerSupport.setup!
         add_running_campaigns!
+        settle_current_term_campaigns!
         extend_open_deadlines!
+        Seeds::CourseworkSupport.setup!
         Seeds::EnrichSupport.enrich!
         # last, so that the accounts the demo scenarios create are usable too
         reset_passwords!
@@ -72,13 +74,28 @@ module Seeds
       end
     end
 
+    # A registration that is still running belongs in the term that is still
+    # being planned. The term the seed plays in is done registering: its lecture
+    # has a finalized roster and students sitting in tutorials.
     def add_running_campaigns!
       ensure_development!
+      term = next_term
 
-      [current_term, next_term].each do |term|
-        open_campaign!(lecture_for(term), TUTORIAL_DESCRIPTION, items_count: 4,
-                                                                capacity: 12)
-        open_campaign!(seminar_for(term), TALK_DESCRIPTION, items_count: 8)
+      open_campaign!(lecture_for(term), TUTORIAL_DESCRIPTION, items_count: 4,
+                                                              capacity: 12)
+      open_campaign!(seminar_for(term), TALK_DESCRIPTION, items_count: 8)
+    end
+
+    # Registration in the term the seed plays in is over: what an earlier build
+    # left open there would be a registration nobody can finish. Only a campaign
+    # that ran its course stays, because that is what its lecture shows.
+    def settle_current_term_campaigns!
+      ensure_development!
+
+      Lecture.where(term: current_term).find_each do |lecture|
+        Registration::Campaign.where(campaignable: lecture).find_each do |campaign|
+          Demo::CampaignCleanup.discard!(campaign) unless campaign.completed?
+        end
       end
     end
 
@@ -155,17 +172,11 @@ module Seeds
       # rubocop:enable Rails/Exit
 
       def current_term
-        Term.active || Term.order(:year, :season).last
+        Demo::TermSupport.active_term
       end
 
       def next_term
-        term = current_term
-        year, season = if term.season == "SS"
-          [term.year, "WS"]
-        else
-          [term.year + 1, "SS"]
-        end
-        Term.find_or_create_by!(year: year, season: season)
+        Demo::TermSupport.next_term
       end
 
       def teacher
@@ -183,17 +194,14 @@ module Seeds
       end
 
       def label(term)
-        "#{term.season} #{term.year}"
+        Demo::TermSupport.label(term)
       end
 
       def find_or_create_lecture!(term, sort, course_title, short_title)
-        course = Course.find_or_create_by!(title: course_title) do |c|
-          c.short_title = short_title
-        end
-        Lecture.find_by(course: course, term: term) ||
-          FactoryBot.create(:lecture, :released_for_all,
-                            course: course, term: term, teacher: teacher,
-                            sort: sort, locale: "en")
+        Demo::TermSupport.find_or_create_lecture!(
+          term: term, teacher: teacher, sort: sort,
+          course_title: course_title, short_title: short_title
+        )
       end
 
       def open_campaign!(lecture, description, items_count:, capacity: nil)

--- a/lib/seeds/coursework_support.rb
+++ b/lib/seeds/coursework_support.rb
@@ -1,0 +1,180 @@
+module Seeds
+  # Makes the lecture the demo opens on look like one that is well under way:
+  # tutors in front of the groups, students spread across them, and exercise
+  # sheets that were handed in and partly corrected. Anything still being
+  # registered for lives in the term after this one.
+  module CourseworkSupport
+    module_function
+
+    SECOND_TUTOR_EMAIL = "tutor2@mampf.edu".freeze
+    NAMED_STUDENT_EMAILS = (1..5).map { |number| "student#{number}@mampf.edu" }.freeze
+    # Left behind on the demo lecture by earlier builds, when the campaign
+    # playground still ran on it.
+    PLAYGROUND_TUTORIAL_TITLES = /\A(FCFS )?Tutorial \d+\z/
+    PLAYGROUND_COHORT_TITLES = ["Repeaters", "Waitlist"].freeze
+
+    def setup!
+      lecture = demo_lecture
+      return if lecture.nil?
+
+      drop_playground_leftovers!(lecture)
+      staff_tutorials!(lecture)
+      seat_named_students!(lecture)
+      hand_in_sheets!(lecture)
+    end
+
+    def demo_lecture
+      Lecture.find_by(id: 1)
+    end
+
+    # The playground moved to the term that is still being registered for; a
+    # rebuild starts from the last dump, so what it left here has to go.
+    def drop_playground_leftovers!(lecture)
+      Demo::CampaignCleanup.discard_all!(lecture, except: kept_campaign_description)
+
+      Cohort.where(context: lecture, title: PLAYGROUND_COHORT_TITLES).destroy_all
+
+      lecture.tutorials.each do |tutorial|
+        next unless tutorial.title.match?(PLAYGROUND_TUTORIAL_TITLES)
+        next if tutorial.tutorial_memberships.any? || tutorial.submissions.any?
+
+        tutorial.destroy!
+      end
+    end
+
+    def kept_campaign_description
+      Demo::SetupSupport::LECTURE_CAMPAIGN_DESCRIPTION
+    end
+
+    def staff_tutorials!(lecture)
+      tutors = [named_user("tutor@mampf.edu"), second_tutor].compact
+      return if tutors.empty?
+
+      lecture.tutorials.order(:title).each_with_index do |tutorial, index|
+        tutor = tutors[index % tutors.size]
+        next if tutor.in?(tutorial.tutors)
+
+        tutorial.tutors << tutor
+      end
+    end
+
+    # The accounts a developer actually logs in with should sit in a group, so
+    # that the submission pages have something to show -- in the group they have
+    # been handing in to, where there is one.
+    def seat_named_students!(lecture)
+      tutorials = seated_tutorials(lecture)
+      return if tutorials.empty?
+
+      named_students.each_with_index do |student, index|
+        next if TutorialMembership.exists?(lecture: lecture, user: student)
+
+        subscribe!(lecture, student)
+        tutorial = tutorial_handed_in_to(lecture, student) ||
+                   tutorials[index % tutorials.size]
+        TutorialMembership.create!(tutorial: tutorial, user: student)
+      end
+    end
+
+    def subscribe!(lecture, student)
+      return if LectureUserJoin.exists?(lecture: lecture, user: student)
+
+      LectureUserJoin.create!(lecture: lecture, user: student)
+    end
+
+    def tutorial_handed_in_to(lecture, student)
+      Submission.joins(:users, :assignment)
+                .where(assignments: { lecture_id: lecture.id },
+                       users: { id: student.id })
+                .first&.tutorial
+    end
+
+    def hand_in_sheets!(lecture)
+      return if manuscript_path.nil?
+
+      lecture.assignments.order(:deadline).each_with_index do |assignment, index|
+        seated_tutorials(lecture).each do |tutorial|
+          teams_for(tutorial).each_with_index do |team, position|
+            corrected = assignment.expired? && position.even?
+            hand_in!(assignment, tutorial, team,
+                     correction: corrected && (index.zero? ? :accepted : :pending))
+          end
+        end
+      end
+    end
+
+    # Two hand in together, the next one alone, and the rest of the group does
+    # not hand in at all -- which is what a tutorial looks like.
+    def teams_for(tutorial)
+      members = tutorial.tutorial_memberships.includes(:user).map(&:user).sort_by(&:id)
+      return [] if members.empty?
+
+      [members.first(2), members.drop(2).first(1)].reject(&:empty?)
+    end
+
+    def hand_in!(assignment, tutorial, team, correction:)
+      return if team.any? { |user| handed_in?(assignment, user) }
+
+      submission = Submission.new(assignment: assignment, tutorial: tutorial,
+                                  users: [team.first])
+      submission.manuscript = manuscript_copy
+      submission.save!
+      # A partner joins an existing submission; handing both users to a new one
+      # trips the team-size check, which counts what is already in the team.
+      team.drop(1).each do |partner|
+        UserSubmissionJoin.create!(user: partner, submission: submission)
+      end
+      return unless correction
+
+      submission.correction = manuscript_copy
+      submission.accepted = correction == :accepted
+      submission.save!
+    end
+
+    # One submission per assignment and person: a team whose member has handed
+    # in already is left alone, which is also what makes this rerunnable.
+    def handed_in?(assignment, user)
+      UserSubmissionJoin.where(user: user, submission: assignment.submissions).any?
+    end
+
+    def seated_tutorials(lecture)
+      @seated_tutorials ||= {}
+      @seated_tutorials[lecture.id] ||=
+        lecture.tutorials.order(:title).select { |t| t.tutorial_memberships.any? }
+               .presence || lecture.tutorials.order(:title).to_a
+    end
+
+    def named_students
+      @named_students ||= NAMED_STUDENT_EMAILS.filter_map { |email| named_user(email) }
+    end
+
+    def named_user(email)
+      User.find_by(email: email)
+    end
+
+    def second_tutor
+      named_user(SECOND_TUTOR_EMAIL) ||
+        FactoryBot.create(:confirmed_user, email: SECOND_TUTOR_EMAIL,
+                                           name: "Toni Tutor")
+    end
+
+    # A file the seed already ships, so the dump grows by nothing that is not
+    # already in it. It is opened again for every hand-in, because Shrine closes
+    # what it has uploaded.
+    def manuscript_path
+      return @manuscript_path if defined?(@manuscript_path)
+
+      source = Medium.where.not(manuscript_data: nil).first
+      @manuscript_path = source && write_copy(source.manuscript.download)
+    end
+
+    def write_copy(download)
+      path = File.join(Dir.mktmpdir, "abgabe.pdf")
+      File.binwrite(path, download.read)
+      path
+    end
+
+    def manuscript_copy
+      manuscript_path && File.open(manuscript_path, "rb")
+    end
+  end
+end

--- a/lib/seeds/coursework_support.rb
+++ b/lib/seeds/coursework_support.rb
@@ -12,6 +12,9 @@ module Seeds
     # playground still ran on it.
     PLAYGROUND_TUTORIAL_TITLES = /\A(FCFS )?Tutorial \d+\z/
     PLAYGROUND_COHORT_TITLES = ["Repeaters", "Waitlist"].freeze
+    # What a group hands in per sheet. Also the ceiling, so that a rebuild does
+    # not pile more on top of what the last one left.
+    TEAMS_PER_TUTORIAL = 2
 
     def setup!
       lecture = demo_lecture
@@ -108,11 +111,14 @@ module Seeds
       members = tutorial.tutorial_memberships.includes(:user).map(&:user).sort_by(&:id)
       return [] if members.empty?
 
-      [members.first(2), members.drop(2).first(1)].reject(&:empty?)
+      teams = [members.first(2), members.drop(2).first(1)]
+      teams.reject(&:empty?).first(TEAMS_PER_TUTORIAL)
     end
 
     def hand_in!(assignment, tutorial, team, correction:)
       return if team.any? { |user| handed_in?(assignment, user) }
+      return if Submission.where(assignment: assignment,
+                                 tutorial: tutorial).count >= TEAMS_PER_TUTORIAL
 
       submission = Submission.new(assignment: assignment, tutorial: tutorial,
                                   users: [team.first])

--- a/lib/seeds/enrich_support.rb
+++ b/lib/seeds/enrich_support.rb
@@ -35,18 +35,63 @@ module Seeds
       "<div>Willkommen bei <strong>%<title>s</strong>!</div>" \
       "<div>Auf dieser Seite findest Du alles zur Veranstaltung: das Skript, " \
       "die Videos zu den einzelnen Sitzungen und die Übungsblätter. Die " \
-      "Aufzeichnung steht in der Regel am Abend nach der Vorlesung bereit.</div>",
+      "Aufzeichnung steht in der Regel am Abend nach der Vorlesung bereit, " \
+      "die Kapitelmarken kommen am Tag darauf dazu.</div>" \
+      "<div>Die Übungsblätter erscheinen mittwochs und werden bis zum " \
+      "Freitag der Folgewoche abgegeben — in Zweiergruppen, direkt hier über " \
+      "MaMpf. Deine Tutorin oder Dein Tutor lädt die Korrektur an derselben " \
+      "Stelle wieder hoch.</div>",
 
       "<div>Diese Seite ist die Anlaufstelle für <strong>%<title>s</strong>.</div>" \
       "<div>Fragen zwischendurch stellst Du am besten im Forum — dort " \
       "antworten auch die Tutorinnen und Tutoren. Wichtige Hinweise " \
-      "erscheinen als Ankündigung ganz oben.</div>",
+      "erscheinen als Ankündigung ganz oben; wenn Du die Veranstaltung " \
+      "abonniert hast, bekommst Du sie außerdem als Benachrichtigung.</div>" \
+      "<div>Das Skript wächst mit der Vorlesung mit. Wo etwas unklar bleibt, " \
+      "hilft oft die verlinkte Wiederholung aus dem vorigen Semester.</div>",
 
       "<div><strong>%<title>s</strong></div>" \
-      "<div>Die Anmeldung zu den Übungsgruppen läuft über MaMpf. Trag Dich " \
-      "bitte in der ersten Vorlesungswoche ein; wer die Gruppe wechseln " \
-      "möchte, meldet sich bei der Übungsleitung.</div>"
+      "<div>Der Ablauf ist der übliche: zwei Vorlesungen und eine Übung pro " \
+      "Woche, dazu ein Übungsblatt, von dem die Hälfte der Punkte zur " \
+      "Klausurzulassung reicht.</div>" \
+      "<div>Alles, was Du dafür brauchst, steht hier: das Skript unter " \
+      "„Manuskript“, die Aufzeichnungen unter „Lektionen“ und die Blätter " \
+      "unter „Übungen“. Die Sprechstunde findet dienstags um 14 Uhr statt.</div>"
     ].freeze
+
+    # The page a student sees before deciding to register, so it says what the
+    # registration is for rather than describing a term already under way.
+    REGISTRATION_INTRO =
+      "<div><strong>%<title>s</strong> im kommenden Semester</div>" \
+      "<div>Die Veranstaltung beginnt in der ersten Vorlesungswoche. Für die " \
+      "Übungsgruppen läuft die Anmeldung bereits: Du gibst Deine Wunschzeiten " \
+      "in der Reihenfolge an, in der sie Dir passen, und bekommst nach dem " \
+      "Ende der Anmeldefrist eine Gruppe zugeteilt.</div>" \
+      "<div>Ein Platz in der Veranstaltung hängt nicht daran — das Abonnement " \
+      "hier ist keine verbindliche Anmeldung.</div>".freeze
+
+    # What people jot down while watching: students ask, the teacher notes what
+    # to change next time round.
+    STUDENT_NOTES = [
+      ["Hier nochmal ansehen, der Schritt ging schnell.", :note, nil],
+      ["Warum darf man die Summe an dieser Stelle vertauschen?", :content, :argument],
+      ["Das ist genau die Aufgabe von Blatt 3.", :content, :strategy],
+      ["Definition sitzt jetzt.", :note, :definition],
+      ["Ab hier ist die Tafel schlecht zu lesen.", :presentation, nil],
+      ["Ich glaube, im Index ist ein Dreher.", :mistake, nil]
+    ].freeze
+
+    TEACHER_NOTES = [
+      ["Voraussetzung fehlt, beim nächsten Mal ergänzen.", :mistake, nil],
+      ["Hier langsamer machen, das geht zu schnell.", :presentation, nil],
+      ["Beispiel für die Übung übernehmen.", :content, :strategy]
+    ].freeze
+
+    # Spread over the sample video, which runs about 42 seconds.
+    ANNOTATION_SECONDS = [4.5, 11.0, 18.5, 25.0, 31.5, 37.0].freeze
+
+    WATCHLIST_NAMES = ["Wiederholung", "Vor der Klausur", "Nochmal ansehen"].freeze
+    TEACHER_WATCHLIST_NAME = "Für die Sprechstunde".freeze
 
     COMMENTS = [
       "Ab Minute 12 ist der Ton etwas leise.",
@@ -76,7 +121,14 @@ module Seeds
       end
 
       def current_lectures
-        @current_lectures ||= Lecture.where(term: Term.active).to_a
+        @current_lectures ||= Lecture.where(term: Demo::TermSupport.active_term).to_a
+      end
+
+      # The pages a visitor actually opens: the term that is running and the one
+      # that can already be registered for.
+      def showcase_lectures
+        @showcase_lectures ||=
+          current_lectures + Lecture.where(term: Demo::TermSupport.next_term).to_a
       end
 
       # The forum name carries the term, which the year shift has moved on.
@@ -88,16 +140,35 @@ module Seeds
 
       # The home page is where a lecture starts for a student, and an empty one
       # says nothing about what the page is for.
+      # The build owns these texts: a dump is rebuilt from the one before it, so
+      # an intro written by an earlier build has to be replaced, not kept.
       def add_home_intros!
-        current_lectures.each_with_index do |lecture, index|
-          next if lecture.home_intro_present?
-
-          text = format(HOME_INTROS[index % HOME_INTROS.size],
-                        title: lecture.course.title)
+        showcase_lectures.each_with_index do |lecture, index|
+          text = format(intro_template(lecture, index), title: lecture.course.title)
           # rubocop:disable Rails/SkipsModelValidations
           lecture.update_columns(home_intro: text)
           # rubocop:enable Rails/SkipsModelValidations
         end
+        attach_program!
+      end
+
+      def intro_template(lecture, index)
+        return REGISTRATION_INTRO if lecture.registration_campaigns.open.any?
+
+        HOME_INTROS[index % HOME_INTROS.size]
+      end
+
+      # The home page offers a welcome text and a program; without one of them
+      # the page keeps telling its teacher that it is empty.
+      def attach_program!
+        lecture = Lecture.find_by(id: 1)
+        return if lecture.nil? || lecture.home_attachment.present?
+
+        source = Medium.where.not(manuscript_data: nil).first
+        return if source.nil?
+
+        lecture.home_attachment = source.manuscript.download
+        lecture.save!
       end
 
       # Announcements stay, but off the landing page, where they greet every
@@ -169,29 +240,71 @@ module Seeds
         end
       end
 
-      # Annotations sit on a video timeline, so only media that carry one.
+      # Annotations sit on a video timeline, so only media that carry one. Every
+      # video gets a few, and the teacher keeps notes on their own lecture.
       def add_annotations!
-        Medium.where.not(video_data: nil).limit(8).each do |medium|
-          students.first(3).each do |student|
-            next if Annotation.exists?(medium_id: medium.id, user_id: student.id)
-
-            FactoryBot.create(:annotation, :with_text,
-                              medium_id: medium.id, user_id: student.id)
+        annotatable_media.each_with_index do |medium, medium_index|
+          students.each_with_index do |student, student_index|
+            annotate!(medium, student, STUDENT_NOTES, medium_index + student_index,
+                      shared: student_index.even?)
           end
+
+          teacher = medium_teacher(medium)
+          annotate!(medium, teacher, TEACHER_NOTES, medium_index) if teacher
         end
       end
 
-      def add_watchlists!
-        media = Medium.limit(6).to_a
-        students.each_with_index do |student, index|
-          next if Watchlist.exists?(user: student)
+      def annotatable_media
+        @annotatable_media ||= Medium.where.not(video_data: nil).to_a
+      end
 
-          watchlist = Watchlist.create!(user: student,
-                                        name: "Wiederholung #{index + 1}")
-          media.sample(3).each_with_index do |medium, position|
-            WatchlistEntry.create!(watchlist: watchlist, medium: medium,
-                                   medium_position: position + 1)
+      def medium_teacher(medium)
+        lecture = medium.teachable.try(:lecture) || medium.teachable
+        lecture.try(:teacher)
+      end
+
+      # Two per person and video, at spots that do not sit on top of each other.
+      def annotate!(medium, user, notes, offset, shared: false)
+        existing = Annotation.where(medium_id: medium.id, user_id: user.id).count
+        return if existing >= 2
+
+        (2 - existing).times do |run|
+          comment, category, subcategory = notes[(offset + run) % notes.size]
+          seconds = ANNOTATION_SECONDS[(offset + (run * 3)) % ANNOTATION_SECONDS.size]
+          Annotation.create!(medium_id: medium.id, user_id: user.id,
+                             comment: comment, category: category,
+                             subcategory: subcategory, visible_for_teacher: shared,
+                             color: Annotation.colors[(offset % 8) + 1],
+                             timestamp: TimeStamp.new(total_seconds: seconds))
+        end
+      end
+
+      # Students collect what they want to see again; the teacher collects what
+      # they keep pointing people at.
+      def add_watchlists!
+        students.each_with_index do |student, index|
+          WATCHLIST_NAMES.first(2).each_with_index do |name, run|
+            fill_watchlist!(student, "#{name} #{index + 1}", offset: index + run)
           end
+        end
+
+        fill_watchlist!(teacher, TEACHER_WATCHLIST_NAME, offset: 2, size: 5) if teacher
+      end
+
+      def teacher
+        return @teacher if defined?(@teacher)
+
+        @teacher = User.find_by(email: "teacher@mampf.edu")
+      end
+
+      def fill_watchlist!(user, name, offset:, size: 3)
+        return if Watchlist.exists?(user: user, name: name)
+
+        watchlist = Watchlist.create!(user: user, name: name)
+        media = annotatable_media.rotate(offset).first(size)
+        media.each_with_index do |medium, position|
+          WatchlistEntry.create!(watchlist: watchlist, medium: medium,
+                                 medium_position: position + 1)
         end
       end
   end

--- a/lib/seeds/enrich_support.rb
+++ b/lib/seeds/enrich_support.rb
@@ -31,44 +31,82 @@ module Seeds
       ]]
     ].freeze
 
-    HOME_INTROS = [
-      "<div>Willkommen bei <strong>%<title>s</strong>!</div>" \
-      "<div>Auf dieser Seite findest Du alles zur Veranstaltung: das Skript, " \
-      "die Videos zu den einzelnen Sitzungen und die Übungsblätter. Die " \
-      "Aufzeichnung steht in der Regel am Abend nach der Vorlesung bereit, " \
-      "die Kapitelmarken kommen am Tag darauf dazu.</div>" \
-      "<div>Die Übungsblätter erscheinen mittwochs und werden bis zum " \
-      "Freitag der Folgewoche abgegeben — in Zweiergruppen, direkt hier über " \
-      "MaMpf. Deine Tutorin oder Dein Tutor lädt die Korrektur an derselben " \
-      "Stelle wieder hoch.</div>",
+    # MaMpf is taught in both languages, and a lecture that says it is English
+    # should not greet its students in German.
+    HOME_INTROS = {
+      "de" => [
+        "<div>Willkommen bei <strong>%<title>s</strong>!</div>" \
+        "<div>Auf dieser Seite findest Du alles zur Veranstaltung: das Skript, " \
+        "die Videos zu den einzelnen Sitzungen und die Übungsblätter. Die " \
+        "Aufzeichnung steht in der Regel am Abend nach der Vorlesung bereit, " \
+        "die Kapitelmarken kommen am Tag darauf dazu.</div>" \
+        "<div>Die Übungsblätter erscheinen mittwochs und werden bis zum " \
+        "Freitag der Folgewoche abgegeben — in Zweiergruppen, direkt hier über " \
+        "MaMpf. Deine Tutorin oder Dein Tutor lädt die Korrektur an derselben " \
+        "Stelle wieder hoch.</div>",
 
-      "<div>Diese Seite ist die Anlaufstelle für <strong>%<title>s</strong>.</div>" \
-      "<div>Fragen zwischendurch stellst Du am besten im Forum — dort " \
-      "antworten auch die Tutorinnen und Tutoren. Wichtige Hinweise " \
-      "erscheinen als Ankündigung ganz oben; wenn Du die Veranstaltung " \
-      "abonniert hast, bekommst Du sie außerdem als Benachrichtigung.</div>" \
-      "<div>Das Skript wächst mit der Vorlesung mit. Wo etwas unklar bleibt, " \
-      "hilft oft die verlinkte Wiederholung aus dem vorigen Semester.</div>",
+        "<div>Diese Seite ist die Anlaufstelle für <strong>%<title>s</strong>.</div>" \
+        "<div>Fragen zwischendurch stellst Du am besten im Forum — dort " \
+        "antworten auch die Tutorinnen und Tutoren. Wichtige Hinweise " \
+        "erscheinen als Ankündigung ganz oben; wenn Du die Veranstaltung " \
+        "abonniert hast, bekommst Du sie außerdem als Benachrichtigung.</div>" \
+        "<div>Das Skript wächst mit der Vorlesung mit. Wo etwas unklar bleibt, " \
+        "hilft oft die verlinkte Wiederholung aus dem vorigen Semester.</div>",
 
-      "<div><strong>%<title>s</strong></div>" \
-      "<div>Der Ablauf ist der übliche: zwei Vorlesungen und eine Übung pro " \
-      "Woche, dazu ein Übungsblatt, von dem die Hälfte der Punkte zur " \
-      "Klausurzulassung reicht.</div>" \
-      "<div>Alles, was Du dafür brauchst, steht hier: das Skript unter " \
-      "„Manuskript“, die Aufzeichnungen unter „Lektionen“ und die Blätter " \
-      "unter „Übungen“. Die Sprechstunde findet dienstags um 14 Uhr statt.</div>"
-    ].freeze
+        "<div><strong>%<title>s</strong></div>" \
+        "<div>Der Ablauf ist der übliche: zwei Vorlesungen und eine Übung pro " \
+        "Woche, dazu ein Übungsblatt, von dem die Hälfte der Punkte zur " \
+        "Klausurzulassung reicht.</div>" \
+        "<div>Alles, was Du dafür brauchst, steht hier: das Skript unter " \
+        "„Manuskript“, die Aufzeichnungen unter „Lektionen“ und die Blätter " \
+        "unter „Übungen“. Die Sprechstunde findet dienstags um 14 Uhr statt.</div>"
+      ],
+      "en" => [
+        "<div>Welcome to <strong>%<title>s</strong>!</div>" \
+        "<div>This page holds everything the course comes with: the notes, the " \
+        "recording of every session and the exercise sheets. A recording is " \
+        "usually up the evening after the lecture, its chapter marks the day " \
+        "after that.</div>" \
+        "<div>Sheets appear on Wednesdays and are handed in by the Friday of " \
+        "the week after — in pairs, here on MaMpf. Your tutor uploads the " \
+        "correction in the same place.</div>",
+
+        "<div>This is where <strong>%<title>s</strong> starts.</div>" \
+        "<div>Ask what comes up in the forum; the tutors read it too. Anything " \
+        "that matters is announced at the top of this page, and reaches you as " \
+        "a notification once you have subscribed to the course.</div>" \
+        "<div>The notes grow with the lecture. Where something stays unclear, " \
+        "the linked revision from last term often helps.</div>",
+
+        "<div><strong>%<title>s</strong></div>" \
+        "<div>The week runs as usual: two lectures, one exercise class, and a " \
+        "sheet of which half the points admit you to the exam.</div>" \
+        "<div>Everything you need for that is here: the notes under " \
+        "\u201CManuscript\u201D, the recordings under \u201CLessons\u201D and the sheets " \
+        "under \u201CExercises\u201D. Office hours are on Tuesdays at 2 pm.</div>"
+      ]
+    }.freeze
 
     # The page a student sees before deciding to register, so it says what the
     # registration is for rather than describing a term already under way.
-    REGISTRATION_INTRO =
-      "<div><strong>%<title>s</strong> im kommenden Semester</div>" \
-      "<div>Die Veranstaltung beginnt in der ersten Vorlesungswoche. Für die " \
-      "Übungsgruppen läuft die Anmeldung bereits: Du gibst Deine Wunschzeiten " \
-      "in der Reihenfolge an, in der sie Dir passen, und bekommst nach dem " \
-      "Ende der Anmeldefrist eine Gruppe zugeteilt.</div>" \
-      "<div>Ein Platz in der Veranstaltung hängt nicht daran — das Abonnement " \
-      "hier ist keine verbindliche Anmeldung.</div>".freeze
+    REGISTRATION_INTROS = {
+      "de" =>
+        "<div><strong>%<title>s</strong> im kommenden Semester</div>" \
+        "<div>Die Veranstaltung beginnt in der ersten Vorlesungswoche. Für die " \
+        "Übungsgruppen läuft die Anmeldung bereits: Du gibst Deine Wunschzeiten " \
+        "in der Reihenfolge an, in der sie Dir passen, und bekommst nach dem " \
+        "Ende der Anmeldefrist eine Gruppe zugeteilt.</div>" \
+        "<div>Ein Platz in der Veranstaltung hängt nicht daran — das Abonnement " \
+        "hier ist keine verbindliche Anmeldung.</div>",
+      "en" =>
+        "<div><strong>%<title>s</strong> next term</div>" \
+        "<div>The course starts in the first week of term. Registration for the " \
+        "exercise groups is already running: you name the slots that suit you, " \
+        "in the order they suit you, and are given a group once the deadline " \
+        "has passed.</div>" \
+        "<div>Your place in the course does not hang on it — subscribing here " \
+        "is not a binding registration.</div>"
+    }.freeze
 
     # What people jot down while watching: students ask, the teacher notes what
     # to change next time round.
@@ -153,9 +191,15 @@ module Seeds
       end
 
       def intro_template(lecture, index)
-        return REGISTRATION_INTRO if lecture.registration_campaigns.open.any?
+        locale = intro_locale(lecture)
+        return REGISTRATION_INTROS[locale] if lecture.registration_campaigns.open.any?
 
-        HOME_INTROS[index % HOME_INTROS.size]
+        HOME_INTROS[locale][index % HOME_INTROS[locale].size]
+      end
+
+      def intro_locale(lecture)
+        locale = lecture.locale_with_inheritance.to_s
+        HOME_INTROS.key?(locale) ? locale : "de"
       end
 
       # The home page offers a welcome text and a program; without one of them

--- a/lib/tasks/seeds_build.rake
+++ b/lib/tasks/seeds_build.rake
@@ -1,5 +1,7 @@
 namespace :seeds do
-  desc "Rebuild the shipped development seed data (term=\"WS 2026\", default one semester on)"
+  desc "Rebuild the shipped development seed data " \
+       "(term=\"WS 2026\" to move it there, the current term to rebuild in place, " \
+       "default one semester on)"
   task build: :environment do
     Seeds::BuildSupport.build!(target_term: ENV.fetch("term", nil))
   end


### PR DESCRIPTION
Lecture 1 — the lecture most GUI work starts from — was where the campaign playground hung its scenarios: twelve tutorials, seven of them empty, two open registrations, not one tutor in a group, five submissions across three sheets.

The playground moves to the term after the current one, where a registration still being run belongs, and what earlier builds left open in the running term is settled. What stays is a lecture in progress: tutors in front of the groups, students seated where they hand in, sheets handed in and partly corrected, home pages that say something in the lecture's own language, annotations on every video — the teacher keeps their own — and watchlists that are no longer the students' alone.

`rails seeds:build` could not run against its own output before this branch. It now clears what it is about to stage, in the order the app allows, and looks up only what belongs to its own lecture; naming the term the data is already in rebuilds an edition where it stands.

Measured on a scratch database built from the shipped dump, twice in a row:

| | before | after |
|---|---|---|
| campaigns on lecture 1 | 3, two open | 1, completed |
| its tutorials | 12, seven empty, none staffed | 5, all staffed, 37 members |
| its submissions | 5 | 29 (11 corrected, 5 accepted) |
| open registrations in the running term | 4 | 0 |
| annotations | 27, none by the teacher | 167, 26 by the teacher |
| watchlists / entries | 6 / 14 | 17 / 49 |
| `seeds:build` on the shipped dump | fails | runs, twice |

No new dump is published with this; mampf-init-data gets one once this is merged and the seed is rebuilt, staying in SS 2026.