### PR TITLE
Name the reason a form was rejected, in the page and in the log

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,10 +8,15 @@ class RegistrationsController < Devise::RegistrationsController
   def create
     altcha_param = params.permit(:altcha)[:altcha]
     if altcha_param.present? && Altcha.verify(altcha_param)
-      super
+      super do |user|
+        next if user.persisted?
+
+        log_rejected_sign_up(user.errors.full_messages.to_sentence)
+      end
     else
       build_resource(devise_parameter_sanitizer.sanitize(:sign_up))
       clean_up_passwords(resource)
+      log_rejected_sign_up("captcha verification failed")
       flash.now[:alert] = I18n.t("devise.registrations.user.captcha_error")
       render_flash
     end
@@ -69,7 +74,8 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
     def check_registration_limit
-      timeframe = (ENV.fetch("MAMPF_REGISTRATION_TIMEFRAME", 15).to_i.minutes.ago..)
+      minutes = ENV.fetch("MAMPF_REGISTRATION_TIMEFRAME", 15).to_i
+      timeframe = (minutes.minutes.ago..)
       num_new_registrations = User.where(confirmed_at: nil, created_at: timeframe).count
       max_registrations = ENV.fetch("MAMPF_MAX_REGISTRATION_PER_TIMEFRAME", 40).to_i
       return if num_new_registrations <= max_registrations
@@ -77,9 +83,19 @@ class RegistrationsController < Devise::RegistrationsController
       # Current number of new registrations is too high
       self.resource = resource_class.new(devise_parameter_sanitizer.sanitize(:sign_up))
       resource.validate # Look for any other validation errors besides reCAPTCHA
+      log_rejected_sign_up("registration limit reached: #{num_new_registrations} " \
+                           "unconfirmed in the last #{minutes} min, " \
+                           "max #{max_registrations}")
       set_flash_message(:alert, :too_many_registrations)
       set_minimum_password_length
       respond_with_navigational(resource) { render :new }
+    end
+
+    # A rejected sign-up is ordinary control flow, so nothing else records why
+    # the form came back. Emails are filtered out of the logs, so after the
+    # fact the reason is otherwise unreachable.
+    def log_rejected_sign_up(reason)
+      Rails.logger.info { "Sign-up rejected: #{reason}" }
     end
 
     def deletion_params

--- a/app/helpers/form_unknown_error_helper.rb
+++ b/app/helpers/form_unknown_error_helper.rb
@@ -30,11 +30,20 @@ module FormUnknownErrorHelper
 
       last_submit = submit_buttons.last
       error_span = Nokogiri::HTML::DocumentFragment.parse(
-        content_tag(:span, t("errors.unknown"),
+        content_tag(:span, whole_form_error_text(form_object),
                     class: "invalid-feedback d-block",
                     "aria-live": "polite")
       )
       last_submit.add_next_sibling(error_span)
       doc.to_html
+    end
+
+    # The errors no field could show. Naming them beats the generic fallback,
+    # which blames the server for what is really a validation failure.
+    def whole_form_error_text(form_object)
+      messages = form_object.errors.full_messages.uniq.compact_blank
+      return t("errors.unknown") if messages.empty?
+
+      safe_join(messages, tag.br)
     end
 end

--- a/app/helpers/form_unknown_error_helper.rb
+++ b/app/helpers/form_unknown_error_helper.rb
@@ -44,6 +44,8 @@ module FormUnknownErrorHelper
       messages = form_object.errors.full_messages.uniq.compact_blank
       return t("errors.unknown") if messages.empty?
 
-      safe_join(messages, tag.br)
+      # full_messages hands a :base message straight through, so a caller that
+      # marked one html_safe would reach the page unescaped. Drop that flag.
+      safe_join(messages.map { |message| String.new(message) }, tag.br)
     end
 end

--- a/app/helpers/form_unknown_error_helper.rb
+++ b/app/helpers/form_unknown_error_helper.rb
@@ -41,14 +41,23 @@ module FormUnknownErrorHelper
 
     # Which attributes had no field to show them. Nothing else records this:
     # the request completes normally, so only the attribute names say why the
-    # page fell back to a whole-form message. Codes only -- errors.details also
-    # carries the submitted value, and email is filtered out of the logs.
+    # page fell back to a whole-form message.
     def log_whole_form_error(form_object)
-      codes = form_object.errors.details
-                         .transform_values { |list| list.map { |detail| detail[:error] } }
+      codes = form_object.errors.details.transform_values do |list|
+        list.map { |detail| error_code(detail[:error]) }
+      end
       Rails.logger.info do
         "Form error with no field: #{form_object.class.name} #{codes.inspect}"
       end
+    end
+
+    # `errors.add` stores a message string here whenever it was given one, and
+    # this helper logs for every form in the app, so a free-text message could
+    # carry a submitted value into a log that filters email on purpose -- or a
+    # newline that forges a line. Symbols are ours, anything else is named but
+    # not repeated.
+    def error_code(error)
+      error.is_a?(Symbol) ? error : :custom_message
     end
 
     # The errors no field could show. Naming them beats the generic fallback,

--- a/app/helpers/form_unknown_error_helper.rb
+++ b/app/helpers/form_unknown_error_helper.rb
@@ -35,7 +35,20 @@ module FormUnknownErrorHelper
                     "aria-live": "polite")
       )
       last_submit.add_next_sibling(error_span)
+      log_whole_form_error(form_object)
       doc.to_html
+    end
+
+    # Which attributes had no field to show them. Nothing else records this:
+    # the request completes normally, so only the attribute names say why the
+    # page fell back to a whole-form message. Codes only -- errors.details also
+    # carries the submitted value, and email is filtered out of the logs.
+    def log_whole_form_error(form_object)
+      codes = form_object.errors.details
+                         .transform_values { |list| list.map { |detail| detail[:error] } }
+      Rails.logger.info do
+        "Form error with no field: #{form_object.class.name} #{codes.inspect}"
+      end
     end
 
     # The errors no field could show. Naming them beats the generic fallback,

--- a/spec/helpers/form_unknown_error_helper_spec.rb
+++ b/spec/helpers/form_unknown_error_helper_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe(FormUnknownErrorHelper, type: :helper) do
     end
   end
 
+  def info_logs_while
+    logged = []
+    allow(Rails.logger).to receive(:info) do |*args, &block|
+      logged << (block ? block.call : args.first).to_s
+    end
+    yield
+    logged.join("\n")
+  end
+
   describe "an error that belongs to no field" do
     let(:user) do
       User.new.tap { |u| u.errors.add(:base, "Du bist bereits angemeldet") }
@@ -53,6 +62,34 @@ RSpec.describe(FormUnknownErrorHelper, type: :helper) do
   describe "a form object without errors" do
     it "adds nothing" do
       expect(form_html(User.new)).not_to include("invalid-feedback")
+    end
+  end
+
+  describe "the log trail" do
+    it "names the attributes that had no field" do
+      user = User.new.tap { |u| u.errors.add(:locale, :inclusion) }
+
+      logs = info_logs_while { form_html(user) }
+
+      expect(logs).to include("Form error with no field: User {locale: [:inclusion]}")
+    end
+
+    it "keeps the submitted value out of the log" do
+      user = User.new(email: "geheim@example.com")
+      user.errors.add(:email, :taken, value: user.email)
+
+      logs = info_logs_while { form_html(user) }
+
+      expect(logs).to include(":taken")
+      expect(logs).not_to include("geheim@example.com")
+    end
+
+    it "stays quiet when a field shows the error" do
+      user = User.new.tap { |u| u.errors.add(:name, "muss ausgefüllt werden") }
+
+      logs = info_logs_while { form_html(user, with_field: true) }
+
+      expect(logs).not_to include("Form error with no field")
     end
   end
 

--- a/spec/helpers/form_unknown_error_helper_spec.rb
+++ b/spec/helpers/form_unknown_error_helper_spec.rb
@@ -22,6 +22,24 @@ RSpec.describe(FormUnknownErrorHelper, type: :helper) do
     end
   end
 
+  describe "a message carrying markup" do
+    it "escapes it" do
+      user = User.new.tap { |u| u.errors.add(:base, "<script>alert(1)</script>") }
+
+      expect(form_html(user)).to include("&lt;script&gt;")
+    end
+
+    # full_messages returns a :base message untouched, so its html_safe flag
+    # would otherwise survive all the way into the page.
+    it "escapes it even when a caller marked it html_safe" do
+      user = User.new.tap do |u|
+        u.errors.add(:base, "<img src=x onerror=alert(1)>".html_safe)
+      end
+
+      expect(form_html(user)).to include("&lt;img")
+    end
+  end
+
   describe "an error a field already shows" do
     let(:user) do
       User.new.tap { |u| u.errors.add(:name, "muss ausgefüllt werden") }

--- a/spec/helpers/form_unknown_error_helper_spec.rb
+++ b/spec/helpers/form_unknown_error_helper_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe(FormUnknownErrorHelper, type: :helper) do
+  def form_html(object, with_field: false)
+    helper.form_with(model: object, url: "/somewhere") do |f|
+      helper.concat(f.text_field(:name)) if with_field
+      helper.concat(f.submit("Speichern"))
+    end
+  end
+
+  describe "an error that belongs to no field" do
+    let(:user) do
+      User.new.tap { |u| u.errors.add(:base, "Du bist bereits angemeldet") }
+    end
+
+    it "names the reason" do
+      expect(form_html(user)).to include("Du bist bereits angemeldet")
+    end
+
+    it "does not blame the server" do
+      expect(form_html(user)).not_to include(I18n.t("errors.unknown").strip)
+    end
+  end
+
+  describe "an error a field already shows" do
+    let(:user) do
+      User.new.tap { |u| u.errors.add(:name, "muss ausgefüllt werden") }
+    end
+
+    it "leaves the whole-form message out" do
+      expect(form_html(user, with_field: true)).not_to include("invalid-feedback d-block")
+    end
+  end
+
+  describe "a form object without errors" do
+    it "adds nothing" do
+      expect(form_html(User.new)).not_to include("invalid-feedback")
+    end
+  end
+end

--- a/spec/helpers/form_unknown_error_helper_spec.rb
+++ b/spec/helpers/form_unknown_error_helper_spec.rb
@@ -55,4 +55,14 @@ RSpec.describe(FormUnknownErrorHelper, type: :helper) do
       expect(form_html(User.new)).not_to include("invalid-feedback")
     end
   end
+
+  describe "an error whose message is blank" do
+    # errors is not empty, yet nothing printable comes out of full_messages.
+    # This is the only way the generic notice is still reached.
+    it "falls back to the generic notice" do
+      user = User.new.tap { |u| u.errors.add(:base, "") }
+
+      expect(form_html(user)).to include(I18n.t("errors.unknown").strip)
+    end
+  end
 end

--- a/spec/helpers/form_unknown_error_helper_spec.rb
+++ b/spec/helpers/form_unknown_error_helper_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe(FormUnknownErrorHelper, type: :helper) do
       expect(logs).not_to include("geheim@example.com")
     end
 
+    # errors.add stores a whole message string here when it was given one, so a
+    # free-text message must not reach the log verbatim.
+    it "names a free-text message without repeating it" do
+      user = User.new.tap { |u| u.errors.add(:base, "Kontakt geheim@example.com\nfake line") }
+
+      logs = info_logs_while { form_html(user) }
+
+      expect(logs).to include(":custom_message")
+      expect(logs).not_to include("geheim@example.com")
+      expect(logs).not_to include("fake line")
+    end
+
     it "stays quiet when a field shows the error" do
       user = User.new.tap { |u| u.errors.add(:name, "muss ausgefüllt werden") }
 

--- a/spec/requests/auth/registrations_spec.rb
+++ b/spec/requests/auth/registrations_spec.rb
@@ -70,6 +70,56 @@ RSpec.describe("Auth registrations", type: :request) do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(I18n.t("devise.registrations.user.too_many_registrations"))
     end
+
+    describe "records why a sign-up was rejected" do
+      # Nothing raises on a rejected sign-up and emails are filtered out of the
+      # logs, so an operator can only see the reason if we log it on purpose.
+      def info_logs_while
+        logged = []
+        allow(Rails.logger).to receive(:info) do |*args, &block|
+          logged << (block ? block.call : args.first).to_s
+        end
+        yield
+        logged.join("\n")
+      end
+
+      it "names the validation errors" do
+        allow(Altcha).to receive(:verify).and_return(true)
+        params = base_params.merge(altcha: "valid")
+        params[:user] = params[:user].except(:consents)
+
+        logs = info_logs_while { post(user_registration_path, params: params) }
+
+        expect(logs).to match(/Sign-up rejected: \S+/)
+      end
+
+      it "names a failed captcha" do
+        allow(Altcha).to receive(:verify).and_return(false)
+
+        logs = info_logs_while do
+          post(user_registration_path,
+               params: base_params.merge(altcha: "invalid"),
+               as: :turbo_stream)
+        end
+
+        expect(logs).to include("Sign-up rejected: captcha verification failed")
+      end
+
+      it "names the exceeded registration limit" do
+        allow(Altcha).to receive(:verify).and_return(true)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("MAMPF_REGISTRATION_TIMEFRAME", 15).and_return("15")
+        allow(ENV).to receive(:fetch).with("MAMPF_MAX_REGISTRATION_PER_TIMEFRAME", 40)
+                                     .and_return("0")
+        create(:user, created_at: 1.minute.ago)
+
+        logs = info_logs_while do
+          post(user_registration_path, params: base_params.merge(altcha: "valid"))
+        end
+
+        expect(logs).to include("registration limit reached")
+      end
+    end
   end
 
   describe "DELETE /users" do

--- a/spec/requests/auth/registrations_spec.rb
+++ b/spec/requests/auth/registrations_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe("Auth registrations", type: :request) do
 
         logs = info_logs_while { post(user_registration_path, params: params) }
 
-        expect(logs).to match(/Sign-up rejected: \S+/)
+        # The attribute name carries the reason and is not translated, so this
+        # holds in either locale while still naming which validation failed.
+        expect(logs).to include("Sign-up rejected: Consents")
       end
 
       it "names a failed captcha" do


### PR DESCRIPTION
A student got the message "You filled out the form correctly, but unfortunately something went wrong on the server" while registering. Nothing had gone wrong on the server: the whole-form fallback fires on **validation** errors that no field could display, and calls them a server error anyway.

Diagnosing it took a long detour through the request logs, because nothing records the reason either — a failed validation raises nothing, so Rails logs no cause, and emails are in `filter_parameters`, so a request cannot even be tied to a person after the fact.

Two changes:

- `FormUnknownErrorHelper` renders the actual `errors.full_messages`. The generic text stays only as a fallback for when the model yields nothing printable.
- `RegistrationsController` logs the reason on all three rejection paths (validation, captcha, registration limit) at info level, without any user-supplied values.

Specs: a new helper spec covering the three fallback cases, plus three logging examples on the existing sign-up request spec.