### PR TITLE
Group annotations of course media under their course

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -226,7 +226,9 @@ class AnnotationsController < ApplicationController
         .sort_by { |_title, annos| annos.filter_map { |a| a[:lecture].updated_at }.max }
         .reverse.to_h
         .transform_values { |annos| annos.map { |a| a.except(:lecture) } }
-        .transform_values { |annos| annos.sort_by { |a| a[:created_at] }.reverse }
+        # Newest first, by the timestamp the entry actually carries -- and the
+        # one it shows.
+        .transform_values { |annos| annos.sort_by { |a| a[:updated_at] }.reverse }
     end
 
     def extract_annotation_overview_information(annotation, is_shared)

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -217,6 +217,7 @@ class AnnotationsController < ApplicationController
     def annotations_by_lecture(annotations, is_shared: false)
       annotations
         .map { |a| extract_annotation_overview_information(a, is_shared) }
+        .reject { |annotation| annotation[:lecture].nil? }
         .group_by { |annotation| annotation[:lecture] }
         .sort_by { |lecture, _annotations| lecture.updated_at }.reverse.to_h
         # Instead of the full lecture object, we only need its title,
@@ -232,7 +233,9 @@ class AnnotationsController < ApplicationController
         text: annotation.comment_optional,
         color: annotation.color,
         updated_at: annotation.updated_at,
-        lecture: annotation.medium.teachable.lecture,
+        # A medium can hang off a course rather than a lecture, and then the
+        # course is what its annotations are grouped under.
+        lecture: annotation.medium.teachable&.then { |t| t.lecture || t },
         link: helpers.annotation_open_link(annotation, is_shared),
         medium_title: annotation.medium.caption,
         medium_date: annotation.medium.lesson&.date_localized

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -218,11 +218,13 @@ class AnnotationsController < ApplicationController
       annotations
         .map { |a| extract_annotation_overview_information(a, is_shared) }
         .reject { |annotation| annotation[:lecture].nil? }
-        .group_by { |annotation| annotation[:lecture] }
-        .sort_by { |lecture, _annotations| lecture.updated_at }.reverse.to_h
-        # Instead of the full lecture object, we only need its title,
-        # and also not as value anymore for individual annotations.
-        .transform_keys(&:title)
+        # Grouped by the heading rather than by the record behind it: a
+        # term-independent lecture is titled after its course, so the two would
+        # end up as separate groups of which only one survives being keyed by
+        # title.
+        .group_by { |annotation| annotation[:lecture].title }
+        .sort_by { |_title, annos| annos.filter_map { |a| a[:lecture].updated_at }.max }
+        .reverse.to_h
         .transform_values { |annos| annos.map { |a| a.except(:lecture) } }
         .transform_values { |annos| annos.sort_by { |a| a[:created_at] }.reverse }
     end

--- a/spec/requests/annotations_spec.rb
+++ b/spec/requests/annotations_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe("Annotations", type: :request) do
       expect(response.body).to include(ERB::Util.html_escape(course_medium.teachable.title))
     end
 
-    it "keeps both when a course and a lecture share their heading" do
+    it "keeps both under one heading when a course and a lecture share it" do
       course_medium = create(:course_medium)
       course = course_medium.teachable
       course.update!(term_independent: true)
@@ -47,6 +47,9 @@ RSpec.describe("Annotations", type: :request) do
 
       get annotations_path
 
+      buttons = Nokogiri::HTML(response.body).css(".accordion-button")
+      headings = buttons.map { |button| button.text.squish }
+      expect(headings).to contain_exactly("#{course.title} (2)")
       expect(response.body).to include("on the course", "on the lecture")
     end
 

--- a/spec/requests/annotations_spec.rb
+++ b/spec/requests/annotations_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe("Annotations", type: :request) do
       get annotations_path
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(course_medium.teachable.title)
+      # The heading is escaped on its way into the page, and a course title can
+      # carry an apostrophe.
+      expect(response.body).to include(ERB::Util.html_escape(course_medium.teachable.title))
     end
 
     it "keeps both when a course and a lecture share their heading" do

--- a/spec/requests/annotations_spec.rb
+++ b/spec/requests/annotations_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe("Annotations", type: :request) do
                     total_seconds: "10", post_as_comment: "0" } }
   end
 
+  describe "GET /annotations" do
+    it "lists an annotation on a medium that hangs off a course" do
+      course_medium = create(:course_medium)
+      create(:annotation, medium_id: course_medium.id, user_id: owner.id,
+                          comment: "on a course medium", category: :note)
+      sign_in owner
+
+      get annotations_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(course_medium.teachable.title)
+    end
+  end
+
   describe "an annotation owned by another user" do
     let!(:annotation) do
       create(:annotation, medium_id: medium.id, user_id: owner.id,

--- a/spec/requests/annotations_spec.rb
+++ b/spec/requests/annotations_spec.rb
@@ -30,6 +30,35 @@ RSpec.describe("Annotations", type: :request) do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(course_medium.teachable.title)
     end
+
+    it "keeps both when a course and a lecture share their heading" do
+      course_medium = create(:course_medium)
+      course = course_medium.teachable
+      course.update!(term_independent: true)
+      lecture = create(:lecture, course: course, term: nil)
+      lecture_medium = create(:valid_medium, teachable: lecture)
+      create(:annotation, medium_id: course_medium.id, user_id: owner.id,
+                          comment: "on the course", category: :note)
+      create(:annotation, medium_id: lecture_medium.id, user_id: owner.id,
+                          comment: "on the lecture", category: :note)
+      sign_in owner
+
+      get annotations_path
+
+      expect(response.body).to include("on the course", "on the lecture")
+    end
+
+    it "leaves out an annotation on a medium that belongs to nothing" do
+      orphan = create(:medium, :with_description, teachable: nil, sort: "RandomQuiz")
+      create(:annotation, medium_id: orphan.id, user_id: owner.id,
+                          comment: "on nothing at all", category: :note)
+      sign_in owner
+
+      get annotations_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("on nothing at all")
+    end
   end
 
   describe "an annotation owned by another user" do


### PR DESCRIPTION
Reported from staging: `annotations#index` answers 500 with `undefined method 'updated_at' for nil`.

Media hang off a lecture, a lesson, a talk — or a course, and `Course#lecture` is nil. The overview groups by lecture and then sorts the groups, so a single annotation on a worked example of a course took the page down for its owner.

Such an annotation is now grouped under its course, which is the heading it belongs under; one that belongs to nothing at all (a medium's teachable is optional) is left out rather than crashing the page. A request spec covers the course case and fails without the change.