### PR TITLE
Retry deadlocks in the Playwright factory bridge

### DIFF
--- a/app/controllers/cypress/factories_playwright_controller.rb
+++ b/app/controllers/cypress/factories_playwright_controller.rb
@@ -60,12 +60,14 @@ module Cypress
     private
 
       # A test's own page can still be finishing a request while the next test
-      # asks for its records, and Postgres picks one of the two to abort. Nothing
-      # is half-written when it does, so the way out is to ask again.
-      def retrying_deadlocks
+      # asks for its records, and Postgres picks one of the two to abort. The
+      # attempt runs as one transaction, because a factory persists a record's
+      # associations before the record itself: without it, the aborted attempt
+      # would leave its course and term behind for the next one to duplicate.
+      def retrying_deadlocks(&)
         attempt = 0
         begin
-          yield
+          ActiveRecord::Base.transaction(&)
         rescue ActiveRecord::Deadlocked
           attempt += 1
           raise if attempt >= ATTEMPTS

--- a/app/controllers/cypress/factories_playwright_controller.rb
+++ b/app/controllers/cypress/factories_playwright_controller.rb
@@ -4,10 +4,14 @@ module Cypress
   # It is inspired by this blog post by Tom Conroy:
   # https://tbconroy.com/2018/04/07/creating-data-with-factorybot-for-rails-cypress-tests/
   class FactoriesPlaywrightController < CypressController
+    ATTEMPTS = 3
+
     # Creates an instance of the factory (via FactoryBot) and returns it as JSON.
     def create
       attributes, should_validate = to_attribute_list(params)
-      data = create_class_instance_via_factorybot(attributes, should_validate)
+      data = retrying_deadlocks do
+        create_class_instance_via_factorybot(attributes, should_validate)
+      end
       render json: data.as_json, status: :created
     end
 
@@ -54,6 +58,22 @@ module Cypress
     end
 
     private
+
+      # A test's own page can still be finishing a request while the next test
+      # asks for its records, and Postgres picks one of the two to abort. Nothing
+      # is half-written when it does, so the way out is to ask again.
+      def retrying_deadlocks
+        attempt = 0
+        begin
+          yield
+        rescue ActiveRecord::Deadlocked
+          attempt += 1
+          raise if attempt >= ATTEMPTS
+
+          sleep(0.1 * attempt)
+          retry
+        end
+      end
 
       def validate_factory_name(factory_name)
         return factory_name if factory_name.is_a?(String)

--- a/spec/requests/cypress/factories_playwright_spec.rb
+++ b/spec/requests/cypress/factories_playwright_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe("Cypress::FactoriesPlaywright", type: :request) do
+  let(:params) { { factory_name: "term", traits: [] } }
+
+  # A browser test's own page can still be finishing a request while the next
+  # test asks for its records; the bridge has to survive that.
+  it "asks again when the database picks its request to abort" do
+    attempts = 0
+    allow(FactoryBot).to receive(:create) do
+      attempts += 1
+      raise(ActiveRecord::Deadlocked, "deadlock detected") if attempts == 1
+
+      Term.new(year: 2099, season: "SS")
+    end
+
+    post "/cypress/factories_playwright", params: params
+
+    expect(response).to have_http_status(:created)
+    expect(attempts).to eq(2)
+  end
+
+  it "gives up in the end, so a deadlock that stays is not hidden" do
+    allow(FactoryBot).to receive(:create)
+      .and_raise(ActiveRecord::Deadlocked, "deadlock detected")
+
+    post "/cypress/factories_playwright", params: params
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body["error"]).to include("Deadlocked")
+  end
+end

--- a/spec/requests/cypress/factories_playwright_spec.rb
+++ b/spec/requests/cypress/factories_playwright_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe("Cypress::FactoriesPlaywright", type: :request) do
     expect(attempts).to eq(2)
   end
 
+  it "leaves nothing behind from the attempt that was aborted" do
+    attempts = 0
+    allow(FactoryBot).to receive(:create) do
+      attempts += 1
+      # What a factory does before it saves the record itself.
+      term = Term.create!(year: 2090 + attempts, season: "SS")
+      raise(ActiveRecord::Deadlocked, "deadlock detected") if attempts == 1
+
+      term
+    end
+
+    expect { post("/cypress/factories_playwright", params: params) }
+      .to change(Term, :count).by(1)
+  end
+
   it "gives up in the end, so a deadlock that stays is not hidden" do
     allow(FactoryBot).to receive(:create)
       .and_raise(ActiveRecord::Deadlocked, "deadlock detected")


### PR DESCRIPTION
`e2e (Playwright)` fails now and then with `ActiveRecord::Deadlocked` out of the factory bridge, most recently on #1195 — the failing test had done nothing yet but ask for a lecture and a medium.

A test's own page can still be finishing a request while the next test creates its records, and Postgres resolves the lock cycle by aborting one of the two. Nothing is half-written when it does, so the bridge asks again, up to three times.

Two request specs: one deadlock is retried, a deadlock that stays comes back as an error rather than being hidden.