### PR TITLE
Vignette actiontext: Serve the preview of a pdf, and link what has no preview

### DIFF
--- a/app/services/active_storage_scan_gate.rb
+++ b/app/services/active_storage_scan_gate.rb
@@ -9,6 +9,11 @@ class ActiveStorageScanGate
   # can carry video.
   SCAN_MAX_BYTES = 32 * 1024 * 1024
 
+  # How far a file can stand from the one that was scanned: a page of a PDF is
+  # first drawn as a preview and that preview is then resized, so what a page
+  # asks for is two steps from the file somebody uploaded.
+  DERIVATION_DEPTH = 3
+
   class << self
     def scan(io)
       scope = io.size.to_i > SCAN_MAX_BYTES ? "prefix" : "full"
@@ -37,9 +42,14 @@ class ActiveStorageScanGate
     end
 
     def cleared_blob?(blob)
-      return false if blob.nil?
+      DERIVATION_DEPTH.times do
+        return false if blob.nil?
+        return true if clean?(blob)
 
-      clean?(blob) || clean?(origin_of(blob))
+        blob = origin_of(blob)
+      end
+
+      false
     end
 
     def clean?(blob)

--- a/app/services/active_storage_scan_gate.rb
+++ b/app/services/active_storage_scan_gate.rb
@@ -36,18 +36,31 @@ class ActiveStorageScanGate
       cleared_blob?(ActiveStorage::Blob.find_by(key: key))
     end
 
-    # A thumbnail is derived from an original that was scanned and gets no
-    # verdict of its own, so hanging on a variant record clears it too.
     def cleared_blob?(blob)
       return false if blob.nil?
-      return true if clean?(blob)
 
-      blob.attachments.exists?(record_type: "ActiveStorage::VariantRecord")
+      clean?(blob) || clean?(origin_of(blob))
     end
 
     def clean?(blob)
-      blob.metadata.dig(MalwareScanGate::METADATA_KEY,
-                        MalwareScanGate::STATUS_KEY) == MalwareScanGate::CLEAN_STATUS
+      blob&.metadata&.dig(MalwareScanGate::METADATA_KEY,
+                          MalwareScanGate::STATUS_KEY) == MalwareScanGate::CLEAN_STATUS
+    end
+
+    # A thumbnail and a PDF preview are made here, from a file that was scanned
+    # on its way in, and carry no verdict of their own. ActiveStorage hangs a
+    # thumbnail on a variant record and a preview on the blob it came from, so
+    # the file it was made from is one attachment away either way.
+    def origin_of(blob)
+      attachment = blob.attachments.first
+      return if attachment.nil?
+
+      case attachment.record_type
+      when "ActiveStorage::VariantRecord"
+        ActiveStorage::VariantRecord.find_by(id: attachment.record_id)&.blob
+      when "ActiveStorage::Blob"
+        ActiveStorage::Blob.find_by(id: attachment.record_id) if attachment.name == "preview_image"
+      end
     end
   end
 end

--- a/app/services/active_storage_scan_gate.rb
+++ b/app/services/active_storage_scan_gate.rb
@@ -9,10 +9,11 @@ class ActiveStorageScanGate
   # can carry video.
   SCAN_MAX_BYTES = 32 * 1024 * 1024
 
-  # How far a file can stand from the one that was scanned: a page of a PDF is
-  # first drawn as a preview and that preview is then resized, so what a page
-  # asks for is two steps from the file somebody uploaded.
-  DERIVATION_DEPTH = 3
+  # How often a file may be derived from the one that was scanned: a page of a
+  # PDF is drawn as a preview and that preview is then resized, which is as far
+  # as ActiveStorage goes. The walk looks at the file and at every origin
+  # behind it, so it inspects one more blob than there are steps.
+  DERIVATION_STEPS = 2
 
   class << self
     def scan(io)
@@ -42,7 +43,7 @@ class ActiveStorageScanGate
     end
 
     def cleared_blob?(blob)
-      DERIVATION_DEPTH.times do
+      (DERIVATION_STEPS + 1).times do
         return false if blob.nil?
         return true if clean?(blob)
 

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,10 +1,12 @@
-<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+<% kind = blob.representable? ? "preview" : "file" %>
+<figure class="attachment attachment--<%= kind %> attachment--<%= blob.filename.extension %>">
   <% if blob.video? %>
     <video controls="true" controlsList="nodownload" width="75%">
       <source src=<%= rails_blob_url(blob) %>, type=<%= blob.content_type %> >
     </video>
   <% elsif blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <% resize_to_limit = local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ] %>
+    <%= image_tag blob.representation(resize_to_limit: resize_to_limit) %>
   <% else %>
     <%= link_to blob.filename.to_s, rails_blob_url(blob) %>
   <% end %>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,11 +1,12 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <% if blob.image? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
-  <% end %>
   <% if blob.video? %>
     <video controls="true" controlsList="nodownload" width="75%">
       <source src=<%= rails_blob_url(blob) %>, type=<%= blob.content_type %> >
     </video>
+  <% elsif blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% else %>
+    <%= link_to blob.filename.to_s, rails_blob_url(blob) %>
   <% end %>
 
   <figcaption class="attachment__caption">

--- a/config/initializers/action_text_previewable.rb
+++ b/config/initializers/action_text_previewable.rb
@@ -1,0 +1,12 @@
+# Trix draws every attachment it is told is previewable into an <img>, and
+# ActionText tells it so for anything ActiveStorage can represent -- which
+# includes a PDF wherever a previewer is installed. A browser cannot render a
+# PDF as an image, so what the editor showed was a broken frame. Only pictures
+# are pictures.
+Rails.application.config.to_prepare do
+  ActiveStorage::Blob.class_eval do
+    def previewable_attachable?
+      image?
+    end
+  end
+end

--- a/spec/lib/action_text_previewable_spec.rb
+++ b/spec/lib/action_text_previewable_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe("Attachments offered to the Trix editor") do
+  def trix_html_for(filename, content_type)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(SPEC_FILES, filename)),
+      filename: filename, content_type: content_type
+    )
+    ActionText::Content.new(ActionText::Attachment.from_attachable(blob).to_html)
+                       .to_trix_html
+  end
+
+  it "keeps a picture previewable, which the editor can draw" do
+    expect(trix_html_for("image.png", "image/png")).to include("previewable")
+  end
+
+  it "does not offer a PDF as a preview, which the editor cannot draw" do
+    expect(trix_html_for("manuscript.pdf", "application/pdf")).not_to include("previewable")
+  end
+end

--- a/spec/services/active_storage_scan_gate_spec.rb
+++ b/spec/services/active_storage_scan_gate_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe(ActiveStorageScanGate) do
 
       expect(described_class.cleared?(variant.key)).to be(true)
     end
+
+    it "clears the preview of a scanned file, which hangs on the file itself" do
+      original = blob_for(metadata: { "malware_scan" => { "status" => "clean" } })
+      preview = blob_for
+      ActiveStorage::Attachment.create!(name: "preview_image", blob: preview,
+                                        record: original)
+
+      expect(described_class.cleared?(preview.key)).to be(true)
+    end
+
+    it "holds back what was derived from a file that was never scanned" do
+      unscanned = blob_for
+      preview = blob_for
+      ActiveStorage::Attachment.create!(name: "preview_image", blob: preview,
+                                        record: unscanned)
+
+      expect(described_class.cleared?(preview.key)).to be(false)
+    end
   end
 
   describe ".record_verdict!" do

--- a/spec/services/active_storage_scan_gate_spec.rb
+++ b/spec/services/active_storage_scan_gate_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe(ActiveStorageScanGate) do
       expect(described_class.cleared?(thumbnail.key)).to be(true)
     end
 
+    it "gives up rather than following a chain of any length" do
+      original = blob_for(metadata: { "malware_scan" => { "status" => "clean" } })
+      derived = 3.times.reduce(original) do |origin, _|
+        blob_for.tap do |blob|
+          ActiveStorage::Attachment.create!(name: "preview_image", blob: blob,
+                                            record: origin)
+        end
+      end
+
+      expect(described_class.cleared?(derived.key)).to be(false)
+    end
+
     it "holds back a variant of a file that was never scanned" do
       unscanned = blob_for
       variant = blob_for

--- a/spec/services/active_storage_scan_gate_spec.rb
+++ b/spec/services/active_storage_scan_gate_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe(ActiveStorageScanGate) do
       expect(described_class.cleared?(preview.key)).to be(true)
     end
 
+    it "clears a thumbnail of a preview, two steps from the scanned file" do
+      original = blob_for(metadata: { "malware_scan" => { "status" => "clean" } })
+      preview = blob_for
+      thumbnail = blob_for
+      ActiveStorage::Attachment.create!(name: "preview_image", blob: preview,
+                                        record: original)
+      ActiveStorage::Attachment.create!(
+        name: "image", blob: thumbnail,
+        record: ActiveStorage::VariantRecord.create!(blob: preview,
+                                                     variation_digest: "digest")
+      )
+
+      expect(described_class.cleared?(thumbnail.key)).to be(true)
+    end
+
     it "holds back what was derived from a file that was never scanned" do
       unscanned = blob_for
       preview = blob_for

--- a/spec/services/active_storage_scan_gate_spec.rb
+++ b/spec/services/active_storage_scan_gate_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe(ActiveStorageScanGate) do
       expect(described_class.cleared?(thumbnail.key)).to be(true)
     end
 
+    it "holds back a variant of a file that was never scanned" do
+      unscanned = blob_for
+      variant = blob_for
+      ActiveStorage::Attachment.create!(
+        name: "image", blob: variant,
+        record: ActiveStorage::VariantRecord.create!(blob: unscanned,
+                                                     variation_digest: "digest")
+      )
+
+      expect(described_class.cleared?(variant.key)).to be(false)
+    end
+
     it "holds back what was derived from a file that was never scanned" do
       unscanned = blob_for
       preview = blob_for

--- a/spec/views/active_storage/blobs/_blob.html.erb_spec.rb
+++ b/spec/views/active_storage/blobs/_blob.html.erb_spec.rb
@@ -12,8 +12,19 @@ RSpec.describe("active_storage/blobs/_blob.html.erb", type: :view) do
     render(partial: "active_storage/blobs/blob", locals: { blob: blob })
   end
 
-  it "shows the preview of a file that has one" do
+  it "shows a picture" do
     render_blob(blob_for("image.png", "image/png"))
+
+    assert_select("img")
+  end
+
+  it "shows the preview of a file that is no picture" do
+    blob = blob_for("manuscript.pdf", "application/pdf")
+    # True wherever a previewer is installed, and that is what decides whether
+    # the page gets a preview -- the examples should not.
+    allow(blob).to receive(:previewable?).and_return(true)
+
+    render_blob(blob)
 
     assert_select("img")
   end

--- a/spec/views/active_storage/blobs/_blob.html.erb_spec.rb
+++ b/spec/views/active_storage/blobs/_blob.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe("active_storage/blobs/_blob.html.erb", type: :view) do
+  def blob_for(filename, content_type)
+    ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(SPEC_FILES, filename)),
+      filename: filename, content_type: content_type
+    )
+  end
+
+  def render_blob(blob)
+    render(partial: "active_storage/blobs/blob", locals: { blob: blob })
+  end
+
+  it "shows the preview of a file that has one" do
+    render_blob(blob_for("image.png", "image/png"))
+
+    assert_select("img")
+  end
+
+  it "offers a file without a preview for download" do
+    blob = blob_for("manuscript.pdf", "application/pdf")
+    allow(blob).to receive(:representable?).and_return(false)
+
+    render_blob(blob)
+
+    assert_select("a", text: "manuscript.pdf")
+  end
+
+  it "plays a video rather than previewing it" do
+    render_blob(blob_for("talk.mp4", "video/mp4"))
+
+    assert_select("video source")
+    assert_select("img", false)
+  end
+end


### PR DESCRIPTION
Three things that meet in a vignette slide with a PDF in it.

**The scan gate cleared a thumbnail but not a preview.** ActiveStorage hangs a thumbnail on an `ActiveStorage::VariantRecord` and a preview on the blob it was made from, and only the first shape was known — so the preview of a scanned PDF or video was answered with 404. A page of a PDF is drawn as a preview and that preview is then resized, so what the page asks for stands two steps from the file somebody uploaded; the gate now walks back up to three and clears the file as soon as it reaches a clean verdict. It also refuses a derivation whose origin carries none, which the variant case did not check before.

**`active_storage/blobs/_blob` rendered an empty frame** for anything that is neither image nor video: a PDF in a slide showed nothing at all, not even a link. It shows the preview where there is one and the file name to click where there is not.

**Trix drew a PDF into an `<img>` while editing.** ActionText marks everything ActiveStorage can represent as previewable, and with a previewer installed that includes PDFs, so the editor showed a broken frame. Only pictures are offered as pictures now; the rendered page is unaffected, it decides for itself.

Measured against the running app before and after: the representation URL of a scanned PDF answered 404, and answers 200 with the image.