### PR TITLE
Retry the test database truncation when it deadlocks

### DIFF
--- a/app/controllers/cypress/cypress_controller.rb
+++ b/app/controllers/cypress/cypress_controller.rb
@@ -12,7 +12,25 @@ module Cypress
     rescue_from Exception, with: :show_errors
     skip_before_action :authenticate_user!
 
+    ATTEMPTS = 3
+
     private
+
+      # A test's own page can still be finishing a request while the next test
+      # asks the bridge for something, and Postgres picks one of the two to
+      # abort. Nothing is half-done when it does, so the way out is to ask again.
+      def retrying_deadlocks
+        attempt = 0
+        begin
+          yield
+        rescue ActiveRecord::Deadlocked
+          attempt += 1
+          raise if attempt >= ATTEMPTS
+
+          sleep(0.1 * attempt)
+          retry
+        end
+      end
 
       # Returns the error as JSON such that it can be displayed in the Cypress test.
       def show_errors(exception)

--- a/app/controllers/cypress/database_cleaner_controller.rb
+++ b/app/controllers/cypress/database_cleaner_controller.rb
@@ -2,7 +2,7 @@ module Cypress
   # Cleans the database for use in Cypress tests.
   class DatabaseCleanerController < CypressController
     def create
-      res = DatabaseCleaner.clean_with(:truncation)
+      res = retrying_deadlocks { DatabaseCleaner.clean_with(:truncation) }
 
       render json: res.to_json, status: :created
     end

--- a/app/controllers/cypress/factories_playwright_controller.rb
+++ b/app/controllers/cypress/factories_playwright_controller.rb
@@ -4,13 +4,16 @@ module Cypress
   # It is inspired by this blog post by Tom Conroy:
   # https://tbconroy.com/2018/04/07/creating-data-with-factorybot-for-rails-cypress-tests/
   class FactoriesPlaywrightController < CypressController
-    ATTEMPTS = 3
-
     # Creates an instance of the factory (via FactoryBot) and returns it as JSON.
     def create
       attributes, should_validate = to_attribute_list(params)
       data = retrying_deadlocks do
-        create_class_instance_via_factorybot(attributes, should_validate)
+        # One transaction per attempt: a factory persists a record's
+        # associations before the record itself, and the aborted attempt would
+        # otherwise leave them behind for the next one to duplicate.
+        ActiveRecord::Base.transaction do
+          create_class_instance_via_factorybot(attributes, should_validate)
+        end
       end
       render json: data.as_json, status: :created
     end
@@ -58,24 +61,6 @@ module Cypress
     end
 
     private
-
-      # A test's own page can still be finishing a request while the next test
-      # asks for its records, and Postgres picks one of the two to abort. The
-      # attempt runs as one transaction, because a factory persists a record's
-      # associations before the record itself: without it, the aborted attempt
-      # would leave its course and term behind for the next one to duplicate.
-      def retrying_deadlocks(&)
-        attempt = 0
-        begin
-          ActiveRecord::Base.transaction(&)
-        rescue ActiveRecord::Deadlocked
-          attempt += 1
-          raise if attempt >= ATTEMPTS
-
-          sleep(0.1 * attempt)
-          retry
-        end
-      end
 
       def validate_factory_name(factory_name)
         return factory_name if factory_name.is_a?(String)

--- a/spec/requests/cypress/database_cleaner_spec.rb
+++ b/spec/requests/cypress/database_cleaner_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe("Cypress::DatabaseCleaner", type: :request) do
+  # The truncation waits for a lock that the previous test's page still holds,
+  # and Postgres picks one of the two to abort.
+  it "asks again when the database picks its request to abort" do
+    attempts = 0
+    allow(DatabaseCleaner).to receive(:clean_with) do
+      attempts += 1
+      raise(ActiveRecord::Deadlocked, "deadlock detected") if attempts == 1
+
+      []
+    end
+
+    post "/cypress/database_cleaner"
+
+    expect(response).to have_http_status(:created)
+    expect(attempts).to eq(2)
+  end
+
+  it "gives up in the end, so a deadlock that stays is not hidden" do
+    allow(DatabaseCleaner).to receive(:clean_with)
+      .and_raise(ActiveRecord::Deadlocked, "deadlock detected")
+
+    post "/cypress/database_cleaner"
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body["error"]).to include("Deadlocked")
+  end
+end


### PR DESCRIPTION
#1264 put the retry in the wrong place. The deadlock that keeps failing browser runs — again on #1266 after #1264 had been merged — happens in the cleanup between two tests, not in the factory:

```
DETAIL: Process 104 waits for AccessExclusiveLock on relation 19140; blocked by process 107.
        Process 107 waits for AccessShareLock on relation 20050; blocked by process 104.
DatabaseCleaner::ActiveRecord::Truncation#clean
```

The previous test's page is still finishing a request while the next test asks for a clean database; the truncation wants an exclusive lock, and Postgres resolves the cycle by aborting one of the two.

The retry moves into `Cypress::CypressController`, where both endpoints reach it, and the truncation now uses it too. The transaction stays where it belongs — around the factory attempt, not around a truncation.

Two request specs for the cleaner, matching the two for the factory: one deadlock is retried, a deadlock that stays comes back as an error.