### PR TITLE
Reject random quizzes as watchlist entries

### DIFF
--- a/app/models/watchlist_entry.rb
+++ b/app/models/watchlist_entry.rb
@@ -6,4 +6,16 @@ class WatchlistEntry < ApplicationRecord
   acts_as_list scope: :watchlist, top_of_list: 0, column: :medium_position
 
   validates :medium_id, uniqueness: { scope: :watchlist_id }
+  validate :medium_is_proper
+
+  private
+
+    # A random quiz is what a self test leaves behind: it belongs to no lecture,
+    # has no page of its own, and Medium.expired throws it away a day later.
+    # Nothing may collect it.
+    def medium_is_proper
+      return if medium.nil? || medium.proper?
+
+      errors.add(:medium, :improper)
+    end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4287,6 +4287,9 @@ de:
                 Diese Rolle ist für diese Vorlesung nicht verfügbar.
         watchlist_entry:
           attributes:
+            medium:
+              improper: >
+                Ein Zufallsquiz kann nicht auf eine Merkliste gesetzt werden.
             medium_id:
               taken:
                 ist schon in dieser Watchlist.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4289,7 +4289,8 @@ de:
           attributes:
             medium:
               improper: >
-                Ein Zufallsquiz kann nicht auf eine Merkliste gesetzt werden.
+                Ein Zufallsquiz kann nicht zu einer Watchlist hinzugefügt
+                werden.
             medium_id:
               taken:
                 ist schon in dieser Watchlist.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4060,6 +4060,9 @@ en:
                 This role is not available for this lecture.
         watchlist_entry:
           attributes:
+            medium:
+              improper: >
+                A random quiz cannot be put on a watchlist.
             medium_id:
               taken:
                 is already in this watchlist.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4062,7 +4062,7 @@ en:
           attributes:
             medium:
               improper: >
-                A random quiz cannot be put on a watchlist.
+                A random quiz cannot be added to a watchlist.
             medium_id:
               taken:
                 is already in this watchlist.

--- a/lib/seeds/enrich_support.rb
+++ b/lib/seeds/enrich_support.rb
@@ -326,6 +326,7 @@ module Seeds
       # Students collect what they want to see again; the teacher collects what
       # they keep pointing people at.
       def add_watchlists!
+        drop_improper_entries!
         students.each_with_index do |student, index|
           WATCHLIST_NAMES.first(2).each_with_index do |name, run|
             fill_watchlist!(student, "#{name} #{index + 1}", offset: index + run)
@@ -339,6 +340,12 @@ module Seeds
         return @teacher if defined?(@teacher)
 
         @teacher = User.find_by(email: "teacher@mampf.edu")
+      end
+
+      # An earlier edition collected a random quiz, which belongs to no lecture
+      # and takes the watchlist page down with it.
+      def drop_improper_entries!
+        WatchlistEntry.joins(:medium).where(media: { sort: "RandomQuiz" }).destroy_all
       end
 
       def fill_watchlist!(user, name, offset:, size: 3)

--- a/spec/models/watchlist_entry_spec.rb
+++ b/spec/models/watchlist_entry_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe(WatchlistEntry, type: :model) do
     expect(entry.errors).not_to have_key(:watchlist)
   end
 
+  # A random quiz is what a self test leaves behind: it belongs to no lecture,
+  # has no page of its own, and the cleanup throws it away a day later.
+  it "refuses a random quiz" do
+    quiz = FactoryBot.create(:medium, :with_description, teachable: nil,
+                                                         sort: "RandomQuiz")
+    entry = FactoryBot.build(:watchlist_entry, :with_watchlist, medium: quiz)
+
+    expect(entry).not_to be_valid
+    expect(entry.errors[:medium])
+      .to include(I18n.t("activerecord.errors.models.watchlist_entry" \
+                         ".attributes.medium.improper"))
+  end
+
   it "must have a watchlist" do
     entry = FactoryBot.build(:watchlist_entry, :with_medium)
     expect(entry).not_to be_valid


### PR DESCRIPTION
Staging answered 500 on `watchlists#show`: `undefined method 'card_header_path' for nil`.

A random quiz is what a self test leaves behind. It belongs to no lecture, has no page of its own, and `Medium.expired` throws it away a day later — nothing in the interface offers to put one on a watchlist, and now nothing accepts it either. The seed carries two such entries from an earlier edition; the build drops them, so the next dump goes out without them.