### PR TITLE
Show a card for a medium that belongs to nothing

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -508,10 +508,12 @@ class Medium < ApplicationRecord
 
   # methods that create card header and subheader for a medium card
 
-  delegate :card_header, to: :teachable
+  # A medium does not have to belong to a teachable, and one that does not still
+  # shows up as a card -- on a watchlist, for instance.
+  delegate :card_header, to: :teachable, allow_nil: true
 
   def card_header_teachable_path(user)
-    teachable.card_header_path(user)
+    teachable&.card_header_path(user)
   end
 
   def card_subheader

--- a/spec/requests/watchlists_spec.rb
+++ b/spec/requests/watchlists_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe("Watchlists", type: :request) do
+  let(:user) { create(:confirmed_user) }
+
+  before { sign_in user }
+
+  describe "GET /watchlists/:id" do
+    # A quiz medium carries no teachable, and a watchlist takes any medium.
+    it "shows a watchlist that holds a medium without a teachable" do
+      watchlist = Watchlist.create!(user: user, name: "Wiederholung")
+      medium = create(:medium, :with_description, teachable: nil, sort: "RandomQuiz")
+      WatchlistEntry.create!(watchlist: watchlist, medium: medium,
+                             medium_position: 1)
+
+      get watchlist_path(watchlist)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Reported from staging: `watchlists#show` answers 500 with `undefined method 'card_header_path' for nil`.

`Medium#teachable` is optional and a quiz medium has none, but the card partial asks it for the header and its path without checking. A watchlist takes any medium, so one such entry takes the whole page down; the seed has one (`RandomQuiz`, no teachable) and a student's watchlist points at it.

The card now renders without a header link for those, which is what the partial already does when the path comes back empty. A request spec on `watchlists#show` covers it and fails without the change.