### PR TITLE
Add a seeds:package task that builds uploads.zip from the records

### DIFF
--- a/lib/seeds/package_support.rb
+++ b/lib/seeds/package_support.rb
@@ -1,0 +1,114 @@
+require "zip"
+
+module Seeds
+  # Packs the uploads that belong to the seed data: the files its records point
+  # at, and nothing else. A development store collects far more than that over
+  # time, and an archive built by hand keeps files of models that have since
+  # been removed -- both of which the published set has suffered from.
+  module PackageSupport
+    module_function
+
+    ARCHIVE_ROOT = "uploads".freeze
+
+    def package!(path: default_path)
+      ensure_development!
+      files = referenced_files
+      missing = files.reject { |file| File.exist?(file) }
+
+      write_archive!(path, files - missing)
+      report!(path, files.size, missing)
+      missing
+    end
+
+    # Everything the records point at: each Shrine attachment, the derivatives
+    # hanging off it, and the blobs ActiveStorage keeps for rich text.
+    def referenced_files
+      Rails.application.eager_load!
+      files = attachment_files + blob_files
+      files.uniq
+    end
+
+    def attachment_files
+      attachment_models.flat_map do |model|
+        columns = model.column_names.select { |column| column.end_with?("_data") }
+        model.find_each.flat_map do |record|
+          columns.flat_map { |column| paths_in(parse(record[column])) }
+        end
+      end
+    end
+
+    def blob_files
+      ActiveStorage::Blob.find_each.map { |blob| blob.service.path_for(blob.key) }
+    end
+
+    def attachment_models
+      ApplicationRecord.descendants.select do |model|
+        !model.abstract_class? && model.table_exists? &&
+          model.column_names.any? { |column| column.end_with?("_data") }
+      end
+    end
+
+    def paths_in(data)
+      return [] unless data.is_a?(Hash)
+
+      own = storage_path(data["storage"], data["id"])
+      derived = data["derivatives"].to_h.values.flat_map { |child| paths_in(child) }
+
+      [own, *derived].compact
+    end
+
+    def storage_path(storage, id)
+      return if storage.blank? || id.blank?
+
+      storage = Shrine.storages[storage.to_sym]
+      return unless storage.respond_to?(:path)
+
+      storage.path(id).to_s
+    end
+
+    def parse(value)
+      return value if value.is_a?(Hash)
+      return if value.blank?
+
+      JSON.parse(value)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def write_archive!(path, files)
+      FileUtils.mkdir_p(File.dirname(path))
+      FileUtils.rm_f(path)
+      root = Rails.public_path.to_s
+
+      Zip::File.open(path, create: true) do |archive|
+        files.sort.each do |file|
+          archive.add(File.join(ARCHIVE_ROOT, relative_to_uploads(file, root)), file)
+        end
+      end
+    end
+
+    # The archive is unpacked over `public/`, so it carries the same layout.
+    def relative_to_uploads(file, root)
+      file.sub("#{root}/#{ARCHIVE_ROOT}/", "")
+    end
+
+    def default_path
+      Rails.root.join("db/backups/development/uploads.zip").to_s
+    end
+
+    # rubocop:disable Rails/Exit
+    def ensure_development!
+      return if Rails.env.development?
+
+      abort("This packs the development seed: refusing to run in #{Rails.env}.")
+    end
+    # rubocop:enable Rails/Exit
+
+    def report!(path, wanted, missing)
+      Rails.logger.debug do
+        "Packed #{wanted - missing.size} of #{wanted} referenced files into #{path}"
+      end
+      missing.each { |file| Rails.logger.debug { "Missing: #{file}" } }
+    end
+  end
+end

--- a/lib/tasks/seeds_build.rake
+++ b/lib/tasks/seeds_build.rake
@@ -5,4 +5,9 @@ namespace :seeds do
   task build: :environment do
     Seeds::BuildSupport.build!(target_term: ENV.fetch("term", nil))
   end
+
+  desc "Pack the uploads the seed data points at, for publishing beside the dump"
+  task package: :environment do
+    Seeds::PackageSupport.package!
+  end
 end

--- a/spec/lib/seeds/package_support_spec.rb
+++ b/spec/lib/seeds/package_support_spec.rb
@@ -1,18 +1,43 @@
 require "rails_helper"
 
 RSpec.describe(Seeds::PackageSupport) do
-  describe ".paths_in" do
-    before do
-      allow(Shrine).to receive(:storages).and_return(
-        store: Shrine::Storage::FileSystem.new("public", prefix: "uploads/store")
-      )
-    end
+  # The task runs against the development store; the spec writes into a corner
+  # of it that it cleans up again.
+  let(:prefix) { "uploads/store/seed-package-spec" }
+  let(:directory) { Rails.public_path.join(prefix) }
+  let(:archive) { Rails.root.join("tmp/seed-package-spec.zip") }
 
+  before do
+    allow(described_class).to receive(:ensure_development!)
+    allow(Shrine).to receive(:storages).and_return(
+      store: Shrine::Storage::FileSystem.new("public", prefix: prefix)
+    )
+    FileUtils.mkdir_p(directory)
+  end
+
+  after do
+    FileUtils.rm_rf(directory)
+    FileUtils.rm_f(archive)
+  end
+
+  def attach!(record, column, id, derivative: nil)
+    data = { "id" => id, "storage" => "store" }
+    data["derivatives"] = { "thumb" => { "id" => derivative, "storage" => "store" } } if derivative
+    # rubocop:disable Rails/SkipsModelValidations
+    record.update_columns(column => data.to_json)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def write!(name)
+    File.write(directory.join(name), "seed")
+  end
+
+  describe ".paths_in" do
     it "reads the file an attachment points at" do
       data = { "id" => "medium/1/video/clip.mp4", "storage" => "store" }
 
       expect(described_class.paths_in(data))
-        .to eq([Rails.public_path.join("uploads/store/medium/1/video/clip.mp4").to_s])
+        .to eq([Rails.public_path.join(prefix, "medium/1/video/clip.mp4").to_s])
     end
 
     it "takes the derivatives along, which are files of their own" do
@@ -30,5 +55,46 @@ RSpec.describe(Seeds::PackageSupport) do
 
       expect(described_class.paths_in(data)).to be_empty
     end
+  end
+
+  describe ".referenced_files" do
+    it "finds what a record points at, derivative and rich-text blob included" do
+      write!("sheet.pdf")
+      write!("thumbnail.png")
+      attach!(create(:valid_medium), :manuscript_data, "sheet.pdf",
+              derivative: "thumbnail.png")
+      blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new("blob"),
+                                                    filename: "vignette.png")
+
+      files = described_class.referenced_files
+
+      expect(files).to include(directory.join("sheet.pdf").to_s,
+                               directory.join("thumbnail.png").to_s,
+                               blob.service.path_for(blob.key))
+    end
+  end
+
+  describe ".package!" do
+    it "packs what is there, under the path the archive is unpacked to" do
+      write!("sheet.pdf")
+      attach!(create(:valid_medium), :manuscript_data, "sheet.pdf")
+
+      described_class.package!(path: archive.to_s)
+
+      expect(entries(archive)).to include("#{prefix}/sheet.pdf")
+    end
+
+    it "reports what a record points at but nobody stored, and leaves it out" do
+      attach!(create(:valid_medium), :manuscript_data, "gone.pdf")
+
+      missing = described_class.package!(path: archive.to_s)
+
+      expect(missing).to eq([directory.join("gone.pdf").to_s])
+      expect(entries(archive)).not_to include("#{prefix}/gone.pdf")
+    end
+  end
+
+  def entries(path)
+    Zip::File.open(path) { |zip| zip.map(&:name) }
   end
 end

--- a/spec/lib/seeds/package_support_spec.rb
+++ b/spec/lib/seeds/package_support_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe(Seeds::PackageSupport) do
+  describe ".paths_in" do
+    before do
+      allow(Shrine).to receive(:storages).and_return(
+        store: Shrine::Storage::FileSystem.new("public", prefix: "uploads/store")
+      )
+    end
+
+    it "reads the file an attachment points at" do
+      data = { "id" => "medium/1/video/clip.mp4", "storage" => "store" }
+
+      expect(described_class.paths_in(data))
+        .to eq([Rails.public_path.join("uploads/store/medium/1/video/clip.mp4").to_s])
+    end
+
+    it "takes the derivatives along, which are files of their own" do
+      data = {
+        "id" => "sheet.pdf", "storage" => "store",
+        "derivatives" => { "thumb" => { "id" => "thumbnail.png", "storage" => "store" } }
+      }
+
+      expect(described_class.paths_in(data).map { |path| File.basename(path) })
+        .to eq(["sheet.pdf", "thumbnail.png"])
+    end
+
+    it "passes over an attachment in a storage that keeps no files" do
+      data = { "id" => "clip.mp4", "storage" => "cache" }
+
+      expect(described_class.paths_in(data)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
The dump published in mampf-init-data comes with an archive of the files its records refer to, and that archive was assembled by hand. It showed: 486 of its 584 files belonged to `VttContainer`, which the app removed a while ago, and the files of the hand-ins added in #1260 were missing.

`rails seeds:package` reads it off the records instead — every Shrine attachment, the derivatives hanging off it, and the blobs ActiveStorage keeps for rich text — and writes `db/backups/development/uploads.zip`. It reports anything a record points at that is not on disk.

Together with the two steps that were already there, republishing an edition is `seeds:build`, `db:dump`, `seeds:package`.

The archive it produces is identical to the one in mampf-init-data#4, which was packed by the script this task grew out of.