### PR TITLE
Give the coming term a fold of its own

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -36,6 +36,9 @@ class MainController < ApplicationController
                                                                    :term)
                                        .sort
     end
+    @next_term_stuff = current_user.next_term_lectures
+    @next_term_pending = current_user.next_term_registered_lectures -
+                         @next_term_stuff
     next_term_banner
     @talks = current_user.talks.includes(lecture: :term)
                          .select { |t| t.visible_for_user?(current_user) }

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -37,8 +37,9 @@ class MainController < ApplicationController
                                        .sort
     end
     @next_term_stuff = current_user.next_term_lectures
+    @next_term_seats = current_user.next_term_seated_lectures - @next_term_stuff
     @next_term_pending = current_user.next_term_registered_lectures -
-                         @next_term_stuff
+                         @next_term_stuff - @next_term_seats
     next_term_banner
     @talks = current_user.talks.includes(lecture: :term)
                          .select { |t| t.visible_for_user?(current_user) }

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -185,7 +185,8 @@ class ProfileController < ApplicationController
       @lecture = Lecture.find_by(id: lecture_params[:id])
       @passphrase = lecture_params[:passphrase]
       @parent = lecture_params[:parent]
-      @current = !@parent.in?(["lectureSearch", "inactive"])
+      @current = !@parent.in?(["lectureSearch", "inactive",
+                               "next_term_subscribed", "next_term_registered"])
       redirect_to start_path unless @lecture
     end
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -109,6 +109,7 @@ class ProfileController < ApplicationController
                  when "inactive" then current_user.inactive_lectures.empty?
                  when "next_term_subscribed"
                    current_user.next_term_lectures.empty? &&
+                   current_user.next_term_seated_lectures.empty? &&
                    current_user.next_term_registered_lectures.empty?
     end
   end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -102,6 +102,9 @@ class ProfileController < ApplicationController
                  when "current_subscribed" then current_user.current_subscribed_lectures
                                                             .empty?
                  when "inactive" then current_user.inactive_lectures.empty?
+                 when "next_term_subscribed"
+                   current_user.next_term_lectures.empty? &&
+                   current_user.next_term_registered_lectures.empty?
     end
   end
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -98,6 +98,11 @@ class ProfileController < ApplicationController
 
   def unsubscribe_lecture
     @success = current_user.unsubscribe_lecture!(@lecture)
+    # An application outlives the subscription, so the card stays: a reload
+    # shows it among the applications of the coming term.
+    @application_left =
+      @parent == "next_term_subscribed" &&
+      current_user.next_term_registered_lectures.include?(@lecture)
     @none_left = case @parent
                  when "current_subscribed" then current_user.current_subscribed_lectures
                                                             .empty?

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -98,11 +98,12 @@ class ProfileController < ApplicationController
 
   def unsubscribe_lecture
     @success = current_user.unsubscribe_lecture!(@lecture)
-    # An application outlives the subscription, so the card stays: a reload
-    # shows it among the applications of the coming term.
-    @application_left =
+    # A seat or an application outlives the subscription, so the card stays:
+    # the next load shows the lecture in the group that carries it.
+    @place_left =
       @parent == "next_term_subscribed" &&
-      current_user.next_term_registered_lectures.include?(@lecture)
+      (current_user.next_term_seated_lectures +
+       current_user.next_term_registered_lectures).include?(@lecture)
     @none_left = case @parent
                  when "current_subscribed" then current_user.current_subscribed_lectures
                                                             .empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -604,9 +604,15 @@ class User < ApplicationRecord
     lectures.where(term: Term.active).includes(:course, :term)
   end
 
-  # What this user has subscribed for the term after the running one, while
-  # that term is being prepared. Lectures without a term are not among them:
-  # they run always and belong to the current fold.
+  # A subscription (LectureUserJoin), a seat (LectureMembership,
+  # CohortMembership) and an application (Registration::UserRegistration) exist
+  # independently of each other, which is why the start page asks
+  # `next_term_lectures`, `next_term_seated_lectures` and
+  # `next_term_registered_lectures` rather than one of them.
+  #
+  # What this user has subscribed for the term after the running one. Lectures
+  # without a term are not among them: they run always, and the fold of the
+  # running term carries them.
   def next_term_lectures
     coming = Term.active&.next
     return [] if coming.blank?
@@ -615,10 +621,8 @@ class User < ApplicationRecord
             .natural_sort_by(&:title)
   end
 
-  # Lectures of the coming term the user has a seat in without a subscription.
-  # A cohort only enrols its members into the lecture when it is set to, and a
-  # seat on the lecture roster itself does not subscribe either; both leave the
-  # lecture with nothing to say for itself on the start page.
+  # Cohorts with propagate_to_lecture: false do not create lecture memberships.
+  # Include them directly so their lectures remain visible on the start page.
   def next_term_seated_lectures
     coming = Term.active&.next
     return [] if coming.blank?
@@ -630,10 +634,8 @@ class User < ApplicationRecord
            .includes(:course, :term).natural_sort_by(&:title)
   end
 
-  # The lectures of the coming term this user has applied to and has not been
-  # rejected from, while the campaign is still deciding. A registration is not
-  # a subscription: the seat, and with it access, is granted when the campaign
-  # is finalized, which is why these are named apart from the subscribed ones.
+  # After Registration::Campaign#finalize! a confirmed registration has a seat,
+  # and the two methods above carry the lecture from then on.
   def next_term_registered_lectures
     coming = Term.active&.next
     return [] if coming.blank?
@@ -649,8 +651,8 @@ class User < ApplicationRecord
            .includes(:course, :term).natural_sort_by(&:title)
   end
 
-  # The running term and the one after it have folds of their own on the start
-  # page, so neither belongs here.
+  # The start page shows Term.active and Term.active.next separately, so
+  # exclude both here to avoid duplicate lecture cards.
   def inactive_lectures
     lectures.where.not(term: [Term.active, Term.active&.next])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -615,6 +615,21 @@ class User < ApplicationRecord
             .natural_sort_by(&:title)
   end
 
+  # Lectures of the coming term the user has a seat in without a subscription.
+  # A cohort only enrols its members into the lecture when it is set to, and a
+  # seat on the lecture roster itself does not subscribe either; both leave the
+  # lecture with nothing to say for itself on the start page.
+  def next_term_seated_lectures
+    coming = Term.active&.next
+    return [] if coming.blank?
+
+    seat_ids = cohorts.where(context_type: "Lecture").pluck(:context_id) |
+               lecture_memberships.pluck(:lecture_id)
+
+    Lecture.where(id: seat_ids, term: coming)
+           .includes(:course, :term).natural_sort_by(&:title)
+  end
+
   # The lectures of the coming term this user has applied to and has not been
   # rejected from, while the campaign is still deciding. A registration is not
   # a subscription: the seat, and with it access, is granted when the campaign

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -604,8 +604,40 @@ class User < ApplicationRecord
     lectures.where(term: Term.active).includes(:course, :term)
   end
 
+  # What this user has subscribed for the term after the running one, while
+  # that term is being prepared. Lectures without a term are not among them:
+  # they run always and belong to the current fold.
+  def next_term_lectures
+    coming = Term.active&.next
+    return [] if coming.blank?
+
+    lectures.where(term: coming).includes(:course, :term)
+            .natural_sort_by(&:title)
+  end
+
+  # The lectures of the coming term this user has applied to and has not been
+  # rejected from, while the campaign is still deciding. A registration is not
+  # a subscription: the seat, and with it access, is granted when the campaign
+  # is finalized, which is why these are named apart from the subscribed ones.
+  def next_term_registered_lectures
+    coming = Term.active&.next
+    return [] if coming.blank?
+
+    campaigns = Registration::UserRegistration
+                .where(user: self).where.not(status: :rejected)
+                .joins(:registration_campaign)
+                .merge(Registration::Campaign.where.not(status: :completed))
+                .where(registration_campaigns: { campaignable_type: "Lecture" })
+
+    Lecture.where(id: campaigns.select("registration_campaigns.campaignable_id"),
+                  term: coming)
+           .includes(:course, :term).natural_sort_by(&:title)
+  end
+
+  # The running term and the one after it have folds of their own on the start
+  # page, so neither belongs here.
   def inactive_lectures
-    lectures.where.not(term: Term.active)
+    lectures.where.not(term: [Term.active, Term.active&.next])
   end
 
   def nonsubscribed_lectures

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -102,10 +102,10 @@
             </div>
           <% end %>
 
-          <% if @next_term_stuff.empty? && @next_term_pending.empty? %>
-            <div id="emptyNextTermStuff">
-              <%= t("profile.no_next_term_stuff") %>
-            </div>
+          <%= tag.div id: "emptyNextTermStuff",
+                      style: (@next_term_stuff.any? || @next_term_pending.any?) ?
+                               "display: none;" : "" do %>
+            <%= t("profile.no_next_term_stuff") %>
           <% end %>
         </div>
       </div>

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -46,6 +46,70 @@
       </div>
     </div>
   <% end %>
+  <%# Transitional: until the dashboard arrives, the lectures of the term
+    being prepared get a fold of their own rather than sitting among the
+    subscriptions of terms gone by. The list is short and rendered here, so
+    this fold needs no round trip when it opens. %>
+
+  <% if Term.active&.next %>
+    <div class="accordion-item">
+      <div class="accordion-header">
+        <button class="accordion-button collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#collapseNextTermStuff"
+                aria-expanded="false"
+                aria-controls="collapseNextTermStuff">
+          <h4 class="text-dark" id="nextTermStuffLink">
+            <%= t('profile.my_next_term_html',
+                  term: Term.active.next.to_label) %>
+          </h4>
+        </button>
+      </div>
+      <div class="collapse" id="collapseNextTermStuff"
+           data-bs-parent="#subscriptionsAccordion">
+        <div class="accordion-body">
+          <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
+               id="collapseNextTermStuffContent"
+               data-testid="next-term-subscribed">
+            <%= render partial: 'main/start/lecture',
+                       collection: @next_term_stuff,
+                       locals: { current: false,
+                                 subscribed: true,
+                                 parent: 'next_term_subscribed' },
+                       as: :lecture %>
+          </div>
+
+          <%# A registration is not a seat: it is decided when the campaign is
+            finalized. These lectures therefore stand in their own group,
+            under the sentence that says what is still open about them. %>
+
+          <% if @next_term_pending.any? %>
+            <p class="text-muted small mb-2">
+              <%= t('profile.next_term_registrations') %>
+            </p>
+
+            <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
+                 data-testid="next-term-registrations">
+              <%= render partial: 'main/start/lecture',
+                         collection: @next_term_pending,
+                         locals: { current: false,
+                                   subscribed: false,
+                                   parent: 'next_term_registered' },
+                         as: :lecture %>
+            </div>
+          <% end %>
+
+          <% if @next_term_stuff.empty? && @next_term_pending.empty? %>
+            <div id="emptyNextTermStuff">
+              <%= t('profile.no_next_term_stuff') %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <div class="accordion-item">
     <div class="accordion-header">
       <button class="accordion-button collapsed"

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -46,10 +46,9 @@
       </div>
     </div>
   <% end %>
-  <%# Transitional: until the dashboard arrives, the lectures of the term
-    being prepared get a fold of their own rather than sitting among the
-    subscriptions of terms gone by. The list is short and rendered here, so
-    this fold needs no round trip when it opens. %>
+  <%# Rendered with the page rather than fetched when it opens: this fold
+    carries no `subscriptionsCollapse` class, so nothing asks the server for
+    its contents. %>
 
   <% if Term.active&.next %>
     <div class="accordion-item">
@@ -82,10 +81,6 @@
 
           </div>
 
-          <%# A seat in a group that does not enrol into the lecture is still a
-            place in the coming term, and the card offers what is missing: the
-            subscription. %>
-
           <% if @next_term_seats.any? %>
             <p class="text-muted small mb-2">
               <%= t("profile.next_term_seats") %>
@@ -102,10 +97,6 @@
                          as: :lecture %>
             </div>
           <% end %>
-
-          <%# A registration is not a seat: it is decided when the campaign is
-            finalized. These lectures therefore stand in their own group,
-            under the sentence that says what is still open about them. %>
 
           <% if @next_term_pending.any? %>
             <p class="text-muted small mb-2">

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -61,7 +61,7 @@
                 aria-expanded="false"
                 aria-controls="collapseNextTermStuff">
           <h4 class="text-dark" id="nextTermStuffLink">
-            <%= t('profile.my_next_term_html',
+            <%= t("profile.my_next_term_html",
                   term: Term.active.next.to_label) %>
           </h4>
         </button>
@@ -69,14 +69,15 @@
       <div class="collapse" id="collapseNextTermStuff"
            data-bs-parent="#subscriptionsAccordion">
         <div class="accordion-body">
-          <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
+          <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3
+                      row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
                id="collapseNextTermStuffContent"
                data-testid="next-term-subscribed">
-            <%= render partial: 'main/start/lecture',
+            <%= render partial: "main/start/lecture",
                        collection: @next_term_stuff,
                        locals: { current: false,
                                  subscribed: true,
-                                 parent: 'next_term_subscribed' },
+                                 parent: "next_term_subscribed" },
                        as: :lecture %>
           </div>
 
@@ -86,23 +87,24 @@
 
           <% if @next_term_pending.any? %>
             <p class="text-muted small mb-2">
-              <%= t('profile.next_term_registrations') %>
+              <%= t("profile.next_term_registrations") %>
             </p>
 
-            <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
+            <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3
+                        row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
                  data-testid="next-term-registrations">
-              <%= render partial: 'main/start/lecture',
+              <%= render partial: "main/start/lecture",
                          collection: @next_term_pending,
                          locals: { current: false,
                                    subscribed: false,
-                                   parent: 'next_term_registered' },
+                                   parent: "next_term_registered" },
                          as: :lecture %>
             </div>
           <% end %>
 
           <% if @next_term_stuff.empty? && @next_term_pending.empty? %>
             <div id="emptyNextTermStuff">
-              <%= t('profile.no_next_term_stuff') %>
+              <%= t("profile.no_next_term_stuff") %>
             </div>
           <% end %>
         </div>

--- a/app/views/main/start.html.erb
+++ b/app/views/main/start.html.erb
@@ -79,7 +79,29 @@
                                  subscribed: true,
                                  parent: "next_term_subscribed" },
                        as: :lecture %>
+
           </div>
+
+          <%# A seat in a group that does not enrol into the lecture is still a
+            place in the coming term, and the card offers what is missing: the
+            subscription. %>
+
+          <% if @next_term_seats.any? %>
+            <p class="text-muted small mb-2">
+              <%= t("profile.next_term_seats") %>
+            </p>
+
+            <div class="row row-cols-1 row-cols-xs-2 row-cols-md-3
+                        row-cols-lg-3 row-cols-xl-4 row-cols-xxl-6"
+                 data-testid="next-term-seats">
+              <%= render partial: "main/start/lecture",
+                         collection: @next_term_seats,
+                         locals: { current: false,
+                                   subscribed: false,
+                                   parent: "next_term_subscribed" },
+                         as: :lecture %>
+            </div>
+          <% end %>
 
           <%# A registration is not a seat: it is decided when the campaign is
             finalized. These lectures therefore stand in their own group,
@@ -102,9 +124,11 @@
             </div>
           <% end %>
 
+          <% fold_filled = @next_term_stuff.any? || @next_term_seats.any? ||
+                           @next_term_pending.any? %>
+
           <%= tag.div id: "emptyNextTermStuff",
-                      style: (@next_term_stuff.any? || @next_term_pending.any?) ?
-                               "display: none;" : "" do %>
+                      style: fold_filled ? "display: none;" : "" do %>
             <%= t("profile.no_next_term_stuff") %>
           <% end %>
         </div>

--- a/app/views/profile/unsubscribe_lecture.coffee
+++ b/app/views/profile/unsubscribe_lecture.coffee
@@ -1,6 +1,7 @@
 <% if @success %>
 $card = $('.lectureCard[data-id="<%= @lecture.id %>"][data-parent="<%= @parent %>"]')
-<% if @parent.in?(['inactive', 'current_subscribed', 'next_term_subscribed']) %>
+<% if @parent.in?(['inactive', 'current_subscribed', 'next_term_subscribed']) &&
+      !@application_left %>
 $card.remove()
 <% if @none_left %>
 <% if @parent == 'current_subscribed' %>

--- a/app/views/profile/unsubscribe_lecture.coffee
+++ b/app/views/profile/unsubscribe_lecture.coffee
@@ -1,7 +1,7 @@
 <% if @success %>
 $card = $('.lectureCard[data-id="<%= @lecture.id %>"][data-parent="<%= @parent %>"]')
 <% if @parent.in?(['inactive', 'current_subscribed', 'next_term_subscribed']) &&
-      !@application_left %>
+      !@place_left %>
 $card.remove()
 <% if @none_left %>
 <% if @parent == 'current_subscribed' %>

--- a/app/views/profile/unsubscribe_lecture.coffee
+++ b/app/views/profile/unsubscribe_lecture.coffee
@@ -1,6 +1,6 @@
 <% if @success %>
 $card = $('.lectureCard[data-id="<%= @lecture.id %>"][data-parent="<%= @parent %>"]')
-<% if @parent.in?(['inactive', 'current_subscribed']) %>
+<% if @parent.in?(['inactive', 'current_subscribed', 'next_term_subscribed']) %>
 $card.remove()
 <% if @none_left %>
 <% if @parent == 'current_subscribed' %>

--- a/app/views/profile/unsubscribe_lecture.coffee
+++ b/app/views/profile/unsubscribe_lecture.coffee
@@ -5,6 +5,8 @@ $card.remove()
 <% if @none_left %>
 <% if @parent == 'current_subscribed' %>
 $('#emptyCurrentStuff').show()
+<% elsif @parent == 'next_term_subscribed' %>
+$('#emptyNextTermStuff').show()
 <% else %>
 $('#emptyInactiveLectures').show()
 <% end %>

--- a/app/views/profile/unsubscribe_lecture.coffee
+++ b/app/views/profile/unsubscribe_lecture.coffee
@@ -1,12 +1,12 @@
 <% if @success %>
 $card = $('.lectureCard[data-id="<%= @lecture.id %>"][data-parent="<%= @parent %>"]')
-<% if @parent.in?(['inactive', 'current_subscribed', 'next_term_subscribed']) &&
+<% if @parent.in?(["inactive", "current_subscribed", "next_term_subscribed"]) &&
       !@place_left %>
 $card.remove()
 <% if @none_left %>
 <% if @parent == 'current_subscribed' %>
 $('#emptyCurrentStuff').show()
-<% elsif @parent == 'next_term_subscribed' %>
+<% elsif @parent == "next_term_subscribed" %>
 $('#emptyNextTermStuff').show()
 <% else %>
 $('#emptyInactiveLectures').show()

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2079,6 +2079,7 @@ de:
       Du möchtest die Veranstaltung %{lecture_title} abonnieren. Diese ist
       durch einen Zugangsschlüssel geschützt. Gib diesen bitte hier ein.
     my_term_html: Mein Semester &ndash; %{term}
+    my_next_term_html: Mein nächstes Semester &ndash; %{term}
     inactive_lectures: Weitere abonnierte Veranstaltungen
     active_nonsubscribed_lectures_html: >
       Aktuelle Veranstaltungen &ndash; %{term}
@@ -2086,6 +2087,10 @@ de:
       Du hast keine Veranstaltungen aus dem aktuellen Semester abonniert.
     no_inactive_stuff: >
       Du hast keine Veranstaltungen außerhalb des aktuellen Semesters abonniert.
+    no_next_term_stuff: >
+      Du hast noch keine Veranstaltungen aus dem kommenden Semester abonniert.
+    next_term_registrations: >
+      Angemeldet — über die Plätze wird nach dem Anmeldeschluss entschieden.
     no_current_at_all: >
       Im aktuellen Semester sind noch keine Veranstaltungen veröffentlicht
       worden.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2092,7 +2092,7 @@ de:
     next_term_registrations: >
       Angemeldet — über die Plätze wird nach dem Anmeldeschluss entschieden.
     next_term_seats: >
-      Für Dich eingetragen — abonniere die Veranstaltung, um ihre Inhalte zu sehen.
+      Du bist eingetragen, hast die Veranstaltung aber noch nicht abonniert.
     no_current_at_all: >
       Im aktuellen Semester sind noch keine Veranstaltungen veröffentlicht
       worden.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2091,6 +2091,8 @@ de:
       Du hast noch keine Veranstaltungen aus dem kommenden Semester abonniert.
     next_term_registrations: >
       Angemeldet — über die Plätze wird nach dem Anmeldeschluss entschieden.
+    next_term_seats: >
+      Für Dich eingetragen — abonniere die Veranstaltung, um ihre Inhalte zu sehen.
     no_current_at_all: >
       Im aktuellen Semester sind noch keine Veranstaltungen veröffentlicht
       worden.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2092,7 +2092,7 @@ de:
     next_term_registrations: >
       Angemeldet — über die Plätze wird nach dem Anmeldeschluss entschieden.
     next_term_seats: >
-      Du bist eingetragen, hast die Veranstaltung aber noch nicht abonniert.
+      Du stehst auf einer Liste dieser Veranstaltung, hast sie aber nicht abonniert.
     no_current_at_all: >
       Im aktuellen Semester sind noch keine Veranstaltungen veröffentlicht
       worden.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1933,6 +1933,7 @@ en:
       You want to subscribe the event series %{lecture_title}. It is protected
       by a pass phrase. Please enter it here.
     my_term_html: My term &ndash; %{term}
+    my_next_term_html: My next term &ndash; %{term}
     inactive_lectures: Further subscribed event series
     active_nonsubscribed_lectures_html: >
       Current event series &ndash; %{term}
@@ -1940,6 +1941,10 @@ en:
       You have not yet subscribed any event series of the current term.
     no_inactive_stuff: >
       You have not yet subscribed any event series outside of the current term.
+    no_next_term_stuff: >
+      You have not yet subscribed any event series of the coming term.
+    next_term_registrations: >
+      Applied for — places are allocated after the registration deadline.
     no_current_at_all: >
       In the current term, no event series have yet been published.
     other_preferences: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1946,7 +1946,7 @@ en:
     next_term_registrations: >
       Applied for — places are allocated after the registration deadline.
     next_term_seats: >
-      You are enrolled, but have not subscribed to the lecture yet.
+      You are on a list for this lecture, but have not subscribed to it.
     no_current_at_all: >
       In the current term, no event series have yet been published.
     other_preferences: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1945,6 +1945,8 @@ en:
       You have not yet subscribed any event series of the coming term.
     next_term_registrations: >
       Applied for — places are allocated after the registration deadline.
+    next_term_seats: >
+      Enrolled for you — subscribe to the lecture to see its content.
     no_current_at_all: >
       In the current term, no event series have yet been published.
     other_preferences: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1946,7 +1946,7 @@ en:
     next_term_registrations: >
       Applied for — places are allocated after the registration deadline.
     next_term_seats: >
-      Enrolled for you — subscribe to the lecture to see its content.
+      You are enrolled, but have not subscribed to the lecture yet.
     no_current_at_all: >
       In the current term, no event series have yet been published.
     other_preferences: >

--- a/spec/requests/main_spec.rb
+++ b/spec/requests/main_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe("Main", type: :request) do
         )
       end
 
-      # A registration is not a subscription: the seat comes when the campaign
-      # is finalized, so the lecture is named rather than shown as a card.
-      it "names a lecture the user has applied to" do
+      # A registration is not a seat, so the lecture stands in its own group
+      # rather than among the subscriptions.
+      it "shows a lecture the user has applied to, apart from the rest" do
         lecture = create(:lecture, :released_for_all, term: next_term)
         campaign = create(:registration_campaign, :open, campaignable: lecture)
         create(:registration_user_registration, :pending,
@@ -59,11 +59,21 @@ RSpec.describe("Main", type: :request) do
 
         get root_path
 
-        registrations = Nokogiri::HTML(response.body)
-                                .at_css("[data-testid='next-term-registrations']")
-
-        expect(registrations.text).to include(lecture.title_no_term)
+        expect(cards_in("next-term-registrations")).to include(lecture.id.to_s)
         expect(cards_in("next-term-subscribed")).to be_empty
+      end
+
+      # A cohort that does not enrol its members leaves them without a
+      # subscription, and the lecture would say nothing for itself.
+      it "shows a lecture the user has a seat in without a subscription" do
+        lecture = create(:lecture, :released_for_all, term: next_term)
+        cohort = create(:cohort, context: lecture, propagate_to_lecture: false)
+        create(:cohort_membership, cohort: cohort, user: user)
+
+        get root_path
+
+        expect(cards_in("next-term-seats")).to include(lecture.id.to_s)
+        expect(user.lectures).not_to include(lecture)
       end
 
       it "says nothing about an application that was turned down" do

--- a/spec/requests/main_spec.rb
+++ b/spec/requests/main_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe("Main", type: :request) do
   end
 
   describe "GET / (start page)" do
-    # Transitional, until the dashboard replaces the accordion: what the user
-    # has subscribed for the term being prepared gets its own fold instead of
-    # sitting among the terms gone by.
     describe "the fold for the coming term" do
       let!(:current_term) { create(:term, :summer, :active, year: 2025) }
       let(:next_term) { create(:term, :winter, year: 2025) }
@@ -49,8 +46,6 @@ RSpec.describe("Main", type: :request) do
         )
       end
 
-      # A registration is not a seat, so the lecture stands in its own group
-      # rather than among the subscriptions.
       it "shows a lecture the user has applied to, apart from the rest" do
         lecture = create(:lecture, :released_for_all, term: next_term)
         campaign = create(:registration_campaign, :open, campaignable: lecture)
@@ -63,8 +58,6 @@ RSpec.describe("Main", type: :request) do
         expect(cards_in("next-term-subscribed")).to be_empty
       end
 
-      # A cohort that does not enrol its members leaves them without a
-      # subscription, and the lecture would say nothing for itself.
       it "shows a lecture the user has a seat in without a subscription" do
         lecture = create(:lecture, :released_for_all, term: next_term)
         cohort = create(:cohort, context: lecture, propagate_to_lecture: false)
@@ -87,8 +80,6 @@ RSpec.describe("Main", type: :request) do
         expect(response.body).not_to include("next-term-registrations")
       end
 
-      # Applying and subscribing are different things, but one card is enough:
-      # the subscription is the stronger statement and already stands there.
       it "shows a subscribed lecture once, even when applied for as well" do
         lecture = create(:lecture, :released_for_all, term: next_term)
         campaign = create(:registration_campaign, :open, campaignable: lecture)
@@ -108,8 +99,6 @@ RSpec.describe("Main", type: :request) do
         expect(response.body).not_to include("collapseNextTermStuff")
       end
 
-      # Both folds would otherwise show the same lecture, one of them under
-      # "further subscribed".
       it "takes the lecture out of the subscriptions of terms gone by" do
         lecture = create(:lecture, :released_for_all, term: next_term)
         user.subscribe_lecture!(lecture)

--- a/spec/requests/main_spec.rb
+++ b/spec/requests/main_spec.rb
@@ -8,6 +8,108 @@ RSpec.describe("Main", type: :request) do
   end
 
   describe "GET / (start page)" do
+    # Transitional, until the dashboard replaces the accordion: what the user
+    # has subscribed for the term being prepared gets its own fold instead of
+    # sitting among the terms gone by.
+    describe "the fold for the coming term" do
+      let!(:current_term) { create(:term, :summer, :active, year: 2025) }
+      let(:next_term) { create(:term, :winter, year: 2025) }
+
+      def cards_in(testid)
+        Nokogiri::HTML(response.body)
+                .css("[data-testid='#{testid}'] .lectureCard")
+                .pluck("data-id")
+      end
+
+      def heading_for(term)
+        CGI.escapeHTML(
+          I18n.t("profile.my_next_term_html", term: term.to_label)
+        ).gsub("&amp;ndash;", "&ndash;")
+      end
+
+      it "lists a lecture the user subscribed for the coming term" do
+        lecture = create(:lecture, :released_for_all, term: next_term)
+        user.subscribe_lecture!(lecture)
+
+        get root_path
+
+        expect(response.body).to include(heading_for(next_term))
+        expect(cards_in("next-term-subscribed")).to include(lecture.id.to_s)
+      end
+
+      it "stands there empty when nothing is subscribed for that term" do
+        create(:lecture, :released_for_all, term: next_term)
+
+        get root_path
+
+        expect(response.body).to include(heading_for(next_term))
+        expect(cards_in("next-term-subscribed")).to be_empty
+        expect(response.body).to include(
+          CGI.escapeHTML(I18n.t("profile.no_next_term_stuff").strip)
+        )
+      end
+
+      # A registration is not a subscription: the seat comes when the campaign
+      # is finalized, so the lecture is named rather than shown as a card.
+      it "names a lecture the user has applied to" do
+        lecture = create(:lecture, :released_for_all, term: next_term)
+        campaign = create(:registration_campaign, :open, campaignable: lecture)
+        create(:registration_user_registration, :pending,
+               user: user, registration_campaign: campaign)
+
+        get root_path
+
+        registrations = Nokogiri::HTML(response.body)
+                                .at_css("[data-testid='next-term-registrations']")
+
+        expect(registrations.text).to include(lecture.title_no_term)
+        expect(cards_in("next-term-subscribed")).to be_empty
+      end
+
+      it "says nothing about an application that was turned down" do
+        lecture = create(:lecture, :released_for_all, term: next_term)
+        campaign = create(:registration_campaign, :open, campaignable: lecture)
+        create(:registration_user_registration, :rejected,
+               user: user, registration_campaign: campaign)
+
+        get root_path
+
+        expect(response.body).not_to include("next-term-registrations")
+      end
+
+      # Applying and subscribing are different things, but one card is enough:
+      # the subscription is the stronger statement and already stands there.
+      it "shows a subscribed lecture once, even when applied for as well" do
+        lecture = create(:lecture, :released_for_all, term: next_term)
+        campaign = create(:registration_campaign, :open, campaignable: lecture)
+        create(:registration_user_registration, :pending,
+               user: user, registration_campaign: campaign)
+        user.subscribe_lecture!(lecture)
+
+        get root_path
+
+        expect(cards_in("next-term-subscribed")).to include(lecture.id.to_s)
+        expect(response.body).not_to include("next-term-registrations")
+      end
+
+      it "has no fold where there is no term to prepare for" do
+        get root_path
+
+        expect(response.body).not_to include("collapseNextTermStuff")
+      end
+
+      # Both folds would otherwise show the same lecture, one of them under
+      # "further subscribed".
+      it "takes the lecture out of the subscriptions of terms gone by" do
+        lecture = create(:lecture, :released_for_all, term: next_term)
+        user.subscribe_lecture!(lecture)
+
+        get root_path
+
+        expect(cards_in("further-subscribed")).not_to include(lecture.id.to_s)
+      end
+    end
+
     describe "next term banner" do
       let!(:current_term) { create(:term, :summer, :active, year: 2025) }
 

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe("Profile", type: :request) do
         expect(response.body).to include("$('#emptyNextTermStuff').show()")
       end
 
+      # The application outlives the subscription: on the next load the
+      # lecture stands among the applications, so its card has to survive.
+      it "keeps the card of a lecture that is still applied for" do
+        campaign = create(:registration_campaign, :open, campaignable: lecture)
+        create(:registration_user_registration, :pending,
+               user: user, registration_campaign: campaign)
+        user.subscribe_lecture!(lecture)
+
+        patch(unsubscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   parent: "next_term_subscribed" } },
+              xhr: true)
+
+        expect(response.body).not_to include("$card.remove()")
+        expect(response.body).to include("$card.empty()")
+      end
+
       it "keeps the empty state hidden while an application is left" do
         user.subscribe_lecture!(lecture)
         other = create(:lecture, :released_for_all, term: next_term)

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -59,6 +59,33 @@ RSpec.describe("Profile", type: :request) do
         expect(response.body).to include("$card.remove()")
       end
 
+      # The fold would otherwise stand empty and unexplained until a reload.
+      it "shows the empty state once the fold has run out of cards" do
+        user.subscribe_lecture!(lecture)
+
+        patch(unsubscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   parent: "next_term_subscribed" } },
+              xhr: true)
+
+        expect(response.body).to include("$('#emptyNextTermStuff').show()")
+      end
+
+      it "keeps the empty state hidden while an application is left" do
+        user.subscribe_lecture!(lecture)
+        other = create(:lecture, :released_for_all, term: next_term)
+        campaign = create(:registration_campaign, :open, campaignable: other)
+        create(:registration_user_registration, :pending,
+               user: user, registration_campaign: campaign)
+
+        patch(unsubscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   parent: "next_term_subscribed" } },
+              xhr: true)
+
+        expect(response.body).not_to include("emptyNextTermStuff")
+      end
+
       # A card outside the running term names its term, and the card the
       # response renders back has to keep it.
       it "keeps the term on the card it renders back" do

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe("Profile", type: :request) do
         expect(response.body).to include("$card.empty()")
       end
 
+      it "keeps the card of a lecture the user has a seat in" do
+        cohort = create(:cohort, context: lecture, propagate_to_lecture: false)
+        create(:cohort_membership, cohort: cohort, user: user)
+        user.subscribe_lecture!(lecture)
+
+        patch(unsubscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   parent: "next_term_subscribed" } },
+              xhr: true)
+
+        expect(response.body).not_to include("$card.remove()")
+      end
+
       it "keeps the empty state hidden while an application is left" do
         user.subscribe_lecture!(lecture)
         other = create(:lecture, :released_for_all, term: next_term)

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -42,6 +42,35 @@ RSpec.describe("Profile", type: :request) do
       end
     end
 
+    context "with a card from the fold of the coming term" do
+      let(:next_term) { create(:term, :winter, year: 2025) }
+      let(:lecture) { create(:lecture, :released_for_all, term: next_term) }
+
+      before { create(:term, :summer, :active, year: 2025) }
+
+      it "takes the card away when the lecture is unsubscribed there" do
+        user.subscribe_lecture!(lecture)
+
+        patch(unsubscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   parent: "next_term_subscribed" } },
+              xhr: true)
+
+        expect(response.body).to include("$card.remove()")
+      end
+
+      # A card outside the running term names its term, and the card the
+      # response renders back has to keep it.
+      it "keeps the term on the card it renders back" do
+        patch(subscribe_lecture_path,
+              params: { lecture: { id: lecture.id,
+                                   parent: "next_term_registered" } },
+              xhr: true)
+
+        expect(response.body).to include(next_term.to_label_short)
+      end
+    end
+
     context "with the plain HTML flow of the lecture home page" do
       let(:lecture) do
         create(:lecture, :released_for_all, passphrase: "secret")

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe("Profile", type: :request) do
         expect(response.body).to include("$card.remove()")
       end
 
-      # The fold would otherwise stand empty and unexplained until a reload.
       it "shows the empty state once the fold has run out of cards" do
         user.subscribe_lecture!(lecture)
 
@@ -71,8 +70,6 @@ RSpec.describe("Profile", type: :request) do
         expect(response.body).to include("$('#emptyNextTermStuff').show()")
       end
 
-      # The application outlives the subscription: on the next load the
-      # lecture stands among the applications, so its card has to survive.
       it "keeps the card of a lecture that is still applied for" do
         campaign = create(:registration_campaign, :open, campaignable: lecture)
         create(:registration_user_registration, :pending,
@@ -103,8 +100,6 @@ RSpec.describe("Profile", type: :request) do
         expect(response.body).not_to include("emptyNextTermStuff")
       end
 
-      # A card outside the running term names its term, and the card the
-      # response renders back has to keep it.
       it "keeps the term on the card it renders back" do
         patch(subscribe_lecture_path,
               params: { lecture: { id: lecture.id,


### PR DESCRIPTION
Until the dashboard replaces the accordion, the start page says nothing about the next term. The new fold contains this info for the time being: Subscribed lectures are cards as everywhere else; lectures the user has applied to but not yet been given a place on the roster stand in a group of their own, under a line saying that places are allocated after the deadline. A lecture that is both appears once, as the subscription. "Further subscribed event series" no longer carries the coming term, or the two folds would show the same lecture. The fold stands whenever a coming term exists, empty with a sentence when the user has nothing there yet. It is meant to go when the dashboard arrives.