### PR TITLE
Build the seed with the reworked vignettes

### DIFF
--- a/lib/seeds/build_support.rb
+++ b/lib/seeds/build_support.rb
@@ -27,6 +27,7 @@ module Seeds
         Demo::SetupSupport.setup!
         Demo::CampaignSetupSupport.setup!
         Demo::NextTermBannerSupport.setup!
+        Demo::VignettesSupport.setup!
         add_running_campaigns!
         settle_current_term_campaigns!
         extend_open_deadlines!
@@ -224,7 +225,8 @@ module Seeds
           "Seed build done: term #{current_term.season} #{current_term.year}, " \
             "#{Lecture.count} lectures, #{User.count} users, " \
             "#{Registration::Campaign.open.count} open campaigns, " \
-            "#{Announcement.count} announcements"
+            "#{Announcement.count} announcements, " \
+            "#{Vignettes::Questionnaire.count} vignettes"
         end
       end
   end


### PR DESCRIPTION
The published seed still carries vignettes of the kind #1241 removed — a lecture of the dead `vignettes` sort, a questionnaire, rich texts with two images. The migration deletes all of it the first time someone runs `db:migrate` on that dump, so the edition ships data that dissolves on contact.

`seeds:build` now stages the new kind instead: `Demo::VignettesSupport` puts six vignettes on lecture 1, one for every state a vignette can be in, and switches the lecture's vignette flag on. It clears its own before building, so a rebuild stays where it is; two builds in a row differ only in the registration preferences the demo scenarios draw at random. The build report names the count.

They carry no attachments, which matters now: a blob a seed creates never passes the disk controller, so it would have no scan verdict and #1258 would not serve it.

The data edition itself follows in mampf-init-data once staging runs the new code.