### PR TITLE
Clear the seed announcements and demo talks before staging them again

### DIFF
--- a/lib/demo/campaign_setup_support.rb
+++ b/lib/demo/campaign_setup_support.rb
@@ -406,11 +406,13 @@ module Demo
       seminar = Lecture.find_by(course: course, teacher: teacher)
       if seminar
         # The scenario is staged from scratch on every build: its campaigns
-        # cannot be rewound once students have registered, and its cohorts would
-        # collide by title. The term follows, in case an earlier build left the
-        # seminar in one that has since started.
+        # cannot be rewound once students have registered, its cohorts would
+        # collide by title, and its talks would pile up twelve at a time. The
+        # term follows, in case an earlier build left the seminar in one that
+        # has since started.
         Demo::CampaignCleanup.discard_all!(seminar)
         Cohort.where(context: seminar).destroy_all
+        Talk.where(lecture: seminar).destroy_all
         seminar.update!(term: Demo::TermSupport.next_term)
       else
         seminar = FactoryBot.create(

--- a/lib/seeds/enrich_support.rb
+++ b/lib/seeds/enrich_support.rb
@@ -222,6 +222,11 @@ module Seeds
         Announcement.update_all(on_main_page: false)
         # rubocop:enable Rails/SkipsModelValidations
 
+        # An edition is built from the one before it, so what this step wrote
+        # last time goes before it is written again -- with its notifications.
+        Announcement.where(details: ADMIN_ANNOUNCEMENTS + LECTURE_ANNOUNCEMENTS)
+                    .destroy_all
+
         ADMIN_ANNOUNCEMENTS.each do |text|
           announce!(Announcement.create!(announcer: admin, details: text,
                                          on_main_page: false))


### PR DESCRIPTION
An edition of the seed data is rebuilt from the one published before it. Two steps of that build only ever added, though: `add_announcements!` created its nine announcements again, each with a notification per recipient, and the two-stage registration scenario created twelve fresh talks in its seminar while discarding only the campaigns and cohorts around them. The published dump shows it — 23 announcements of nine distinct texts, and 24 talks in a seminar that stages twelve.

Both steps now clear what they staged last time. The announcements go by their own texts, so an announcement somebody else wrote stays; their notifications follow from `dependent: :destroy`. The talks go with the campaigns and cohorts of the scenario that owns them.

Two rebuilds in a row from the published dump now differ only where the demo scenarios draw at random. The new edition follows in mampf-init-data.